### PR TITLE
docs(qa): track ISSUE-001 — logged-out detail pages fire a 401 storm

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@
 - [ ] **Lighthouse 质量项**(2026-06-01 把这些从 error 降成 warn 让 CI 过,值得真修):LCP 图提 `fetchpriority="high"` 且不懒加载(`lcp-lazy-loaded`/`prioritize-lcp-image`)· 上 WebP/AVIF(`uses-optimized-images`/`modern-image-formats`)· 对比度(`color-contrast`)· 移动端触控目标(`target-size`)· 控制台报错(`errors-in-console`)· bf-cache 不可用排查。CI 跑 mobile 对 live prod。
 - [ ] 决定 deploy 切 main 后是否退役 `feat/go-backend` 分支(目前两分支内容一致)。
 - [ ] **e2e sandbox 套件退役后陈旧**:`e2e/globalSetup.ts` 仍 seed 已退役的 MongoDB + 需本地 stack 登录,chromium-sandbox(auth/library/player 写路径)在 CI 跑不起来。真修 = 去 Mongo seed(只留 Postgres)+ CI 起一次性测试 PG(用扔掉的测试密码,**非 prod**)+ 在 e2e-sandbox.yml / docker-compose.ci.yml 设 `E2E_SANDBOX=1` opt-in。本次 fix/e2e-prod-globalsetup 已让只读 chromium-prod 在 CI 转绿(globalSetup 默认 no-op),sandbox 单独修。
+- [ ] **ISSUE-001(QA 2026-06-01,Medium):登出番剧详情页 401 风暴** —— 每个登出访客开 `/anime/{id}` 触发 `GET /api/subscriptions/{id}`×2(`SubscriptionButton.tsx:300` + `EpisodesGrid.tsx:91` 各发一次)+ `POST /api/auth/refresh`×1,全 401 = 3 失败请求 + 3 控制台报错 + Sentry envelope 噪音,砸中 SEO 登出主流量。根因:移植丢了老代码 `useSubscription({enabled:!!user})` 的门(客户端读不到 httpOnly session,只能盲探)。修法:SSR 详情页 `cookies().has('session')` 拿登录态 → 下传 `loggedIn` 给两组件 → 登出跳过探测、直渲 anonymous(~4 文件)。验收:浏览器登出详情页 network 0 个 401。详见(本地)`.gstack/qa-reports/qa-report-animegoclub-com-2026-06-01.md`。
 
 ---
 


### PR DESCRIPTION
## /qa Exhaustive — live prod (health ~92/100)

Read-only browser sweep of animegoclub.com. Site is in good shape — every page type loads with the correct status, all auth gates redirect, search works with URL-as-state, **0 horizontal overflow** at 375/768/1440, 41 images / 0 broken. One real **Medium** finding, tracked here (fix deferred per decision).

## ISSUE-001 (Medium) — logged-out `/anime/{id}` 401 storm

Per logged-out detail-page view:
```
GET  /api/subscriptions/{id}  → 401   (SubscriptionButton mount probe)
GET  /api/subscriptions/{id}  → 401   (EpisodesGrid mount probe)
POST /api/auth/refresh        → 401   (authFetch refresh-on-401)
```
= 3 failed requests + 3 console errors + client-Sentry envelopes per view. Hits the **primary SEO/SSR traffic** (logged-out organic visitors land on exactly these pages).

**Root cause:** the RSC port dropped the legacy `useSubscription({ enabled: !!user })` guard (`SubscriptionButton.tsx:295`). The client can't read the httpOnly `session`/`refreshToken` cookies, so both components probe blindly and authFetch then attempts a refresh that also 401s.

**Fix (deferred):** detail page is a Server Component and already reads cookies — add `loggedIn = (await cookies()).has("session")`, pass it to `SubscriptionButton` + `EpisodesGrid`, skip the probe when logged out. ~4 files. Acceptance: 0× 401 on a logged-out detail page.

This PR only adds the TODO.md entry. No code changed. Full report (local, gitignored): `.gstack/qa-reports/qa-report-animegoclub-com-2026-06-01.md`.