### PR TITLE
fix(torrents): cache empty aggregator results with a short TTL

### DIFF
--- a/go-api/internal/torrents/aggregator.go
+++ b/go-api/internal/torrents/aggregator.go
@@ -33,10 +33,20 @@ import (
 	"github.com/lawrenceli0228/animego/go-api/internal/cache"
 )
 
-// torrentCacheTTL is the per-query result TTL.  Express uses 1h
-// (60 * 60 * 1000ms).  An hour is generous; raw upstream RSS feeds
-// rarely change within that window.
+// torrentCacheTTL is the per-query result TTL for a NON-EMPTY result.
+// Express uses 1h (60 * 60 * 1000ms).  An hour is generous; raw upstream
+// RSS feeds rarely change within that window.
 const torrentCacheTTL = 1 * time.Hour
+
+// torrentEmptyCacheTTL is the (much shorter) TTL for an EMPTY result —
+// every source returned nothing.  An all-source miss is far more often a
+// transient upstream hiccup (timeout / rate-limit / one-off schema blip)
+// than a genuine "no torrents exist for this query", so pinning it for the
+// full hour would blackhole the query long after the sources recover.  A
+// short TTL still absorbs a burst of identical empty queries while letting
+// a retry re-hit upstream soon.  (Express cached empties for the full hour
+// too — this is a deliberate divergence that fixes that latent bug.)
+const torrentEmptyCacheTTL = 5 * time.Minute
 
 // torrentCacheMax is the maximum number of distinct queries cached
 // at once.  Express uses 500.  When the LRU is full ristretto evicts
@@ -80,6 +90,11 @@ type Aggregator struct {
 	httpClient *http.Client
 	cache      *cache.Cache[[]TorrentItem]
 	logger     Logger
+
+	// emptyCacheTTL is how long an empty (all-sources-missed) result is
+	// cached.  Defaults to torrentEmptyCacheTTL; WithEmptyCacheTTL overrides
+	// it (test-only, so the short-TTL regression test doesn't wait minutes).
+	emptyCacheTTL time.Duration
 
 	// gardenFn / acgFn / nyaaFn are the wrapped fetchers.  In
 	// production they close over Aggregator.httpClient + .logger.  In
@@ -134,6 +149,17 @@ func WithLogger(l Logger) Option {
 	}
 }
 
+// WithEmptyCacheTTL overrides how long an empty (all-sources-returned-
+// nothing) result stays cached.  Production uses torrentEmptyCacheTTL; this
+// is a test-only knob so the short-TTL regression can assert expiry without
+// waiting the real window.  Mirrors the WithGardenFn/WithAcgFn/WithNyaaFn
+// test-affordance pattern already in this package.
+func WithEmptyCacheTTL(d time.Duration) Option {
+	return func(a *Aggregator) {
+		a.emptyCacheTTL = d
+	}
+}
+
 // WithGardenFn replaces the garden fetcher.  Test-only.  Allows
 // aggregator tests to control timing, failure, and result content
 // without spinning up an httptest server.
