### PR TITLE
seo(brand): unify the brand name to AnimeGoClub (search + visual)

### DIFF
--- a/next-app/src/app/anime/[id]/page.tsx
+++ b/next-app/src/app/anime/[id]/page.tsx
@@ -165,16 +165,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { id } = await params;
   const anilistId = Number(id);
   if (!Number.isFinite(anilistId) || anilistId <= 0) {
-    return { title: "AnimeGo" };
+    return { title: { absolute: "AnimeGoClub" } };
   }
 
   const [lang, detail] = await Promise.all([getLang(), loadDetail(anilistId)]);
   if (!detail) {
-    return { title: "AnimeGo" };
+    return { title: { absolute: "AnimeGoClub" } };
   }
 
   const title = pickTitle(detail, lang);
-  const titleFull = `${title} · AnimeGo`;
+  const titleFull = `${title} · AnimeGoClub`;
   const description = truncate(stripHtml(detail.description || ""), 160);
   const locale = lang === "en" ? "en_US" : "zh_CN";
   const heroImage = detail.bannerImageUrl || detail.coverImageUrl || null;
@@ -183,7 +183,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const openGraph: Metadata["openGraph"] = {
     title,
     description,
-    siteName: "AnimeGo",
+    siteName: "AnimeGoClub",
     locale,
     alternateLocale: lang === "en" ? ["zh_CN"] : ["en_US"],
     type: "video.tv_show",

--- a/next-app/src/app/calendar/page.tsx
+++ b/next-app/src/app/calendar/page.tsx
@@ -27,7 +27,7 @@ async function safeSchedule(): Promise<ScheduleResponse> {
 export async function generateMetadata(): Promise<Metadata> {
   const [dict, lang] = await Promise.all([getDict(), getLang()]);
   const title =
-    lang === "zh" ? "今日新番放送日历 — AnimeGo" : "Airing Calendar — AnimeGo";
+    lang === "zh" ? "今日新番放送日历" : "Airing Calendar";
   const description =
     lang === "zh"
       ? "本周新番放送时间表，按周一至周日分组，覆盖连载中的 TV 动画与 ONA。每日更新。"

--- a/next-app/src/app/faq/page.tsx
+++ b/next-app/src/app/faq/page.tsx
@@ -11,8 +11,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const lang = await getLang();
   const title =
     lang === "zh"
-      ? "常见问题 — AnimeGo"
-      : "Frequently Asked Questions — AnimeGo";
+      ? "常见问题"
+      : "Frequently Asked Questions";
   const description =
     lang === "zh"
       ? "关于 AnimeGoClub 是否免费、与 Bangumi/AniList/MAL 的区别、弹幕来源、OVA/ONA/剧场版的差异等。"

--- a/next-app/src/app/layout.tsx
+++ b/next-app/src/app/layout.tsx
@@ -48,12 +48,12 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     metadataBase: new URL("https://animegoclub.com"),
     title: {
-      template: "%s . AnimeGo",
+      template: "%s . AnimeGoClub",
       default: dict.meta.titleDefault,
     },
     description: dict.meta.description,
-    applicationName: "AnimeGo",
-    authors: [{ name: "AnimeGo" }],
+    applicationName: "AnimeGoClub",
+    authors: [{ name: "AnimeGoClub" }],
     generator: "Next.js",
     keywords: dict.meta.keywords,
     robots: { index: true, follow: true },
@@ -63,7 +63,7 @@ export async function generateMetadata(): Promise<Metadata> {
       apple: "/apple-touch-icon.png",
     },
     openGraph: {
-      siteName: "AnimeGo",
+      siteName: "AnimeGoClub",
       type: "website",
       locale: lang === "en" ? "en_US" : "zh_CN",
       alternateLocale: lang === "en" ? ["zh_CN"] : ["en_US"],

--- a/next-app/src/app/profile/page.tsx
+++ b/next-app/src/app/profile/page.tsx
@@ -49,11 +49,11 @@ async function safeSubscriptions(
 export async function generateMetadata(): Promise<Metadata> {
   const [dict, lang] = await Promise.all([getDict(), getLang()]);
   const title =
-    lang === "zh" ? "我的追番 — AnimeGo" : "My Watchlist — AnimeGo";
+    lang === "zh" ? "我的追番 — AnimeGoClub" : "My Watchlist — AnimeGoClub";
   const description =
     lang === "zh"
       ? `${dict.profile.label} — ${dict.meta.description}`
-      : `Your personal watchlist on AnimeGo.`;
+      : `Your personal watchlist on AnimeGoClub.`;
 
   return {
     title: { absolute: title },

--- a/next-app/src/app/search/page.tsx
+++ b/next-app/src/app/search/page.tsx
@@ -149,8 +149,8 @@ export async function generateMetadata({
     title,
     description: hasQuery
       ? lang === "zh"
-        ? `AnimeGo 搜索结果: ${q || genre}`
-        : `AnimeGo search results for ${q || genre}`
+        ? `AnimeGoClub 搜索结果: ${q || genre}`
+        : `AnimeGoClub search results for ${q || genre}`
       : dict.search.prompt,
     robots: hasQuery
       ? { index: false, follow: true }

--- a/next-app/src/app/seasonal/[season]/[year]/page.tsx
+++ b/next-app/src/app/seasonal/[season]/[year]/page.tsx
@@ -119,7 +119,7 @@ export async function generateMetadata({ params }: { params: PageProps["params"]
     openGraph: {
       title,
       description,
-      siteName: "AnimeGo",
+      siteName: "AnimeGoClub",
       locale: lang === "en" ? "en_US" : "zh_CN",
       alternateLocale: lang === "en" ? ["zh_CN"] : ["en_US"],
       type: "website",

--- a/next-app/src/app/u/[username]/_components/ShareButtonIsland.tsx
+++ b/next-app/src/app/u/[username]/_components/ShareButtonIsland.tsx
@@ -20,7 +20,7 @@ export default function ShareButtonIsland({
 
   const handle = async () => {
     const url = `${window.location.origin}/u/${username}`;
-    const title = `${username} — AnimeGo`;
+    const title = `${username} — AnimeGoClub`;
 
     if (navigator.share) {
       try {

--- a/next-app/src/app/u/[username]/followers/page.tsx
+++ b/next-app/src/app/u/[username]/followers/page.tsx
@@ -47,11 +47,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const title = `${dict.social.followers} · ${username}`;
   const canonical = `/u/${username}/followers`;
   return {
-    title: { absolute: `${title} · AnimeGo` },
+    title: { absolute: `${title} · AnimeGoClub` },
     description:
       lang === "zh"
-        ? `查看 ${username} 的粉丝列表 — AnimeGo`
-        : `People who follow ${username} on AnimeGo`,
+        ? `查看 ${username} 的粉丝列表 — AnimeGoClub`
+        : `People who follow ${username} on AnimeGoClub`,
     alternates: {
       canonical,
       languages: {

--- a/next-app/src/app/u/[username]/following/page.tsx
+++ b/next-app/src/app/u/[username]/following/page.tsx
@@ -41,11 +41,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const title = `${dict.social.following} · ${username}`;
   const canonical = `/u/${username}/following`;
   return {
-    title: { absolute: `${title} · AnimeGo` },
+    title: { absolute: `${title} · AnimeGoClub` },
     description:
       lang === "zh"
-        ? `查看 ${username} 关注的用户 — AnimeGo`
-        : `Users that ${username} follows on AnimeGo`,
+        ? `查看 ${username} 关注的用户 — AnimeGoClub`
+        : `Users that ${username} follows on AnimeGoClub`,
     alternates: {
       canonical,
       languages: {

--- a/next-app/src/app/u/[username]/page.tsx
+++ b/next-app/src/app/u/[username]/page.tsx
@@ -69,11 +69,11 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const canonical = `/u/${username}`;
 
   return {
-    title: { absolute: `${title} · AnimeGo` },
+    title: { absolute: `${title} · AnimeGoClub` },
     description:
       lang === "zh"
-        ? `${username} 的追番列表和社交主页 — AnimeGo`
-        : `${username}'s watchlist and social profile on AnimeGo`,
+        ? `${username} 的追番列表和社交主页 — AnimeGoClub`
+        : `${username}'s watchlist and social profile on AnimeGoClub`,
     alternates: {
       canonical,
       languages: {
@@ -83,7 +83,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     },
     openGraph: {
       title,
-      siteName: "AnimeGo",
+      siteName: "AnimeGoClub",
       type: "profile",
       url: canonical,
     },

--- a/next-app/src/app/welcome/page.tsx
+++ b/next-app/src/app/welcome/page.tsx
@@ -122,7 +122,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const openGraph: Metadata["openGraph"] = {
     title,
     description,
-    siteName: "AnimeGo",
+    siteName: "AnimeGoClub",
     locale,
     alternateLocale: lang === "en" ? ["zh_CN"] : ["en_US"],
     type: "website",

--- a/next-app/src/components/anime/ContinueWatching.tsx
+++ b/next-app/src/components/anime/ContinueWatching.tsx
@@ -200,7 +200,7 @@ function LoggedOutStub({ dict, lang }: ContinueWatchingProps) {
       ? "登录后追番进度会出现在这里"
       : "Login to track your watching progress";
   const cta = dict.nav.login;
-  const ctaAria = lang === "zh" ? "登录 AnimeGo" : "Login to AnimeGo";
+  const ctaAria = lang === "zh" ? "登录 AnimeGoClub" : "Login to AnimeGoClub";
   return (
     <section style={sectionStyle} aria-label={dict.home.watchingTitle}>
       <div style={headerStyle}>

--- a/next-app/src/components/anime/ShareButton.tsx
+++ b/next-app/src/components/anime/ShareButton.tsx
@@ -60,7 +60,7 @@ export default function ShareButton({
       typeof window !== "undefined"
         ? `${window.location.origin}/anime/${anilistId}`
         : `/anime/${anilistId}`;
-    const titleFull = `${shareTitle} — AnimeGo`;
+    const titleFull = `${shareTitle} — AnimeGoClub`;
 
     if (typeof navigator !== "undefined" && navigator.share) {
       try {

--- a/next-app/src/components/landing/FinalCta.tsx
+++ b/next-app/src/components/landing/FinalCta.tsx
@@ -257,7 +257,7 @@ export default function FinalCta({ dict }: FinalCtaProps) {
         </div>
 
         <div className="finalcta-meta" style={s.metaRow}>
-          <span>AnimeGo · v1.0.14</span>
+          <span>AnimeGoClub · v1.0.14</span>
           <span className="finalcta-meta-center" style={s.metaCenter}>
             ─────────── {finalCta.metaMaintenance} ───────────
           </span>

--- a/next-app/src/components/layout/Navbar.tsx
+++ b/next-app/src/components/layout/Navbar.tsx
@@ -180,7 +180,7 @@ export default function Navbar({ season, year }: NavbarProps) {
     <nav style={s.nav} aria-label={lang === "zh" ? "主导航" : "Main navigation"}>
       <div style={s.inner}>
         <Link href="/" style={s.logo} prefetch={false}>
-          AnimeGo
+          AnimeGoClub
         </Link>
         <div style={s.links}>
           {links.map((l) => (

--- a/next-app/src/components/social/ActivityFeed.tsx
+++ b/next-app/src/components/social/ActivityFeed.tsx
@@ -219,7 +219,7 @@ function LoggedOutStub({ dict, lang }: ActivityFeedProps) {
       ? "登录后查看关注的人在追什么"
       : "Login to see what your friends are watching";
   const cta = dict.nav.login;
-  const ctaAria = lang === "zh" ? "登录 AnimeGo" : "Login to AnimeGo";
+  const ctaAria = lang === "zh" ? "登录 AnimeGoClub" : "Login to AnimeGoClub";
   return (
     <section style={sectionStyle} aria-label={dict.social.feedTitle}>
       <div style={headerStyle}>

--- a/next-app/src/lib/i18n.test.ts
+++ b/next-app/src/lib/i18n.test.ts
@@ -122,7 +122,7 @@ describe("tFromDict", () => {
     const dict = getDictByLang("zh");
     const t = tFromDict(dict);
     // meta.titleDefault exists in zh
-    expect(t("meta.titleDefault")).toContain("AnimeGo");
+    expect(t("meta.titleDefault")).toContain("AnimeGoClub");
   });
 
   test("coerces a non-string leaf value to string", () => {

--- a/next-app/src/locales/en-spa.js
+++ b/next-app/src/locales/en-spa.js
@@ -65,7 +65,7 @@ const en = {
   },
   // Login
   login: {
-    title: 'AnimeGo', subtitle: 'Welcome back, continue your journey',
+    title: 'AnimeGoClub', subtitle: 'Welcome back, continue your journey',
     email: 'Email', password: 'Password',
     submit: 'Login', submitting: 'Logging in...',
     noAccount: "Don't have an account? ", registerLink: 'Sign Up',
@@ -89,7 +89,7 @@ const en = {
   },
   // Register
   register: {
-    title: 'Create Account', subtitle: 'Join AnimeGo and start your watchlist',
+    title: 'Create Account', subtitle: 'Join AnimeGoClub and start your watchlist',
     username: 'Username', email: 'Email', password: 'Password (min. 6 chars)',
     submit: 'Create Account', submitting: 'Creating...',
     hasAccount: 'Already have an account? ', loginLink: 'Login',
@@ -147,7 +147,7 @@ const en = {
   },
   // Footer
   footer: {
-    siteCol: 'AnimeGo',
+    siteCol: 'AnimeGoClub',
     siteDesc: 'Rundle Streetが暮れる。東京が灯る。',
     donate: 'Donate',
     apps: 'Apps',
@@ -173,7 +173,7 @@ const en = {
     terms: 'Terms of Service',
     privacy: 'Privacy Policy',
     dataCredits: 'Data provided by',
-    copyright: '© {year} AnimeGo · Rundle Streetが暮れる。東京が灯る。',
+    copyright: '© {year} AnimeGoClub · Rundle Streetが暮れる。東京が灯る。',
   },
   // Comments
   comment: {
@@ -256,7 +256,7 @@ const en = {
   },
   // Landing / About page
   landing: {
-    docTitle: 'AnimeGo · Watch the one you came for',
+    docTitle: 'AnimeGoClub · Watch the one you came for',
     hero: {
       eyebrow: 'v1.0.12 · OKLCH poster identity',
       titleLine1: ['Watch', 'the', 'one'],

--- a/next-app/src/locales/en.ts
+++ b/next-app/src/locales/en.ts
@@ -96,7 +96,7 @@ const en = {
   },
   // Login
   login: {
-    title: 'AnimeGo', pageTitle: 'Login', subtitle: 'Welcome back, continue your journey',
+    title: 'AnimeGoClub', pageTitle: 'Login', subtitle: 'Welcome back, continue your journey',
     email: 'Email', password: 'Password',
     submit: 'Login', submitting: 'Logging in...',
     noAccount: "Don't have an account? ", registerLink: 'Sign Up',
@@ -120,7 +120,7 @@ const en = {
   },
   // Register
   register: {
-    title: 'Create Account', pageTitle: 'Sign Up', subtitle: 'Join AnimeGo and start your watchlist',
+    title: 'Create Account', pageTitle: 'Sign Up', subtitle: 'Join AnimeGoClub and start your watchlist',
     username: 'Username', email: 'Email', password: 'Password (min. 6 chars)',
     submit: 'Create Account', submitting: 'Creating...',
     hasAccount: 'Already have an account? ', loginLink: 'Login',
@@ -181,7 +181,7 @@ const en = {
   },
   // Footer
   footer: {
-    siteCol: 'AnimeGo',
+    siteCol: 'AnimeGoClub',
     siteDesc: 'Rundle Streetが暮れる。東京が灯る。',
     donate: 'Donate',
     apps: 'Apps',
@@ -207,7 +207,7 @@ const en = {
     terms: 'Terms of Service',
     privacy: 'Privacy Policy',
     dataCredits: 'Data provided by',
-    copyright: '© {year} AnimeGo · Rundle Streetが暮れる。東京が灯る。',
+    copyright: '© {year} AnimeGoClub · Rundle Streetが暮れる。東京が灯る。',
   },
   // Comments
   comment: {

--- a/next-app/src/locales/en.ts
+++ b/next-app/src/locales/en.ts
@@ -3,7 +3,7 @@ const en = {
   common: { loading: 'Loading...' },
   // Root <head> metadata (browser title, description, SEO keywords).
   meta: {
-    titleDefault: 'AnimeGo . Catch the episode you came for',
+    titleDefault: 'AnimeGoClub . Catch the episode you came for',
     description:
       'An anime site that makes the cover art the star. Multi-source aggregation, on-screen danmaku, manual episode picking as a fallback — no algorithmic feed, no paywalled episodes.',
     keywords: [
@@ -270,7 +270,7 @@ const en = {
   },
   // Landing / About page
   landing: {
-    docTitle: 'AnimeGo · Watch the one you came for',
+    docTitle: 'AnimeGoClub · Watch the one you came for',
     hero: {
       eyebrow: 'v1.0.12 · OKLCH poster identity',
       titleLine1: ['Watch', 'the', 'one'],

--- a/next-app/src/locales/zh-spa.js
+++ b/next-app/src/locales/zh-spa.js
@@ -115,7 +115,7 @@ const zh = {
   },
   // Login
   login: {
-    title: 'AnimeGo', subtitle: '欢迎回来，继续追番之旅',
+    title: 'AnimeGoClub', subtitle: '欢迎回来，继续追番之旅',
     email: '邮箱', password: '密码',
     submit: '登录', submitting: '登录中...',
     noAccount: '还没有账号？', registerLink: '立即注册',
@@ -139,7 +139,7 @@ const zh = {
   },
   // Register
   register: {
-    title: '创建账号', subtitle: '加入 AnimeGo，开始你的追番列表',
+    title: '创建账号', subtitle: '加入 AnimeGoClub，开始你的追番列表',
     username: '用户名', email: '邮箱', password: '密码（至少6位）',
     submit: '创建账号', submitting: '注册中...',
     hasAccount: '已有账号？', loginLink: '立即登录',
@@ -197,7 +197,7 @@ const zh = {
   },
   // Footer
   footer: {
-    siteCol: 'AnimeGo',
+    siteCol: 'AnimeGoClub',
     siteDesc: 'Rundle Streetが暮れる。東京が灯る。',
     donate: '赞助我们',
     apps: '移动应用',
@@ -223,7 +223,7 @@ const zh = {
     terms: '服务条款',
     privacy: '隐私政策',
     dataCredits: '数据来自',
-    copyright: '© {year} AnimeGo · Rundle Streetが暮れる。東京が灯る。',
+    copyright: '© {year} AnimeGoClub · Rundle Streetが暮れる。東京が灯る。',
   },
   // Comments
   comment: {
@@ -306,7 +306,7 @@ const zh = {
   },
   // Landing / About page
   landing: {
-    docTitle: 'AnimeGo · 追你该追的那一话',
+    docTitle: 'AnimeGoClub · 追你该追的那一话',
     hero: {
       eyebrow: 'v1.0.12 · OKLCH 海报色身份',
       titleLine1: ['追', '你', '该', '追', '的'],

--- a/next-app/src/locales/zh.ts
+++ b/next-app/src/locales/zh.ts
@@ -148,7 +148,7 @@ const zh = {
   },
   // Login
   login: {
-    title: 'AnimeGo', pageTitle: '登录', subtitle: '欢迎回来，继续追番之旅',
+    title: 'AnimeGoClub', pageTitle: '登录', subtitle: '欢迎回来，继续追番之旅',
     email: '邮箱', password: '密码',
     submit: '登录', submitting: '登录中...',
     noAccount: '还没有账号？', registerLink: '立即注册',
@@ -172,7 +172,7 @@ const zh = {
   },
   // Register
   register: {
-    title: '创建账号', pageTitle: '注册', subtitle: '加入 AnimeGo，开始你的追番列表',
+    title: '创建账号', pageTitle: '注册', subtitle: '加入 AnimeGoClub，开始你的追番列表',
     username: '用户名', email: '邮箱', password: '密码（至少6位）',
     submit: '创建账号', submitting: '注册中...',
     hasAccount: '已有账号？', loginLink: '立即登录',
@@ -233,7 +233,7 @@ const zh = {
   },
   // Footer
   footer: {
-    siteCol: 'AnimeGo',
+    siteCol: 'AnimeGoClub',
     siteDesc: 'Rundle Streetが暮れる。東京が灯る。',
     donate: '赞助我们',
     apps: '移动应用',
@@ -259,7 +259,7 @@ const zh = {
     terms: '服务条款',
     privacy: '隐私政策',
     dataCredits: '数据来自',
-    copyright: '© {year} AnimeGo · Rundle Streetが暮れる。東京が灯る。',
+    copyright: '© {year} AnimeGoClub · Rundle Streetが暮れる。東京が灯る。',
   },
   // Comments
   comment: {

--- a/next-app/src/locales/zh.ts
+++ b/next-app/src/locales/zh.ts
@@ -3,7 +3,7 @@ const zh = {
   common: { loading: '加载中...' },
   // Root <head> metadata (browser title, description, SEO keywords).
   meta: {
-    titleDefault: 'AnimeGo . 追你该追的那一话',
+    titleDefault: 'AnimeGoClub . 追你该追的那一话',
     description:
       '把封面当主角的动漫站。多源聚合、弹幕同屏、手动选集兜底 -- 不做信息流推荐，不藏 VIP 集数。',
     keywords: [
@@ -322,7 +322,7 @@ const zh = {
   },
   // Landing / About page
   landing: {
-    docTitle: 'AnimeGo · 追你该追的那一话',
+    docTitle: 'AnimeGoClub · 追你该追的那一话',
     hero: {
       eyebrow: 'v1.0.12 · OKLCH 海报色身份',
       titleLine1: ['追', '你', '该', '追', '的'],


### PR DESCRIPTION
## Why

The brand was **split** across the app:

- **Homepage** (title / h1 / Organization + WebSite JSON-LD) → `AnimeGoClub` ✅
- **Everywhere else** (per-page `<title>` suffix, `og:site_name`, several page titles, **and the visual navbar/footer wordmark**) → `AnimeGo`

`AnimeGo` is a **generic, contested** term — it collides with the Russian pirate **AnimeGO.org** (the exact entity Google currently conflates us with) plus a sea of other "animego" sites. `AnimeGoClub` **matches our domain**, is distinctive, and is the term we can actually rank #1 for. A split signal slows Google's entity resolution and keeps feeding the contested term.

Decision: make the brand **fully `AnimeGoClub`** everywhere (search **and** visual).

## What

**Search signals → AnimeGoClub**
- `title` template `%s . AnimeGo` → `%s . AnimeGoClub`
- `og:site_name` (layout default + anime / u / welcome / seasonal)
- `titleDefault`, `applicationName`, `authors`
- anime detail `titleFull` suffix, `/u` titles + descriptions, `/search` description, `/profile` title, `/welcome` docTitle
- anime detail metadata fallback → `{ absolute: "AnimeGoClub" }` (kills latent template-doubling)

**Visual wordmark → AnimeGoClub**
- navbar logo, landing version tag, share-sheet title, login-CTA aria labels
- login/register headings, footer wordmark, copyright (zh.ts / en.ts)
- `*-spa.js` client locales (player/library app UI): headings, footer, copyright, docTitle
- tightened `i18n.test.ts` to assert the real brand

**Bonus fix:** `/calendar` and `/faq` (both in the sitemap) had a pre-existing **double-brand** `<title>` (`... — AnimeGo . AnimeGo`) — plain-string title that embedded the brand AND got the template suffix. Stripped the inline brand so the template owns one suffix.

## Kept as `AnimeGo` (deliberate)

JSON-LD `alternateName` and the `AnimeGo` keyword — these are **aliases, not displayed brand**. They capture "animego" search traffic and tell Google "also known as AnimeGo", which *helps* disambiguation. (Say the word if you want these gone too.)

## Test plan

- [x] `tsc --noEmit` clean on all changed files
- [x] `bun test i18n.test.ts` → 13 pass
- [x] No `AnimeGoClubClub`; residual `AnimeGo` = only alternateName + keyword
- [ ] Post-deploy: `curl -s https://animegoclub.com/ | grep -o '<title>[^<]*'` + og:site_name = AnimeGoClub; navbar shows AnimeGoClub