### PR TITLE
fix(detail): always show magnet + play buttons (don't gate on AniList episodes)

### DIFF
--- a/next-app/src/components/anime/DetailActions.tsx
+++ b/next-app/src/components/anime/DetailActions.tsx
@@ -4,8 +4,10 @@
 // /anime/[id]. Hosts the five legacy interactions:
 //   1. SubscriptionButton (v2 panel: status select + ep ± + score + remove)
 //   2. ShareButton         — Web Share API / clipboard fallback
-//   3. MagnetButton        — opens TorrentModal (when episodes > 0)
-//   4. PlayButton          — opens /player in a new tab (when episodes > 0)
+//   3. MagnetButton        — opens TorrentModal (always; torrent search is
+//      title-based, needs no episode count)
+//   4. PlayButton          — opens /player in a new tab (always; the player
+//      selects episodes itself)
 //   5. TorrentModal        — rendered when state.torrentOpen is true
 //
 // Labels arrive flat from page.tsx and we shape them per child here so
@@ -89,7 +91,6 @@ export default function DetailActions({
   labels,
 }: DetailActionsProps) {
   const [torrentOpen, setTorrentOpen] = useState(false);
-  const hasEpisodes = typeof episodes === "number" && episodes > 0;
 
   return (
     <>
@@ -119,15 +120,15 @@ export default function DetailActions({
             copyFailed: labels.shareCopyFailed,
           }}
         />
-        {hasEpisodes && (
-          <>
-            <MagnetButton
-              onOpen={() => setTorrentOpen(true)}
-              label={labels.torrents}
-            />
-            <PlayButton ariaLabel={labels.playAria}>{labels.play}</PlayButton>
-          </>
-        )}
+        {/* Always shown. Torrent search works off the title (no episode count
+            needed) and the player selects episodes itself. Gating these on
+            AniList's `episodes` total hid them for every currently-airing show,
+            where AniList returns episodes=null until the run finishes. */}
+        <MagnetButton
+          onOpen={() => setTorrentOpen(true)}
+          label={labels.torrents}
+        />
+        <PlayButton ariaLabel={labels.playAria}>{labels.play}</PlayButton>
       </div>
       {torrentOpen && (
         <TorrentModal


### PR DESCRIPTION
## Problem
All 106 of this week's airing anime show no magnet button and no play button. Root cause: AniList returns `episodes: null` for currently-airing shows (the total isn't finalized until the run ends), and `DetailActions` gated MagnetButton + PlayButton on `episodes > 0` (`hasEpisodes`). So every airing show lost both entries — even though torrents exist (50–155/show via the acg.rip / animes.garden / nyaa aggregator) and Bangumi `episodeTitles` are populated.

## Fix
Ungate both buttons — torrent search is title-based (needs no episode count) and the player selects episodes itself. Remove the now-unused `hasEpisodes`.

## Out of scope (follow-up)
The episode grid (`EpisodesGrid.tsx:128`) + hero episode-count badge are also gated on `episodes` — they stay hidden for airing shows. Separate fix via an `episodeTitles.length` fallback (tracked for later).

## Test plan
- [ ] CI green
- [ ] After deploy: open an airing show (e.g. /anime/197868 メイドさんは食べるだけ) → magnet + play buttons present; magnet modal returns results