### PR TITLE
fix(i18n): stop AnimeGo doubling in player/library/admin tab titles

### DIFF
--- a/next-app/src/locales/en.ts
+++ b/next-app/src/locales/en.ts
@@ -221,7 +221,7 @@ const en = {
   },
   // Player
   player: {
-    pageTitle: 'Player — AnimeGo',
+    pageTitle: 'Player',
     dropLabel: 'Select video folder',
     dropTitle: 'Drag anime folder here or click to select',
     dropReplace: 'Drop to replace current session',
@@ -430,7 +430,7 @@ const en = {
   },
   // Library
   library: {
-    pageTitle: 'My Library — AnimeGo',
+    pageTitle: 'My Library',
     addFolder: 'Add folder',
     dropFolder: 'Drop folder here',
     unsupportedBanner: 'Your browser does not keep libraries between sessions.',
@@ -554,7 +554,7 @@ const en = {
   // Admin
   admin: {
     title: 'Admin Dashboard',
-    pageTitle: 'Admin Dashboard — AnimeGo',
+    pageTitle: 'Admin Dashboard',
     enrichmentTitle: 'Enrichment Management',
     navOverview: 'Overview',
     navEnrichment: 'Enrichment',

--- a/next-app/src/locales/zh.ts
+++ b/next-app/src/locales/zh.ts
@@ -273,7 +273,7 @@ const zh = {
   },
   // Player
   player: {
-    pageTitle: '播放器 — AnimeGo',
+    pageTitle: '播放器',
     dropLabel: '选择视频文件夹',
     dropTitle: '拖入番剧文件夹 或 点击选择',
     dropReplace: '松开以替换当前内容',
@@ -482,7 +482,7 @@ const zh = {
   },
   // Library
   library: {
-    pageTitle: '我的库 — AnimeGo',
+    pageTitle: '我的库',
     addFolder: '添加文件夹',
     dropFolder: '拖入文件夹',
     unsupportedBanner: '当前浏览器不会跨会话保留本地媒体库。',
@@ -606,7 +606,7 @@ const zh = {
   // Admin
   admin: {
     title: '管理后台',
-    pageTitle: '管理后台 — AnimeGo',
+    pageTitle: '管理后台',
     enrichmentTitle: '富化管理',
     navOverview: '总览',
     navEnrichment: '数据富化',


### PR DESCRIPTION
## Summary
The player/library/admin layouts set `title: dict.X.pageTitle`, which runs through the root layout's title template `"%s . AnimeGo"`. Those `pageTitle` strings already ended in `— AnimeGo`, so the browser tab rendered e.g. **`我的库 — AnimeGo . AnimeGo`** (AnimeGo twice). Drop the `— AnimeGo` suffix from the three `pageTitle` strings (zh + en, 6 total) so the template supplies it once → `我的库 . AnimeGo`.

Affected: `/player`, `/library`, `/admin` tab titles. Login/register pageTitles were already clean (no AnimeGo).

## Test plan
- [ ] CI green
- [ ] After deploy: `/library` tab title shows `我的库 . AnimeGo` (single AnimeGo), not doubled