### PR TITLE
fix: detail-page hreflang + CF-cache guard, and jassub WASM caching

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,7 @@
 - [ ] **Lighthouse 质量项**(2026-06-01 把这些从 error 降成 warn 让 CI 过,值得真修):LCP 图提 `fetchpriority="high"` 且不懒加载(`lcp-lazy-loaded`/`prioritize-lcp-image`)· 上 WebP/AVIF(`uses-optimized-images`/`modern-image-formats`)· 对比度(`color-contrast`)· 移动端触控目标(`target-size`)· 控制台报错(`errors-in-console`)· bf-cache 不可用排查。CI 跑 mobile 对 live prod。
 - [ ] 决定 deploy 切 main 后是否退役 `feat/go-backend` 分支(目前两分支内容一致)。
 - [ ] **e2e sandbox 套件退役后陈旧**:`e2e/globalSetup.ts` 仍 seed 已退役的 MongoDB + 需本地 stack 登录,chromium-sandbox(auth/library/player 写路径)在 CI 跑不起来。真修 = 去 Mongo seed(只留 Postgres)+ CI 起一次性测试 PG(用扔掉的测试密码,**非 prod**)+ 在 e2e-sandbox.yml / docker-compose.ci.yml 设 `E2E_SANDBOX=1` opt-in。本次 fix/e2e-prod-globalsetup 已让只读 chromium-prod 在 CI 转绿(globalSetup 默认 no-op),sandbox 单独修。
+- [ ] **soft-404 详情页真 404**:`/anime/{坏id}`(及 `/seasonal/*`、`/welcome`)因 `loading.tsx` 流式渲染,`notFound()` 返 HTTP **200 非 404**(`not-found.tsx` 那句"root not-found 设 404"是 comment rot)。Next 自动注入 `noindex` 已护住索引(2026-06-01 实测),实际危害近零 → **LOW**。真修两条路:① `global-not-found.js`(Next 16 experimental,但文档显示它是给"压根不匹配任何路由"的 URL,对"匹配路由内 streaming notFound"大概率**无效**,需部署后 curl 验);② 删 `/anime/[id]/loading.tsx`(保证真 404,但丢冷 id 骨架屏)。**eng-review pass-2(2026-06-01)决定 feat/detail-seo-fixes PR 不修,defer。**
 
 ---
 

--- a/next-app/next.config.ts
+++ b/next-app/next.config.ts
@@ -65,6 +65,30 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+
+  // Cache the jassub subtitle-engine static binaries (WASM / worker / font) hard.
+  // They live in public/jassub/ (built by `build:jassub` at prebuild) at stable,
+  // non-content-hashed paths, so Next serves them with the public/ default
+  // `Cache-Control: public, max-age=0`. That means the ~2 MB worker WASM is
+  // re-fetched from the origin on every player open; on a slow load it blows
+  // jassub's 10 s init budget and subtitles silently fail to appear (Cf-Cache-
+  // Status was DYNAMIC because CF doesn't edge-cache .wasm by extension either).
+  // A long max-age lets the browser AND the CF edge cache them. No `immutable`:
+  // the paths are not content-hashed, so a 30-day window self-heals after a
+  // jassub upgrade instead of pinning a stale worker for a year. Verified vs the
+  // Next 16 headers() docs — headers are checked before /public, and non-hashed
+  // public assets CAN have Cache-Control overridden (only SHA-hashed
+  // /_next/static immutable assets cannot).
+  async headers() {
+    return [
+      {
+        source: "/jassub/:path*",
+        headers: [
+          { key: "Cache-Control", value: "public, max-age=2592000" }, // 30 days
+        ],
+      },
+    ];
+  },
 };
 
 // Sentry wraps the Next config so the webpack plugin can (a) inject the

--- a/next-app/src/app/anime/[id]/page.tsx
+++ b/next-app/src/app/anime/[id]/page.tsx
@@ -204,12 +204,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     description,
     openGraph,
     twitter,
