### PR TITLE
fix(e2e): unblock chromium-prod CI — globalSetup is sandbox-only

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
 - [ ] **`/welcome` 1.18s 偏慢**(其余路由 <0.12s):复测确认是冷启动还是稳定慢。
 - [ ] **Lighthouse 质量项**(2026-06-01 把这些从 error 降成 warn 让 CI 过,值得真修):LCP 图提 `fetchpriority="high"` 且不懒加载(`lcp-lazy-loaded`/`prioritize-lcp-image`)· 上 WebP/AVIF(`uses-optimized-images`/`modern-image-formats`)· 对比度(`color-contrast`)· 移动端触控目标(`target-size`)· 控制台报错(`errors-in-console`)· bf-cache 不可用排查。CI 跑 mobile 对 live prod。
 - [ ] 决定 deploy 切 main 后是否退役 `feat/go-backend` 分支(目前两分支内容一致)。
+- [ ] **e2e sandbox 套件退役后陈旧**:`e2e/globalSetup.ts` 仍 seed 已退役的 MongoDB + 需本地 stack 登录,chromium-sandbox(auth/library/player 写路径)在 CI 跑不起来。真修 = 去 Mongo seed(只留 Postgres)+ CI 起一次性测试 PG(用扔掉的测试密码,**非 prod**)+ 在 e2e-sandbox.yml / docker-compose.ci.yml 设 `E2E_SANDBOX=1` opt-in。本次 fix/e2e-prod-globalsetup 已让只读 chromium-prod 在 CI 转绿(globalSetup 默认 no-op),sandbox 单独修。
 
 ---
 

--- a/e2e/fixtures/pg.ts
+++ b/e2e/fixtures/pg.ts
@@ -31,13 +31,15 @@ function buildDatabaseUrl(): string {
   return `postgres://animego:${pw}@localhost:5432/animego?sslmode=disable`;
 }
 
-const DATABASE_URL = buildDatabaseUrl();
-
 let _sql: ReturnType<typeof postgres> | null = null;
 
 function getSql(): ReturnType<typeof postgres> {
   if (!_sql) {
-    _sql = postgres(DATABASE_URL, { max: 3, connect_timeout: 5 });
+    // Lazy: resolve the connection string (and throw on a missing password)
+    // only when a DB helper is actually called. Importing this module must
+    // stay side-effect-free — globalSetup imports it unconditionally, and the
+    // read-only chromium-prod project never touches Postgres.
+    _sql = postgres(buildDatabaseUrl(), { max: 3, connect_timeout: 5 });
   }
   return _sql;
 }

--- a/e2e/globalSetup.ts
+++ b/e2e/globalSetup.ts
@@ -95,6 +95,14 @@ async function seed(): Promise<void> {
 }
 
 export default async function globalSetup(_config: FullConfig): Promise<void> {
+  // Sandbox-only setup: seed Mongo + Postgres, then browser-login to mint the
+  // storageState the chromium-sandbox project reuses. The read-only
+  // chromium-prod project (and any `playwright test --project=chromium-prod`,
+  // e.g. .github/workflows/e2e.yml) needs none of it — and would trip over the
+  // retired Mongo / an absent POSTGRES_PASSWORD. Opt IN via E2E_SANDBOX so
+  // prod-style runs are a no-op by default.
+  if (!process.env.E2E_SANDBOX) return;
+
   fs.mkdirSync(path.dirname(STORAGE_STATE_PATH), { recursive: true });
 
   // Wipe stragglers from prior runs BEFORE seeding, so per-spec cleanup


### PR DESCRIPTION
## What

The read-only **chromium-prod** e2e (live-prod smoke, `.github/workflows/e2e.yml`) could never run in CI. It died in `globalSetup` before any spec executed — both Playwright checks have been permanently red for this reason, unrelated to whatever PR they run on.

## Root cause

Playwright's global `globalSetup` runs once for **every** project, but its body is **sandbox-only** work: seed Mongo (retired 2026-06-01), seed Postgres, and browser-login to mint `storageState` for `chromium-sandbox`. Two failures fired before any prod spec ran:

1. `e2e/fixtures/pg.ts` resolved `DATABASE_URL` at **module load** (`const DATABASE_URL = buildDatabaseUrl()`), throwing `POSTGRES_PASSWORD must be set` — and `globalSetup` imports it unconditionally.
2. `globalSetup` then seeds Mongo / Postgres and logs into a local stack that doesn't exist in the prod run.

```
playwright test --project=chromium-prod   (CI: read-only live-prod smoke)
        └─ globalSetup (runs for ALL projects)
             ├─ pg.ts import → throws (no POSTGRES_PASSWORD)   ✗ before anything
             ├─ seed Mongo localhost:27017                     ✗ Mongo retired
             └─ login @ https://localhost                      ✗ no local stack
```

## Fix (minimal, 2 files)

- **`pg.ts`** — resolve the connection string lazily inside `getSql()`. Importing the module is now side-effect-free; the throw only fires if a DB helper is actually called.
- **`globalSetup.ts`** — opt IN to the sandbox seeding via `E2E_SANDBOX`. Prod-style runs (no flag) are a no-op, so `chromium-prod` runs the read-only specs directly. Safe default: anything that isn't explicitly the sandbox does nothing.

No prod secret in CI, no workflow edits needed for the prod fix.

## Test plan

- [x] `bunx playwright test --project=chromium-prod` vs live prod → **7/7 passed** locally (globalSetup no-ops, no Postgres)
- [x] `bun -e 'import("./fixtures/pg.ts")'` → no eager throw
- [ ] CI `e2e.yml` (chromium-prod) goes green on this PR
- [ ] CI `unit-tests.yml` stays green (no test/src changes)

## Deferred (TODO.md)

The `chromium-sandbox` suite (auth/library/player write-paths) is stale post-retirement — it still seeds the retired Mongo and needs a local stack. Real fix: drop Mongo seeding, boot a throwaway test Postgres in CI (test password, **not** prod), and set `E2E_SANDBOX=1` in the sandbox workflow. Tracked in TODO.md.

## Pre-existing, not touched

`tsc --noEmit` reports a handful of `noUncheckedIndexedAccess` errors in `pg.ts:getResetTokenFromPg` and `playwright.config.ts` (env parse loop) — these predate this PR and don't affect Playwright (esbuild transpile). Left out of scope to keep the diff minimal.
