### PR TITLE
fix(detail): skip subscription probe for logged-out visitors (ISSUE-001)

### DIFF
--- a/next-app/src/app/anime/[id]/page.tsx
+++ b/next-app/src/app/anime/[id]/page.tsx
@@ -15,6 +15,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { cookies } from "next/headers";
+import { loggedInFromCookies } from "@/lib/serverAuth";
 import type { CSSProperties } from "react";
 import DescriptionExpand from "@/components/anime/DescriptionExpand";
 import DetailActions from "@/components/anime/DetailActions";
@@ -1206,12 +1208,21 @@ export default async function AnimeDetailPage({ params }: PageProps) {
   const anilistId = Number(id);
   if (!Number.isFinite(anilistId) || anilistId <= 0) notFound();
 
-  const [dict, lang, detail] = await Promise.all([
+  const [dict, lang, detail, cookieStore] = await Promise.all([
     getDict(),
     getLang(),
     loadDetail(anilistId),
+    cookies(),
   ]);
   if (!detail) notFound();
+
+  // ISSUE-001: gate the client-side subscription probes on a server-known
+  // login signal. This page already reads cookies via getLang(), so it is
+  // already rendered dynamically (Cf-Cache-Status: DYNAMIC) — reading one
+  // more cookie adds no caching cost. A logged-out visitor carries neither
+  // cookie and the client components skip the probe instead of firing
+  // GET /api/subscriptions/:id ×2 → 401 → /api/auth/refresh → 401.
+  const loggedIn = loggedInFromCookies(cookieStore);
 
   const jsonLd = buildJsonLd(detail, lang);
 
@@ -1238,6 +1249,7 @@ export default async function AnimeDetailPage({ params }: PageProps) {
         </HeroAccent>
         <div className="container">
           <DetailActions
+            loggedIn={loggedIn}
             anilistId={detail.anilistId}
             episodes={detail.episodes}
             titleRomaji={detail.titleRomaji}
@@ -1282,6 +1294,7 @@ export default async function AnimeDetailPage({ params }: PageProps) {
           <CharactersSection characters={detail.characters} lang={lang} dict={dict} />
           <StaffSectionView staff={detail.staff} lang={lang} dict={dict} />
           <EpisodesGrid
+            loggedIn={loggedIn}
             anilistId={detail.anilistId}
             episodes={detail.episodes}
             episodeTitles={detail.episodeTitles ?? []}

--- a/next-app/src/components/anime/DetailActions.tsx
+++ b/next-app/src/components/anime/DetailActions.tsx
@@ -25,6 +25,8 @@ const TorrentModal = dynamic(() => import("./TorrentModal"), {
 
 interface DetailActionsProps {
   anilistId: number;
+  // Server-known login signal, threaded to SubscriptionButton (ISSUE-001).
+  loggedIn: boolean;
   episodes: number | null;
   titleRomaji: string | null;
   titleEnglish: string | null;
@@ -78,6 +80,7 @@ const rowStyle = {
 
 export default function DetailActions({
   anilistId,
+  loggedIn,
   episodes,
   titleRomaji,
   titleEnglish,
@@ -96,6 +99,7 @@ export default function DetailActions({
       <div style={rowStyle}>
         <SubscriptionButton
           anilistId={anilistId}
+          loggedIn={loggedIn}
           episodes={episodes}
           labels={{
             add: labels.subAdd,

--- a/next-app/src/components/anime/EpisodesGrid.tsx
+++ b/next-app/src/components/anime/EpisodesGrid.tsx
@@ -31,6 +31,9 @@ interface EpisodesGridProps {
   episodeTitles: DetailEpisodeTitle[];
   lang: Lang;
   dict: Dict;
+  // Server-known login signal from the RSC parent — gates the mount probe
+  // so logged-out views skip the 401-storming subscription fetch (ISSUE-001).
+  loggedIn: boolean;
 }
 
 const VALID_STATUSES: ReadonlyArray<SubStatus> = [
@@ -74,6 +77,7 @@ export default function EpisodesGrid({
   episodeTitles,
   lang,
   dict,
+  loggedIn,
 }: EpisodesGridProps) {
   const [sub, setSub] = useState<SubscriptionDoc | null>(null);
   // Which episode's expand panel is open. null = all collapsed. Matches
@@ -85,6 +89,7 @@ export default function EpisodesGrid({
   // neutral grid without an auth bounce. Cancel on unmount in case the
   // user navigates fast.
   useEffect(() => {
+    if (!loggedIn) return;
     let cancelled = false;
     (async () => {
       try {
@@ -102,7 +107,7 @@ export default function EpisodesGrid({
     return () => {
       cancelled = true;
     };
-  }, [anilistId]);
+  }, [anilistId, loggedIn]);
 
   // Listen for SubscriptionButton mutations. We only care about events
   // for THIS anime; the bus is global.

--- a/next-app/src/components/anime/SubscriptionButton.tsx
+++ b/next-app/src/components/anime/SubscriptionButton.tsx
@@ -59,6 +59,10 @@ interface SubscriptionButtonProps {
   anilistId: number;
   episodes: number | null;
   labels: Labels;
+  // Server-known login signal from the RSC parent (it read the session /
+  // refreshToken cookie). Gates the mount probe so logged-out detail-page
+  // views don't 401-storm — restores legacy useSubscription({enabled:!!user}).
+  loggedIn: boolean;
 }
 
 type SubStatus = "watching" | "completed" | "plan_to_watch" | "dropped";
@@ -276,9 +280,14 @@ export default function SubscriptionButton({
   anilistId,
   episodes,
   labels,
+  loggedIn,
 }: SubscriptionButtonProps) {
   const router = useRouter();
-  const [state, setState] = useState<LoadState>("loading");
+  // Logged-out visitors start directly in the anonymous CTA state (no
+  // loading flash, no network) — the probe below is skipped for them.
+  const [state, setState] = useState<LoadState>(
+    loggedIn ? "loading" : "anonymous",
+  );
   const [sub, setSub] = useState<SubscriptionDoc | null>(null);
   const [busy, setBusy] = useState(false);
   const [scoreOpen, setScoreOpen] = useState(false);
@@ -293,7 +302,11 @@ export default function SubscriptionButton({
   };
 
   // Mount probe — mirrors legacy useSubscription({enabled:!!user}).
+  // Skip entirely when logged out: the httpOnly session cookie is
+  // unreadable here, so without this gate every anonymous detail-page
+  // view fires GET /api/subscriptions/:id → 401 → refresh → 401 (ISSUE-001).
   useEffect(() => {
+    if (!loggedIn) return;
     let cancelled = false;
     (async () => {
       try {
@@ -338,7 +351,7 @@ export default function SubscriptionButton({
     return () => {
       cancelled = true;
     };
-  }, [anilistId]);
+  }, [anilistId, loggedIn]);
 
   // Outside-click close for score popup (matches legacy mousedown
   // listener pattern).

--- a/next-app/src/lib/serverAuth.test.ts
+++ b/next-app/src/lib/serverAuth.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { loggedInFromCookies } from "./serverAuth";
+
+// Minimal stand-in for ReadonlyRequestCookies — only `.has` is used.
+function store(names: string[]): { has(name: string): boolean } {
+  const set = new Set(names);
+  return { has: (n: string) => set.has(n) };
+}
+
+describe("loggedInFromCookies", () => {
+  test("true when only the session cookie is present", () => {
+    expect(loggedInFromCookies(store(["session"]))).toBe(true);
+  });
+
+  test("true when only refreshToken is present (expired access, valid refresh)", () => {
+    expect(loggedInFromCookies(store(["refreshToken"]))).toBe(true);
+  });
+
+  test("true when both auth cookies are present", () => {
+    expect(loggedInFromCookies(store(["session", "refreshToken"]))).toBe(true);
+  });
+
+  test("false when neither auth cookie is present (logged-out SEO visitor)", () => {
+    expect(loggedInFromCookies(store([]))).toBe(false);
+  });
+
+  test("false when only unrelated cookies are present (lang/theme)", () => {
+    expect(loggedInFromCookies(store(["lang", "theme"]))).toBe(false);
+  });
+
+  test("ignores cookies whose names merely contain the substring", () => {
+    // Guard against a sloppy `.includes`-style rewrite: a `my-session-x`
+    // cookie must NOT count as a real `session`.
+    expect(loggedInFromCookies(store(["my-session-x", "xrefreshToken"]))).toBe(
+      false,
+    );
+  });
+});

--- a/next-app/src/lib/serverAuth.ts
+++ b/next-app/src/lib/serverAuth.ts
@@ -1,0 +1,20 @@
+// Server-side login signal derived from the request's auth cookies.
+//
+// go-api sets two httpOnly cookies: `session` (15m access JWT) and
+// `refreshToken` (14d). Both are httpOnly, so client components can't read
+// them — only an RSC (which calls `cookies()`) can. A request carrying
+// EITHER cookie is treated as logged in:
+//   - session present                → logged in (access token live).
+//   - refreshToken present, no session → still logged in; the access token
+//     expired but authFetch will refresh on the first 401.
+//   - neither                        → logged out (the SEO organic visitor).
+//
+// Used to gate the client-side subscription probes on the anime detail page
+// so logged-out views don't 401-storm (ISSUE-001). See
+// SubscriptionButton.tsx / EpisodesGrid.tsx.
+
+type CookieReader = { has(name: string): boolean };
+
+export function loggedInFromCookies(store: CookieReader): boolean {
+  return store.has("session") || store.has("refreshToken");
+}


### PR DESCRIPTION
## ISSUE-001 fix — logged-out detail pages no longer 401-storm

Found by `/qa` Exhaustive. Every logged-out `/anime/{id}` view fired 3 failing authenticated requests (2× `GET /api/subscriptions/{id}` + `POST /api/auth/refresh`, all 401) → 3 console errors + client-Sentry envelopes, on the project's primary SEO/logged-out traffic.

## Root cause
The RSC port dropped the legacy `useSubscription({ enabled: !!user })` gate (`SubscriptionButton.tsx`). Two client components probe `/api/subscriptions/{id}` on mount; the client can't read the httpOnly `session`/`refreshToken` cookies, so it probes blindly and authFetch then attempts a refresh that also 401s.

## Fix
Restore the gate **server-side**. The detail page is already dynamic (`getLang()` reads cookies → `Cf-Cache-Status: DYNAMIC`, verified on prod), so reading one more cookie costs nothing. It computes `loggedIn` from the auth cookies and threads it to both client components, which skip the probe and render the anonymous/neutral state directly when logged out.

- `src/lib/serverAuth.ts` — `loggedInFromCookies()` (session OR refreshToken) + 6 unit tests
- `SubscriptionButton` / `EpisodesGrid` — `loggedIn` prop gates the mount probe; logged-out inits straight to the anonymous CTA / neutral grid (no flash, no network)
- `DetailActions` — threads `loggedIn` to `SubscriptionButton`
- `page.tsx` — `cookies()` → `loggedInFromCookies` → both components

## Why this is safe
- No caching change: the page was already dynamic (not ISR — `revalidate` is already moot because i18n reads cookies).
- Logged-in users always carry a `session` cookie after proxy.ts's server-side refresh, so `loggedIn` is accurate; their probe still fires.
- Required prop — tsc enforces every render site passes it (only 2 sites, both updated).

## Test plan
- [x] `bun test` → **229 pass / 0 fail** (was 223; +6 serverAuth tests)
- [x] `tsc --noEmit` → 0 errors in changed files
- [x] No orphan render sites
- [ ] CI unit-tests green
- [ ] Post-deploy: logged-out `/anime/{id}` network shows **0× 401** (ISSUE-001 acceptance)