### PR TITLE
refactor(torrents): extract pluggable Source registry from hardcoded fetchers

### DIFF
--- a/go-api/internal/torrents/acgrip.go
+++ b/go-api/internal/torrents/acgrip.go
@@ -42,6 +42,20 @@ import (
 // acgEndpoint is the acg.rip RSS XML endpoint.
 const acgEndpoint = "https://acg.rip/.xml"
 
+// acgSource is the Source adapter for acg.rip.  Thin wrapper binding the
+// shared *http.Client and delegating to FetchAcgRip — fetch logic
+// unchanged.  Being an RSS scrape it deliberately does NOT implement
+// Capable (no seeders, no special budget).
+type acgSource struct {
+	client *http.Client
+}
+
+func (s acgSource) Name() Source { return SourceAcg }
+
+func (s acgSource) Fetch(ctx context.Context, q string) ([]TorrentItem, error) {
+	return FetchAcgRip(ctx, s.client, q)
+}
+
 // acgEnclosure mirrors the <enclosure> element.  acg.rip puts the
 // magnet URI directly in the @url attribute (not the typical http link)
 // and the byte count in @length.

--- a/go-api/internal/torrents/aggregator.go
+++ b/go-api/internal/torrents/aggregator.go
@@ -1,12 +1,15 @@
 // Package torrents — aggregator.go
 //
 // Parallel fan-out + cache + partial-tolerance.  This is the
-// orchestrating layer the HTTP handler will call; the three
-// FetchXxx functions in garden.go / acgrip.go / nyaa.go are leaves.
+// orchestrating layer the HTTP handler will call.  It fans out over a
+// pluggable Registry of Sources (source.go / registry.go) instead of
+// naming the upstreams directly; the concrete fetch logic still lives in
+// the FetchXxx functions in garden.go / acgrip.go / nyaa.go, which the
+// per-source adapters wrap.
 //
 // Behaviour port of server/controllers/anime.controller.js:289-325:
-//   - Three upstream fetchers run concurrently (errgroup; in Express
-//     it's Promise.allSettled).
+//   - The registered upstream sources run concurrently (errgroup; in
+//     Express it's Promise.allSettled).
 //   - One source failing does NOT propagate as a top-level error —
 //     the aggregator logs and returns an empty slice for that source
 //     so the other two still flow through.  This matches Express's
@@ -73,33 +76,37 @@ type Logger interface {
 	Warn(msg string, args ...any)
 }
 
-// fetchFn is the shape of a single upstream fetcher.  Defining it as
-// a named type lets the Option setters swap in test stubs without
-// caring about the underlying concrete fetcher.
-type fetchFn func(ctx context.Context, q string) ([]TorrentItem, error)
-
-// Aggregator runs the three upstream fetchers in parallel with a
+// Aggregator runs the registered upstream sources in parallel with a
 // per-source timeout, partial-failure tolerance, and a 1-hour
 // per-query cache.  Constructed via New().
 //
 // All fields are package-private; callers configure via Option
 // setters at construction time.  Aggregator is safe for concurrent
 // Fetch calls — the underlying *http.Client and *cache.Cache are
-// both goroutine-safe.
+// both goroutine-safe, and the Registry is treated as read-only once
+// New returns.
 type Aggregator struct {
 	httpClient *http.Client
 	cache      *cache.Cache[[]TorrentItem]
 	logger     Logger
+
+	// registry holds the ordered set of Fetchers fanned out to in Fetch.
+	// New() populates it with garden, acg, nyaa (in that order); the
+	// WithGardenFn / WithAcgFn / WithNyaaFn options override individual
+	// entries in place so merge order is preserved.
+	registry *Registry
 
 	// emptyCacheTTL is how long an empty (all-sources-missed) result is
 	// cached.  Defaults to torrentEmptyCacheTTL; WithEmptyCacheTTL overrides
 	// it (test-only, so the short-TTL regression test doesn't wait minutes).
 	emptyCacheTTL time.Duration
 
-	// gardenFn / acgFn / nyaaFn are the wrapped fetchers.  In
-	// production they close over Aggregator.httpClient + .logger.  In
-	// tests they're swapped via WithGardenFn / WithAcgFn / WithNyaaFn
-	// to control fetch behaviour without an httptest server.
+	// gardenFn / acgFn / nyaaFn hold the per-source override stubs set by
+	// WithGardenFn / WithAcgFn / WithNyaaFn.  In production New() also
+	// fills them with closures over the real source adapters, then folds
+	// them into the registry — so they double as the resolved fetcher for
+	// each built-in source.  Tests swap them to control fetch behaviour
+	// without an httptest server.
 	gardenFn fetchFn
 	acgFn    fetchFn
 	nyaaFn   fetchFn
@@ -160,23 +167,27 @@ func WithEmptyCacheTTL(d time.Duration) Option {
 	}
 }
 
-// WithGardenFn replaces the garden fetcher.  Test-only.  Allows
-// aggregator tests to control timing, failure, and result content
-// without spinning up an httptest server.
+// WithGardenFn overrides the garden source with a single-function stub.
+// Test-only.  New() folds the stub into the registry under the garden
+// Name (preserving its merge position), so aggregator tests can control
+// timing, failure, and result content without spinning up an httptest
+// server.
 func WithGardenFn(f fetchFn) Option {
 	return func(a *Aggregator) {
 		a.gardenFn = f
 	}
 }
 
-// WithAcgFn replaces the acg.rip fetcher.  Test-only.
+// WithAcgFn overrides the acg.rip source with a single-function stub.
+// Test-only.  See WithGardenFn.
 func WithAcgFn(f fetchFn) Option {
 	return func(a *Aggregator) {
 		a.acgFn = f
 	}
 }
 
-// WithNyaaFn replaces the nyaa.si fetcher.  Test-only.
+// WithNyaaFn overrides the nyaa.si source with a single-function stub.
+// Test-only.  See WithGardenFn.
 func WithNyaaFn(f fetchFn) Option {
 	return func(a *Aggregator) {
 		a.nyaaFn = f
@@ -220,26 +231,50 @@ func New(opts ...Option) (*Aggregator, error) {
 		opt(a)
 	}
 
-	// Wire production fetchers, but only if the caller didn't supply
-	// test stubs.  Closures capture a.httpClient + a.logger as they
-	// stood AFTER options were applied.
-	if a.gardenFn == nil {
-		a.gardenFn = func(ctx context.Context, q string) ([]TorrentItem, error) {
-			return FetchGarden(ctx, a.httpClient, a.logger, q)
-		}
-	}
-	if a.acgFn == nil {
-		a.acgFn = func(ctx context.Context, q string) ([]TorrentItem, error) {
-			return FetchAcgRip(ctx, a.httpClient, q)
-		}
-	}
-	if a.nyaaFn == nil {
-		a.nyaaFn = func(ctx context.Context, q string) ([]TorrentItem, error) {
-			return FetchNyaa(ctx, a.httpClient, q)
-		}
-	}
+	// Build the default fan-out registry in the canonical merge order:
+	// garden → acg → nyaa.  These are the real source adapters, binding
+	// a.httpClient + a.logger as they stood AFTER options were applied —
+	// so the gardenSource / acgSource / nyaaSource structs are the genuine
+	// production path, not dead code.
+	a.registry = NewRegistry(
+		gardenSource{client: a.httpClient, logger: a.logger},
+		acgSource{client: a.httpClient},
+		nyaaSource{client: a.httpClient},
+	)
+
+	// Apply any per-source override stubs (WithGardenFn / WithAcgFn /
+	// WithNyaaFn) by swapping the matching source IN PLACE, so an override
+	// keeps its merge position.  The gardenFn / acgFn / nyaaFn fields are
+	// also normalised to the resolved fetcher (override stub or the
+	// adapter's Fetch) so the field-introspection tests still see them
+	// non-nil and pointing at what actually runs.
+	a.gardenFn = a.resolveSource(SourceGarden, a.gardenFn)
+	a.acgFn = a.resolveSource(SourceAcg, a.acgFn)
+	a.nyaaFn = a.resolveSource(SourceNyaa, a.nyaaFn)
 
 	return a, nil
+}
+
+// resolveSource reconciles a per-source override stub with the registry:
+//   - override != nil → replace the registry entry named name with a
+//     funcSource wrapping the stub (preserving position) and return the
+//     stub as the resolved fn.
+//   - override == nil → look up the default source already in the
+//     registry under name and return its Fetch as the resolved fn.
+//
+// The returned fn is stored back on the matching gardenFn / acgFn /
+// nyaaFn field so it always reflects the fetcher that actually runs.
+func (a *Aggregator) resolveSource(name Source, override fetchFn) fetchFn {
+	if override != nil {
+		a.registry.replaceByName(newFuncSource(name, override))
+		return override
+	}
+	for _, s := range a.registry.Sources() {
+		if s.Name() == name {
+			return s.Fetch
+		}
+	}
+	return nil
 }
 
 // Close releases the underlying ristretto cache.  Safe to call
@@ -252,23 +287,23 @@ func (a *Aggregator) Close() {
 	}
 }
 
-// Fetch returns aggregated torrents from all three sources for q.
+// Fetch returns aggregated torrents from every registered source for q.
 //
 // Behaviour:
 //
-//	1. Trim + lowercase q.  Empty → return [] immediately, no cache,
-//	   no upstream calls.
-//	2. Cache hit → return the cached slice as-is.
-//	3. Cache miss → kick off three goroutines via errgroup.WithContext,
-//	   each with its own 8s ctx.WithTimeout.  Per-source errors are
-//	   logged via the optional Logger and converted to an empty slice
-//	   for that source.  errgroup is used purely for goroutine
-//	   lifetime management — its own error channel is never returned
-//	   (we don't propagate per-source errors up).
-//	4. Merge in deterministic order: garden, acg, nyaa.  Cache the
-//	   merged slice — a non-empty result for the full 1h TTL, an empty
-//	   one only briefly (emptyCacheTTL) so a transient all-source miss
-//	   isn't pinned for an hour after the sources recover.
+//  1. Trim + lowercase q.  Empty → return [] immediately, no cache,
+//     no upstream calls.
+//  2. Cache hit → return the cached slice as-is.
+//  3. Cache miss → kick off one goroutine per registered source via
+//     errgroup.WithContext, each with its own 8s ctx.WithTimeout.
+//     Per-source errors are logged via the optional Logger and
+//     converted to an empty slice for that source.  errgroup is used
+//     purely for goroutine lifetime management — its own error channel
+//     is never returned (we don't propagate per-source errors up).
+//  4. Merge in registration order (garden, acg, nyaa by default).
+//     Cache the merged slice — a non-empty result for the full 1h TTL,
+//     an empty one only briefly (emptyCacheTTL) so a transient
+//     all-source miss isn't pinned for an hour after the sources recover.
 //
 // Returns (nil, ctx.Err()) only when the caller's context is cancelled
 // before any goroutine completes — partial failures are never errors.
@@ -277,8 +312,8 @@ func (a *Aggregator) Fetch(ctx context.Context, q string) ([]TorrentItem, error)
 	if key == "" {
 		// Defensive — the HTTP handler validates q upstream and
 		// rejects empty queries with a 400.  This guard just stops a
-		// misconfigured caller from triggering three upstream calls
-		// for nothing.
+		// misconfigured caller from triggering upstream calls for
+		// nothing.
 		return []TorrentItem{}, nil
 	}
 
@@ -286,32 +321,27 @@ func (a *Aggregator) Fetch(ctx context.Context, q string) ([]TorrentItem, error)
 		return cached, nil
 	}
 