+    // hreflang intentionally omitted: the site is zh-canonical only. An
+    // `en-US` alternate at `?lang=en` was a false signal — getLang() is
+    // hardcoded `zh`, so that URL serves byte-identical Chinese HTML (verified
+    // on prod). Re-add a real languages map only when localized URLs exist
+    // (the deferred URL-i18n initiative), not before.
     alternates: {
       canonical,
-      languages: {
-        "zh-CN": canonical,
-        "en-US": `${canonical}?lang=en`,
-      },
     },
   };
 }
@@ -1231,6 +1232,15 @@ function EpisodesSection({
 // --- Page entry ---
 
 export default async function AnimeDetailPage({ params }: PageProps) {
+  // CF EDGE-CACHED ROUTE — keep this server render ANONYMOUS.
+  // `/anime/*` is served from a Cloudflare edge cache (see
+  // docs/migration/CF-EDGE-CACHE-PLAN.md). The cached HTML is handed to every
+  // visitor, so do NOT read cookies()/headers()/searchParams or run any
+  // per-user server fetch on this path: that either forces the page dynamic
+  // (killing ISR) or caches one user's personalized HTML for everyone. Per-user
+  // state hydrates client-side (auth_hint gate, see lib/clientAuth). If this
+  // route ever must become per-user, update/remove the CF cache rule in the
+  // same change.
   const { id } = await params;
   const anilistId = Number(id);
   if (!Number.isFinite(anilistId) || anilistId <= 0) notFound();


### PR DESCRIPTION
## Summary

Two independent fixes surfaced during the CF edge-cache review + a live subtitle incident.

### 1. Detail-page SEO signals (`fix(seo)`)
- **Drop false `en-US` hreflang** on `/anime/[id]`. `generateMetadata` advertised an `en-US` alternate at `?lang=en`, but `getLang()` is hardcoded `zh` and the server ignores the query param, so that URL serves byte-identical Chinese HTML (verified on prod) — an invalid hreflang plus a duplicate cache key. Keep the `zh` canonical; re-add a real `languages` map only when localized URLs exist (deferred URL-i18n initiative).
- **Anonymity guard comment** at the page entry: `/anime/*` is CF edge-cached, so the server render must stay anonymous (no `cookies()`/`headers()`/per-user fetch) or the CF cache rule must change in lockstep. Guards against a future per-user regression leaking a cached personalized page.

### 2. Player subtitle caching (`perf(player)`)
- Root-caused intermittent "subtitles missing" (`[jassub] renderer.ready still pending after 10s`): the 2 MB jassub worker WASM was served `max-age=0` + CF `DYNAMIC` (CF doesn't edge-cache `.wasm` by extension), so it re-downloaded from the HK origin on every player open. Slow loads blew jassub's 10 s init budget.
- Add a `next.config` `headers()` rule for `/jassub/:path*` → `max-age=2592000` (30 d, no `immutable` since the paths aren't content-hashed, so it self-heals after a jassub upgrade). Pairs with a Cloudflare `/jassub/*` cache rule (tracked in the CF edge plan) for the global edge-cache win.

## Not in scope / deferred
- **Streamed soft-404**: `/anime/{bad-id}` returns HTTP 200 (not 404) because `loading.tsx` streams the shell before `notFound()` runs. Next auto-injects `noindex`, so the index is protected → LOW. `global-not-found.js` is experimental and (per the Next 16 docs) likely ineffective for matched-route streaming; deferred to `TODO.md`.

## Test plan
- [ ] CI green (go test + bun test + jest)
- [ ] After deploy: `curl -s https://animegoclub.com/anime/154587 | grep hreflang` → no `?lang=en` alternate; canonical still present
- [ ] After deploy: `curl -sI https://animegoclub.com/jassub/wasm/jassub-worker.wasm` → `Cache-Control: public, max-age=2592000`
- [ ] After the CF `/jassub/*` rule: same curl → `Cf-Cache-Status: HIT` (warm); player opens without the 10 s subtitle stall
- [ ] Logged-in navbar still renders on `/anime/[id]` (anonymity change is comment-only, no behavior change)
