### PR TITLE
fix(player): stop fullscreen subtitle-cue flicker on control bar/heatmap

### DIFF
--- a/next-app/src/app/globals.css
+++ b/next-app/src/app/globals.css
@@ -160,3 +160,27 @@ h4 {
     animation: none;
   }
 }
+
+/* ── Player: fullscreen subtitle-cue flicker ───────────────────────────
+   artplayer rewrites .art-subtitle innerHTML on every `cuechange` and
+   toggles its display between dialogue lines. The element is a full-width,
+   bottom-anchored, z-index:20 overlay with a 4-layer text-shadow outline.
+   In fullscreen the browser re-rasterizes/re-composites that large layer on
+   each cue and bleeds a repaint into the bottom region it overlaps (controls
+   + danmaku heatmap) → a visible flicker every time a subtitle line appears
+   or changes. Windowed mode is too small to notice; only fullscreen shows it.
+   Known Chrome fullscreen + subtitle compositing quirk (cf. Stremio #644).
+
+   Fix: promote the subtitle (and the heatmap it overlaps) onto their own
+   stable GPU compositor layers and contain the subtitle's paint, so a cue
+   swap re-rasterizes only the subtitle's own texture and never invalidates
+   the controls/heatmap underneath. Pure compositing hints — no behaviour
+   change. */
+.art-video-player .art-subtitle {
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  contain: layout paint;
+}
+.art-video-player .art-control-heatmap {
+  transform: translateZ(0);
+}


### PR DESCRIPTION
## Symptom

The bottom **control bar / progress / danmaku heatmap** flickers a few times during playback. Confirmed via the user's repro (`MF GHOST 3rd Season - 06.mkv`, 10:05–10:20):

- only visible in **fullscreen** (windowed is too small to notice)
- **in sync with subtitle line changes** (every dialogue cue)
- **stops when paused**
- independent of content type and of the player's own subtitle on/off toggle

## Root cause (confirmed)

DevTools `cuechange` logging showed **one** textTrack (artplayer's own, `mode=hidden`) firing a cue per dialogue line. artplayer source: on every `cuechange` it runs `update()` → **rewrites `.art-subtitle` innerHTML** and toggles the element's display between lines. `.art-subtitle` is a full-width, bottom-anchored, `z-index:20` overlay with a **4-layer `text-shadow`** outline.

In **fullscreen**, the browser re-rasterizes/re-composites that large layer on each cue and **bleeds a repaint into the bottom region it overlaps** — the controls + heatmap — so they flicker on every subtitle change. Known Chrome fullscreen+subtitle compositing quirk (cf. [Stremio stremio-web#644](https://github.com/Stremio/stremio-web/issues/644), Intel GPU reports).

Why each clue fits: subtitle-toggle-independent → track stays `hidden`, cues keep firing, `update()` keeps running. Pause-stops → `cuechange` stops. Fullscreen-only → the layer is large enough for the repaint to show.

## Fix

Pure compositing hints in `globals.css`, scoped to `.art-video-player`:

```css
.art-video-player .art-subtitle { transform: translateZ(0); backface-visibility: hidden; contain: layout paint; }
.art-video-player .art-control-heatmap { transform: translateZ(0); }
```

Promotes the subtitle (and the heatmap it overlaps) onto their own stable GPU layers + contains the subtitle's paint, so a cue swap re-rasterizes only the subtitle's own texture and can't invalidate the controls/heatmap underneath. **Zero behaviour change.**

## Out of scope (noted, not fixed)

The heatmap's custom-styling CSS (`--heatmap-h` / `--heatmap-scale-y` / `--heatmap-fill` / `--heatmap-opacity` / `[data-heatmap-always]`) that `HeatmapTuner` + `VideoPlayer` set is **missing from the repo** (lost in migration) — the heatmap currently renders with artplayer defaults. Separate pass.

## Test plan

- [ ] Deploy → **fullscreen** playback of a subtitled MKV, watch the control bar/heatmap during dialogue (e.g. MF GHOST 06 @ 10:05–10:20) → no flicker on subtitle changes
- [ ] Subtitles still render correctly; controls/heatmap unchanged otherwise