+	sources := a.registry.Sources()
+
 	// errgroup.WithContext gives each goroutine a derived context that
 	// is cancelled the moment any goroutine returns an error.  We never
 	// return non-nil from a goroutine (per-source errors are absorbed
-	// below) so the group context survives until all three finish.
+	// below) so the group context survives until all sources finish.
 	// That preserves Express's Promise.allSettled "wait for everyone"
 	// semantics.
 	g, gctx := errgroup.WithContext(ctx)
 
-	var (
-		gardenResults []TorrentItem
-		acgResults    []TorrentItem
-		nyaaResults   []TorrentItem
-	)
+	// results is indexed by source position so the merge below stays in
+	// registration order regardless of which goroutine finishes first.
+	results := make([][]TorrentItem, len(sources))
 
-	g.Go(func() error {
-		gardenResults = a.runOne(gctx, "garden", a.gardenFn, q)
-		return nil
-	})
-	g.Go(func() error {
-		acgResults = a.runOne(gctx, "acg", a.acgFn, q)
-		return nil
-	})
-	g.Go(func() error {
-		nyaaResults = a.runOne(gctx, "nyaa", a.nyaaFn, q)
-		return nil
-	})
+	for i, src := range sources {
+		i, src := i, src // capture per iteration for the goroutine closure
+		g.Go(func() error {
+			results[i] = a.runOne(gctx, src, q)
+			return nil
+		})
+	}
 
 	if err := g.Wait(); err != nil {
 		// runOne never returns non-nil, so g.Wait() can only surface
@@ -319,10 +349,14 @@ func (a *Aggregator) Fetch(ctx context.Context, q string) ([]TorrentItem, error)
 		return nil, err
 	}
 