@@ -169,8 +195,9 @@ func WithNyaaFn(f fetchFn) Option {
 // here, but the error is surfaced for completeness).
 func New(opts ...Option) (*Aggregator, error) {
 	a := &Aggregator{
-		httpClient: &http.Client{},
-		ownsCache:  true,
+		httpClient:    &http.Client{},
+		ownsCache:     true,
+		emptyCacheTTL: torrentEmptyCacheTTL,
 	}
 
 	// Default cache.  Numeric inputs chosen to match Express's
@@ -239,7 +266,9 @@ func (a *Aggregator) Close() {
 //	   lifetime management — its own error channel is never returned
 //	   (we don't propagate per-source errors up).
 //	4. Merge in deterministic order: garden, acg, nyaa.  Cache the
-//	   merged slice.
+//	   merged slice — a non-empty result for the full 1h TTL, an empty
+//	   one only briefly (emptyCacheTTL) so a transient all-source miss
+//	   isn't pinned for an hour after the sources recover.
 //
 // Returns (nil, ctx.Err()) only when the caller's context is cancelled
 // before any goroutine completes — partial failures are never errors.
@@ -295,7 +324,14 @@ func (a *Aggregator) Fetch(ctx context.Context, q string) ([]TorrentItem, error)
 	merged = append(merged, acgResults...)
 	merged = append(merged, nyaaResults...)
 
-	a.cache.Set(key, merged)
+	// Quality-aware TTL: a non-empty result is stable for the full hour;
+	// an empty one (every source missed) is cached only briefly so a
+	// transient upstream blip doesn't pin the query empty for an hour.
+	if len(merged) > 0 {
+		a.cache.Set(key, merged)
+	} else {
+		a.cache.SetWithTTL(key, merged, a.emptyCacheTTL)
+	}
 
 	return merged, nil
 }

--- a/go-api/internal/torrents/aggregator_test.go
+++ b/go-api/internal/torrents/aggregator_test.go
@@ -188,6 +188,84 @@ func TestAggregator_CacheHit_SkipsFetchers(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Quality-aware cache TTL: an EMPTY (all-sources-missed) result is cached
+// only briefly so a transient upstream blip isn't pinned for the full hour;
+// a NON-EMPTY result keeps the long default TTL.  Regression for the latent
+// "empty cached 1h" bug ported verbatim from Express.
+// ---------------------------------------------------------------------------
+
+func TestAggregator_EmptyResult_ShortTTL_ReFetchesAfterExpiry(t *testing.T) {
+	t.Parallel()
+
+	var gc, ac, nc atomic.Int32
+	a := newTestAggregator(t,
+		WithGardenFn(staticFn(nil, &gc)),
+		WithAcgFn(staticFn(nil, &ac)),
+		WithNyaaFn(staticFn(nil, &nc)),
+		WithEmptyCacheTTL(50*time.Millisecond),
+	)
+
+	// First fetch: all sources miss → empty; each fetcher ran once.
+	out, err := a.Fetch(context.Background(), "obscure-ova")
+	require.NoError(t, err)
+	require.Empty(t, out)
+	require.Equal(t, int32(1), gc.Load())
+	require.Equal(t, int32(1), ac.Load())
+	require.Equal(t, int32(1), nc.Load())
+
+	a.cache.Wait()
+
+	// Within the short window the empty result IS cached — a re-query does
+	// NOT re-hit upstream (a momentary burst of identical empties is absorbed).
+	out, err = a.Fetch(context.Background(), "obscure-ova")
+	require.NoError(t, err)
+	require.Empty(t, out)
+	assert.Equal(t, int32(1), gc.Load(), "empty result should be cached within its TTL")
+	assert.Equal(t, int32(1), ac.Load())
+	assert.Equal(t, int32(1), nc.Load())
+
+	// After the short TTL elapses the empty entry expires → fetchers run
+	// again.  Before the fix this used the 1h TTL, so the count stayed 1 and
+	// a transient all-source miss blackholed the query for a whole hour.
+	time.Sleep(150 * time.Millisecond)
+	out, err = a.Fetch(context.Background(), "obscure-ova")
+	require.NoError(t, err)
+	require.Empty(t, out)
+	assert.Equal(t, int32(2), gc.Load(), "empty entry must expire fast and re-fetch")
+	assert.Equal(t, int32(2), ac.Load())
+	assert.Equal(t, int32(2), nc.Load())
+}
+
+func TestAggregator_NonEmptyResult_KeepsLongTTL(t *testing.T) {
+	t.Parallel()
+
+	var gc atomic.Int32
+	a := newTestAggregator(t,
+		WithGardenFn(staticFn([]TorrentItem{stubItem(SourceGarden)}, &gc)),
+		WithAcgFn(staticFn(nil, nil)),
+		WithNyaaFn(staticFn(nil, nil)),
+		// A short empty-TTL must NOT touch a non-empty result — it keeps the
+		// long default (1h) TTL.
+		WithEmptyCacheTTL(50*time.Millisecond),
+	)
+
+	out, err := a.Fetch(context.Background(), "naruto")
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, int32(1), gc.Load())
+
+	a.cache.Wait()
+
+	// Past the short empty-TTL window: a non-empty result is cached under the
+	// 1h default, so it's still a hit and garden is NOT re-called.
+	time.Sleep(150 * time.Millisecond)
+	out, err = a.Fetch(context.Background(), "naruto")
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, int32(1), gc.Load(), "non-empty result must keep the long TTL, not the short empty one")
+}
+
+// ---------------------------------------------------------------------------
 // Empty / whitespace query → no fetchers invoked, no cache write
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What
The magnet aggregator (`internal/torrents`) cached an **empty** result (every upstream source returned nothing) for the full 1h TTL, identical to a real result. An all-source miss is far more often a transient upstream hiccup (timeout / rate-limit / one-off schema blip) than a genuine "no torrents exist", so a momentary blip would blackhole the query empty for a whole hour even after the sources recovered. Ported verbatim from the old Express backend, which carried the same latent bug.

## Fix
- **Non-empty** result: cached for 1h as before (`torrentCacheTTL`).
- **Empty** result: cached only for `torrentEmptyCacheTTL` (5m) via `SetWithTTL`, so a retry re-hits upstream soon while still absorbing a burst of identical empty queries.
- Added a test-only `WithEmptyCacheTTL` option (mirrors the existing `WithGardenFn/WithAcgFn/WithNyaaFn` test affordances) so the regression asserts fast expiry without a multi-minute wait.

## Test plan
- [x] `go test -race ./internal/torrents/...` green
- [x] `go vet ./internal/torrents/...` clean
- New `TestAggregator_EmptyResult_ShortTTL_ReFetchesAfterExpiry`: empty result is cached within the window, then expires and re-fetches.
- New `TestAggregator_NonEmptyResult_KeepsLongTTL`: a non-empty result is unaffected by the short empty-TTL.

First slice of the magnet-coverage work (eng-review scoped to the live-path upgrade). Follow-ups: Source interface + registry, infohash dedup + seeders rank, AnimeTosho aid feed, new sources (dmhy / Mikan).