-	merged := make([]TorrentItem, 0, len(gardenResults)+len(acgResults)+len(nyaaResults))
-	merged = append(merged, gardenResults...)
-	merged = append(merged, acgResults...)
-	merged = append(merged, nyaaResults...)
+	total := 0
+	for _, r := range results {
+		total += len(r)
+	}
+	merged := make([]TorrentItem, 0, total)
+	for _, r := range results {
+		merged = append(merged, r...)
+	}
 
 	// Quality-aware TTL: a non-empty result is stable for the full hour;
 	// an empty one (every source missed) is cached only briefly so a
@@ -336,20 +370,20 @@ func (a *Aggregator) Fetch(ctx context.Context, q string) ([]TorrentItem, error)
 	return merged, nil
 }
 
-// runOne wraps a single fetchFn with the per-source 8s timeout and the
+// runOne wraps a single Fetcher with the per-source 8s timeout and the
 // partial-failure tripwire.  Always returns a non-nil slice (possibly
 // empty) so the caller can append unconditionally.
 //
-// The source parameter is purely for logging — it tags the warning
+// The fetcher's Name is used purely for logging — it tags the warning
 // with which upstream failed so an oncall grep can pinpoint the cause.
-func (a *Aggregator) runOne(parent context.Context, source string, fn fetchFn, q string) []TorrentItem {
+func (a *Aggregator) runOne(parent context.Context, src Fetcher, q string) []TorrentItem {
 	ctx, cancel := context.WithTimeout(parent, perSourceTimeout)
 	defer cancel()
 
-	items, err := fn(ctx, q)
+	items, err := src.Fetch(ctx, q)
 	if err != nil {
 		if a.logger != nil {
-			a.logger.Warn("torrents: source failed", "source", source, "error", err.Error())
+			a.logger.Warn("torrents: source failed", "source", string(src.Name()), "error", err.Error())
 		}
 		return nil
 	}

--- a/go-api/internal/torrents/garden.go
+++ b/go-api/internal/torrents/garden.go
@@ -56,6 +56,25 @@ const gardenType = "动画"
 // uses "AnimeGo/1.0" exactly; we mirror it for parity in upstream logs.
 const userAgent = "AnimeGo/1.0"
 
+// gardenSource is the Source adapter for animes.garden.  It is a thin
+// wrapper that binds the shared *http.Client + optional Logger and
+// delegates straight to FetchGarden — the fetch logic itself is
+// unchanged.  Registered by New() as the first (highest-priority by
+// merge order) source.
+//
+// Unlike the RSS sources it carries a logger because FetchGarden emits a
+// silent-failure tripwire (200 OK + zero items) the others don't.
+type gardenSource struct {
+	client *http.Client
+	logger Logger
+}
+
+func (s gardenSource) Name() Source { return SourceGarden }
+
+func (s gardenSource) Fetch(ctx context.Context, q string) ([]TorrentItem, error) {
+	return FetchGarden(ctx, s.client, s.logger, q)
+}
+
 // gardenResource is the minimal field set we decode from each item in
 // the upstream resources array.  Unknown fields are silently dropped by
 // encoding/json — animes.garden adds new fields freely and we don't
@@ -191,7 +210,7 @@ func mapGardenResources(rs []gardenResource) []TorrentItem {
 	return out
 }
 
-// pickGardenFansub mirrors `r.fansub?.name ?? parseFansub(r.title ?? '')`.
+// pickGardenFansub mirrors `r.fansub?.name ?? parseFansub(r.title ?? ”)`.
 // If the upstream provided a structured fansub object with a non-empty
 // name, use it.  Otherwise fall back to bracket parsing on the title.
 func pickGardenFansub(r gardenResource) *string {

--- a/go-api/internal/torrents/nyaa.go
+++ b/go-api/internal/torrents/nyaa.go
@@ -65,6 +65,20 @@ const (
 	nyaaTracker2 = "http%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce"
 )
 
+// nyaaSource is the Source adapter for nyaa.si.  Thin wrapper binding
+// the shared *http.Client and delegating to FetchNyaa — fetch logic
+// unchanged.  Like acgSource it is an RSS scrape and does NOT implement
+// Capable.
+type nyaaSource struct {
+	client *http.Client
+}
+
+func (s nyaaSource) Name() Source { return SourceNyaa }
+
+func (s nyaaSource) Fetch(ctx context.Context, q string) ([]TorrentItem, error) {
+	return FetchNyaa(ctx, s.client, q)
+}
+
 // nyaaItem mirrors a single <item> in the nyaa.si RSS feed.
 //
 // The custom-namespace tags require the full URI form

--- a/go-api/internal/torrents/registry.go
+++ b/go-api/internal/torrents/registry.go
@@ -1,0 +1,65 @@
+// Package torrents — registry.go
+//
+// Registry is the ordered collection of Fetchers the aggregator fans out
+// over.  It replaces the three hard-coded fetcher fields on Aggregator:
+// the fan-out loop iterates Sources() instead of naming garden / acg /
+// nyaa explicitly, so adding a source is a Register call rather than an
+// edit to the aggregator core.
+//
+// Order is load-bearing.  The aggregator merges results in registration
+// order (garden → acg → nyaa by default), and several tests assert that
+// order, so Registry preserves insertion order and replaceByName swaps a
+// source in place rather than re-appending it.
+package torrents
+
+// Registry holds the ordered set of Fetchers to fan out to.  It is NOT
+// safe for concurrent mutation; build it fully during construction (in
+// New / via options) and treat it as read-only once Fetch is running.
+// Sources() returns a defensive copy so callers cannot mutate the
+// backing slice mid-flight.
+type Registry struct {
+	sources []Fetcher
+}
+
+// NewRegistry builds a Registry from the given fetchers, preserving
+// order.  Passing zero fetchers yields an empty registry (the aggregator
+// then merges nothing — a valid, if inert, configuration).
+func NewRegistry(fetchers ...Fetcher) *Registry {
+	// Copy into a freshly-sized slice so the caller's variadic backing
+	// array can't be aliased and mutated out from under us.
+	cp := make([]Fetcher, len(fetchers))
+	copy(cp, fetchers)
+	return &Registry{sources: cp}
+}
+
+// Register appends a fetcher to the end of the registry, so it merges
+// last relative to the sources already present.
+func (r *Registry) Register(f Fetcher) {
+	r.sources = append(r.sources, f)
+}
+
+// Sources returns the registered fetchers in registration order.  The
+// returned slice is a copy — mutating it does not affect the registry.
+func (r *Registry) Sources() []Fetcher {
+	out := make([]Fetcher, len(r.sources))
+	copy(out, r.sources)
+	return out
+}
+
+// replaceByName swaps the first fetcher whose Name equals replacement's
+// Name, in place (preserving its position so merge order is unchanged),
+// and reports whether a match was found.  When no fetcher matches, the
+// registry is left untouched and false is returned.
+//
+// This is the primitive the WithGardenFn / WithAcgFn / WithNyaaFn
+// options use to override a built-in source with a single-function stub
+// without disturbing the order of the other sources.
+func (r *Registry) replaceByName(replacement Fetcher) bool {
+	for i, s := range r.sources {
+		if s.Name() == replacement.Name() {
+			r.sources[i] = replacement
+			return true
+		}
+	}
+	return false
+}

--- a/go-api/internal/torrents/registry_test.go
+++ b/go-api/internal/torrents/registry_test.go
@@ -1,0 +1,144 @@
+// Package torrents — registry_test.go
+//
+// Covers the pluggable-source seam added in the source-registry
+// refactor.  These tests are additive — the pre-existing aggregator /
+// fetcher tests are untouched and still exercise behaviour parity.
+//
+//   - Registry preserves registration order via Sources()
+//   - Register appends in order
+//   - replaceByName swaps a source in place (position preserved)
+//   - the aggregator merges results in registry order even when a later
+//     source finishes BEFORE an earlier one (ordering must come from the
+//     registry, not goroutine completion timing)
+//   - compile-time: the three built-in source adapters satisfy Fetcher,
+//     and the RSS sources deliberately do NOT satisfy Capable
+package torrents
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Compile-time: adapters satisfy Fetcher; Capable is opt-in.
+// ---------------------------------------------------------------------------
+
+var (
+	_ Fetcher = gardenSource{}
+	_ Fetcher = acgSource{}
+	_ Fetcher = nyaaSource{}
+	_ Fetcher = funcSource{}
+)
+
+func TestRSSSources_DoNotImplementCapable(t *testing.T) {
+	t.Parallel()
+
+	// RSS scrapes have no seeders / special budget — they must stay the
+	// zero-Capabilities default so a future ranker doesn't treat them as
+	// richer than they are.
+	if _, ok := any(acgSource{}).(Capable); ok {
+		t.Fatal("acgSource should NOT implement Capable")
+	}
+	if _, ok := any(nyaaSource{}).(Capable); ok {
+		t.Fatal("nyaaSource should NOT implement Capable")
+	}
+
+	// CapabilitiesOf falls back to the zero value for a non-Capable source.
+	assert.Equal(t, Capabilities{}, CapabilitiesOf(acgSource{}))
+	assert.Equal(t, Capabilities{}, CapabilitiesOf(nyaaSource{}))
+}
+
+// ---------------------------------------------------------------------------
+// Registry ordering primitives.
+// ---------------------------------------------------------------------------
+
+func TestRegistry_PreservesRegistrationOrder(t *testing.T) {
+	t.Parallel()
+
+	g := newFuncSource(SourceGarden, staticFn(nil, nil))
+	a := newFuncSource(SourceAcg, staticFn(nil, nil))
+	n := newFuncSource(SourceNyaa, staticFn(nil, nil))
+
+	r := NewRegistry(g, a, n)
+	got := r.Sources()
+	require.Len(t, got, 3)
+	assert.Equal(t, SourceGarden, got[0].Name())
+	assert.Equal(t, SourceAcg, got[1].Name())
+	assert.Equal(t, SourceNyaa, got[2].Name())
+
+	// Register appends last.
+	extra := newFuncSource(Source("extra"), staticFn(nil, nil))
+	r.Register(extra)
+	got = r.Sources()
+	require.Len(t, got, 4)
+	assert.Equal(t, Source("extra"), got[3].Name())
+
+	// Sources() returns a copy — mutating it must not affect the registry.
+	got[0] = extra
+	assert.Equal(t, SourceGarden, r.Sources()[0].Name(),
+		"Sources() must return a defensive copy")
+}
+
+func TestRegistry_ReplaceByName_PreservesPosition(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry(
+		newFuncSource(SourceGarden, staticFn(nil, nil)),
+		newFuncSource(SourceAcg, staticFn(nil, nil)),
+		newFuncSource(SourceNyaa, staticFn(nil, nil)),
+	)
+
+	// Replace the middle source; order must be unchanged and the swap
+	// must report a hit.
+	replacement := newFuncSource(SourceAcg, staticFn([]TorrentItem{stubItem(SourceAcg)}, nil))
+	require.True(t, r.replaceByName(replacement))
+
+	got := r.Sources()
+	assert.Equal(t, SourceGarden, got[0].Name())
+	assert.Equal(t, SourceAcg, got[1].Name(), "replaced source keeps its position")
+	assert.Equal(t, SourceNyaa, got[2].Name())
+
+	// A name not present is a no-op miss.
+	assert.False(t, r.replaceByName(newFuncSource(Source("nope"), staticFn(nil, nil))))
+	assert.Len(t, r.Sources(), 3)
+}
+
+// ---------------------------------------------------------------------------
+// Fan-out order: registry order wins over goroutine completion timing.
+// ---------------------------------------------------------------------------
+
+// TestRegistry_FanoutOrder asserts the merged output follows the
+// registration order (garden → acg → nyaa) even when the FIRST source is
+// the SLOWEST to return.  If the aggregator merged by completion order
+// this would fail — it must merge by registry position.
+func TestRegistry_FanoutOrder(t *testing.T) {
+	t.Parallel()
+
+	// garden is slow but registered first; acg/nyaa are instant.  The
+	// slow source must still appear first in the merged slice.
+	slowGarden := func(ctx context.Context, _ string) ([]TorrentItem, error) {
+		select {
+		case <-time.After(40 * time.Millisecond):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		return []TorrentItem{stubItem(SourceGarden)}, nil
+	}
+
+	a := newTestAggregator(t,
+		WithGardenFn(slowGarden),
+		WithAcgFn(staticFn([]TorrentItem{stubItem(SourceAcg)}, nil)),
+		WithNyaaFn(staticFn([]TorrentItem{stubItem(SourceNyaa)}, nil)),
+	)
+
+	out, err := a.Fetch(context.Background(), "naruto")
+	require.NoError(t, err)
+	require.Len(t, out, 3)
+	assert.Equal(t, SourceGarden, out[0].Source, "garden registered first → merged first despite being slowest")
+	assert.Equal(t, SourceAcg, out[1].Source)
+	assert.Equal(t, SourceNyaa, out[2].Source)
+}

--- a/go-api/internal/torrents/source.go
+++ b/go-api/internal/torrents/source.go
@@ -1,0 +1,115 @@
+// Package torrents — source.go
+//
+// The pluggable-source abstraction the aggregator fans out over.  Each
+// upstream (garden / acg / nyaa, and any future addition) is a Source:
+// it knows its own Name and how to Fetch for a query.  The aggregator
+// no longer hard-codes three fetcher fields — it iterates whatever the
+// Registry holds (see registry.go), so adding a source is "register one
+// implementation", not "edit the fan-out core".
+//
+// This file is a pure structural extraction: the concrete Fetch bodies
+// still live in garden.go / acgrip.go / nyaa.go (the FetchXxx exported
+// functions are untouched).  The thin source structs there wrap those.
+package torrents
+
+import (
+	"context"
+	"time"
+)
+
+// Fetcher is one upstream source the aggregator fans out to.
+// Deliberately tiny (accept-interfaces / return-structs): a Name for
+// identity + logging, and a Fetch that returns this source's items for a
+// query.
+//
+// (The interface is named Fetcher rather than "Source" because the
+// pre-existing Source string type — the upstream identifier returned by
+// Name — already owns that name and is referenced throughout the package
+// and its tests.)
+//
+// Fetch's contract matches the legacy per-source fetcher exactly:
+//   - (items, nil)  → success (items may be empty)
+//   - (nil, err)    → this source failed; the aggregator logs it and
+//     substitutes an empty slice so the other sources still flow through
+//     (partial-failure tolerance).  A Fetcher MUST NOT panic — return an
+//     error instead.
+//
+// Fetch receives the per-source child context (already carrying the
+// aggregator's per-source timeout); implementations should honour
+// ctx.Done().
+type Fetcher interface {
+	// Name reports which upstream this is.  Used as the merge-order key
+	// and the failure-log tag; must be stable and unique within a
+	// Registry.
+	Name() Source
+	// Fetch returns this source's torrents for q.  See the interface
+	// docstring for the error contract.
+	Fetch(ctx context.Context, q string) ([]TorrentItem, error)
+}
+
+// Capabilities describes optional, source-specific hints the aggregator
+// can consult.  It exists so a future scheduler / ranker can treat
+// richer sources differently WITHOUT the aggregator growing a switch on
+// concrete types.  Nothing in this PR reads these fields yet — they're
+// the forward-looking seam for seeders, per-source budgets, and
+// priority ordering that later PRs will wire in.
+//
+// Zero value is the "no special capabilities" default the aggregator
+// falls back to when a Source does not implement Capable.
+type Capabilities struct {
+	// SupportsSeeders reports whether this source can populate a
+	// seeders/leechers count.  RSS scrapes (acg / nyaa) cannot; a richer
+	// JSON source could.  Default false.
+	SupportsSeeders bool
+	// Budget is a per-source time budget hint.  Zero means "use the
+	// aggregator's default per-source timeout".
+	Budget time.Duration
+	// Priority orders sources when a future ranker needs a tie-break.
+	// Higher wins.  Zero is the neutral default.
+	Priority int
+}
+
+// Capable is the optional companion interface a Fetcher may implement to
+// advertise Capabilities.  The aggregator type-asserts for it and falls
+// back to the zero Capabilities when a source does not implement it, so
+// implementing Capable is strictly opt-in.  The RSS sources (acg / nyaa)
+// deliberately do NOT implement it.
+type Capable interface {
+	Capabilities() Capabilities
+}
+
+// CapabilitiesOf returns the Capabilities a Fetcher advertises, or the
+// zero value when it does not implement Capable.  Centralised so every
+// call site does the type-assert the same way (and so the default is
+// defined in exactly one place).
+func CapabilitiesOf(f Fetcher) Capabilities {
+	if c, ok := f.(Capable); ok {
+		return c.Capabilities()
+	}
+	return Capabilities{}
+}
+
+// fetchFn is the shape of a single upstream fetcher.  Kept as a named
+// type so the WithXxxFn option setters can swap in test stubs without
+// caring about the concrete source behind them.
+type fetchFn func(ctx context.Context, q string) ([]TorrentItem, error)
+
+// funcSource adapts a bare fetchFn + a name into a Fetcher.  It is the
+// mechanism the WithGardenFn / WithAcgFn / WithNyaaFn options use to
+// override a registered source by Name with a single-function stub —
+// the registry swap preserves position so merge order is unchanged.
+type funcSource struct {
+	name  Source
+	fetch fetchFn
+}
+
+// newFuncSource wraps fn as a Fetcher named name.
+func newFuncSource(name Source, fn fetchFn) funcSource {
+	return funcSource{name: name, fetch: fn}
+}
+
+func (s funcSource) Name() Source { return s.name }
+
+func (s funcSource) Fetch(ctx context.Context, q string) ([]TorrentItem, error) {
+	return s.fetch(ctx, q)
+}

--- a/go-api/internal/torrents/types.go
+++ b/go-api/internal/torrents/types.go
@@ -9,6 +9,8 @@
 //   - garden.go   : animes.garden JSON aggregator (covers 动漫花园 + bangumi.moe)
 //   - acgrip.go   : acg.rip RSS scrape
 //   - nyaa.go     : nyaa.si RSS scrape
+//   - source.go   : Source interface + Capabilities + funcSource adapter
+//   - registry.go : ordered, pluggable collection of Sources to fan out to
 //   - aggregator.go : parallel fan-out + cache + partial-tolerance
 //
 // types.go owns the wire-level result struct and the helpers shared by
@@ -80,7 +82,7 @@ func hasMagnetScheme(s string) bool {
 // FormatBytes mirrors server/controllers/anime.controller.js:158
 // formatBytes.  Input is a raw byte count (e.g. acg.rip RSS
 // enclosure[@length]).  Empty / zero / negative / non-numeric prefix →
-// returns the empty string, matching JS `if (!n || n <= 0) return '';`.
+// returns the empty string, matching JS `if (!n || n <= 0) return ”;`.
 //
 // Output format (Express parity):
 //   - n >= 1e9 → "X.X GB" via toFixed(1)
@@ -91,9 +93,9 @@ func hasMagnetScheme(s string) bool {
 //   - parseInt is permissive — "1234abc" parses as 1234.  We mimic
 //     this by stripping any non-digit suffix.
 //   - parseInt("") and parseInt("abc") return NaN, which JS coerces
-//     to falsy → '' is returned.
+//     to falsy → ” is returned.
 //   - Negative inputs (parseInt("-5") = -5) are also caught by the
-//     <= 0 guard and return ''.
+//     <= 0 guard and return ”.
 func FormatBytes(raw string) string {
 	n, ok := parseIntJSLike(raw)
 	if !ok || n <= 0 {
@@ -189,7 +191,7 @@ func stringPtr(s string) *string {
 //   - No digits → returns (0, false).
 //
 // Returns (n, true) on a valid parse.  The bool lets callers distinguish
-// "0 parsed" from "no number" — currently both code paths return ''
+// "0 parsed" from "no number" — currently both code paths return ”
 // from Format{Bytes,Kb} so it's a defensive distinction, but it keeps
 // the helper honest if a future call site cares.
 func parseIntJSLike(raw string) (int, bool) {


### PR DESCRIPTION
> **Stacked on #30** (`fix/torrents-empty-result-ttl`). Review/merge #30 first, then retarget this to `main`.

## What
Zero-behavior-change structural refactor of the magnet aggregator: the 3 hardcoded fetcher fields (`gardenFn/acgFn/nyaaFn`) become a pluggable `Fetcher` interface + ordered `Registry`. Adding a source is now "register an implementation" instead of editing the aggregator core — the backbone for the upcoming infohash dedup, seeders ranking, and new sources (AnimeTosho / dmhy / Mikan).

## Changes
- **`source.go`** (new): `Fetcher` interface (`Name() Source` + `Fetch`); opt-in `Capable` interface + `Capabilities{SupportsSeeders, Budget, Priority}` seam (nothing reads it yet — forward-looking).
- **`registry.go`** (new): ordered `Registry` with `Register`/`Sources()` + position-preserving override.
- **`garden.go`/`acgrip.go`/`nyaa.go`**: thin `xxxSource` structs wrapping the existing `FetchXxx` funcs (the `FetchXxx` exports + their tests are untouched).
- **`aggregator.go`**: `Fetch` fans out over `registry.Sources()`, merges by registration order (garden→acg→nyaa, unchanged). `WithGardenFn/WithAcgFn/WithNyaaFn` shims preserved (override the registry by name) so `handlers_test.go` + `aggregator_test.go` are unchanged. **`Fetch` signature unchanged.**

## Naming note
The interface is named `Fetcher`, not `Source` — `Source` is already the existing `type Source string` enum (`SourceGarden`, `TorrentItem.Source`). `Name()` returns that enum. Renaming the string type would have forced edits to existing tests (which this PR avoids).

## Test plan
- [x] `go test -race ./internal/torrents/...` green — **existing tests unmodified**
- [x] `go test -race ./internal/anime/...` green (handler consumer of `WithXxxFn` still works)
- [x] `go vet ./...` + `go build ./...` clean
- New `TestRegistry_FanoutOrder`: a slow-but-first source still merges first (order from registry, not goroutine timing).

Out of scope (later PRs): infohash dedup, seeders field, sorting, circuit-breaking.