### PR TITLE
feat(torrents): dedup by infohash + seeders-ranked results

### DIFF
--- a/go-api/internal/torrents/aggregator.go
+++ b/go-api/internal/torrents/aggregator.go
@@ -358,6 +358,17 @@ func (a *Aggregator) Fetch(ctx context.Context, q string) ([]TorrentItem, error)
 		merged = append(merged, r...)
 	}
 
+	// Normalise → dedup → rank, in that order, before caching.  parseInfohash
+	// runs off each row's magnet (source-agnostic), so the same torrent
+	// surfaced by two sources collapses to a single best copy, and the
+	// survivors come back ordered by seeders (nil sinks last) → date → source
+	// priority.  ranks is derived from the registry once and threaded through
+	// both passes so the per-source tie-break is consistent.  All three
+	// helpers return fresh slices (immutability), so `merged` is never
+	// mutated in place.
+	ranks := sourceRanks(a.registry)
+	merged = rankItems(dedupByInfohash(merged, ranks), ranks)
+
 	// Quality-aware TTL: a non-empty result is stable for the full hour;
 	// an empty one (every source missed) is cached only briefly so a
 	// transient upstream blip doesn't pin the query empty for an hour.

--- a/go-api/internal/torrents/dedup_integration_test.go
+++ b/go-api/internal/torrents/dedup_integration_test.go
@@ -1,0 +1,75 @@
+// Package torrents — dedup_integration_test.go
+//
+// End-to-end assertions that the normalise → dedup → rank pass is wired
+// into Aggregator.Fetch (not just unit-tested in isolation).  These drive
+// the real fan-out via the WithXxxFn stubs and inspect the merged result.
+//
+// Kept in its own file (rather than appended to aggregator_test.go) so it
+// doesn't collide with concurrent edits to the constructor/registration
+// tests.  Reuses newTestAggregator / staticFn / strPtr / intPtr from the
+// sibling _test.go files in this package.
+package torrents
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFetch_DedupsAndRanksAcrossSources is the integration test for the
+// whole feature: two sources surface the SAME torrent (one in hex, one in
+// base32) with different seeder counts, plus a couple of unique rows.  The
+// merged Fetch result must:
+//   - collapse the duplicate to one row (the higher-seeder copy), and
+//   - come back ordered by seeders desc, with the nil-seeder row last.
+func TestFetch_DedupsAndRanksAcrossSources(t *testing.T) {
+	t.Parallel()
+
+	// garden: the duplicate in HEX with 80 seeders, plus a unique 200-seeder
+	// row that should rank first overall.
+	gardenItems := []TorrentItem{
+		{Title: "dup-hex", Magnet: magnetFor(knownV1Hex), Source: SourceGarden, Seeders: intPtr(80)},
+		{Title: "garden-top", Magnet: magnetFor(hashB), Source: SourceGarden, Seeders: intPtr(200)},
+	}
+	// acg: the SAME torrent as garden's dup, but in BASE32 with FEWER seeders
+	// (10) — must lose the merge to garden's 80.
+	acgItems := []TorrentItem{
+		{Title: "dup-base32", Magnet: "magnet:?xt=urn:btih:" + knownV1Base32, Source: SourceAcg, Seeders: intPtr(10)},
+	}
+	// nyaa: a unique row with UNKNOWN seeders → must sink to the bottom.
+	nyaaItems := []TorrentItem{
+		{Title: "nyaa-unknown", Magnet: magnetFor(hashA), Source: SourceNyaa, Seeders: nil},
+	}
+
+	a := newTestAggregator(t,
+		WithGardenFn(staticFn(gardenItems, nil)),
+		WithAcgFn(staticFn(acgItems, nil)),
+		WithNyaaFn(staticFn(nyaaItems, nil)),
+	)
+
+	out, err := a.Fetch(context.Background(), "spy x family")
+	require.NoError(t, err)
+
+	// 4 inputs, one cross-source duplicate collapsed → 3 survivors.
+	require.Len(t, out, 3, "the hex/base32 duplicate should collapse to one row")
+
+	// Ranked by seeders desc: 200 (garden-top) → 80 (the merged dup) →
+	// nil (nyaa-unknown) last.
+	titles := []string{out[0].Title, out[1].Title, out[2].Title}
+	assert.Equal(t, "garden-top", titles[0], "highest seeders first")
+	assert.Equal(t, "nyaa-unknown", titles[2], "unknown seeders sink to the bottom")
+
+	// The merged duplicate is garden's 80-seeder copy, and it carries the
+	// normalised hex infohash regardless of which encoding survived.
+	dup := out[1]
+	require.NotNil(t, dup.Seeders)
+	assert.Equal(t, 80, *dup.Seeders, "the higher-seeder copy of the duplicate must win")
+	assert.Equal(t, knownV1Hex, dup.Infohash, "survivor carries the normalised hex hash")
+
+	// Every survivor with a parseable magnet got its Infohash stamped.
+	for _, it := range out {
+		assert.NotEmpty(t, it.Infohash, "row %q should have a stamped infohash", it.Title)
+	}
+}

--- a/go-api/internal/torrents/infohash.go
+++ b/go-api/internal/torrents/infohash.go
@@ -1,0 +1,158 @@
+// Package torrents — infohash.go
+//
+// parseInfohash extracts and normalises the BitTorrent infohash from a
+// magnet URI so the aggregator can dedup the same torrent surfaced by
+// different sources.  It is deliberately source-agnostic: it works off
+// the magnet string every source already produces, so no source needs a
+// pre-populated Infohash field for dedup to function (nyaa builds its
+// magnet from <nyaa:infoHash>, garden/acg carry it inline).
+//
+// Normalisation rules — two magnets are "the same torrent" iff their
+// normalised hashes are byte-equal:
+//
+//   - The hash is read from the xt=urn:btih:<hash> parameter (the
+//     "btih" — BitTorrent Info Hash — URN).  The xt key and the
+//     "urn:btih:" prefix are matched case-insensitively; everything
+//     after the prefix is the raw hash.
+//   - A 40-char hex string is a v1 infohash; a 64-char hex string is a
+//     v2 infohash.  Both are lower-cased and returned verbatim (length
+//     preserved — v1 and v2 are NEVER truncated to align, since a 64-hex
+//     v2 hash and its 40-hex truncation are different identifiers).
+//   - A 32-char RFC4648 base32 string is the base32 ENCODING of a v1
+//     hash; it is decoded to its 20 raw bytes and rendered as 40-char
+//     lowercase hex.  This matters because some sources emit base32 and
+//     others (nyaa) emit hex for the SAME torrent — comparing the two
+//     encodings literally would miss the duplicate.
+//   - Anything else (no xt=urn:btih:, an unrecognised length, or
+//     undecodable base32) yields "" — the caller treats an empty hash as
+//     "not deduplicable" and passes the row through untouched.
+package torrents
+
+import (
+	"encoding/base32"
+	"encoding/hex"
+	"strings"
+)
+
+// btihPrefix is the URN that precedes a BitTorrent infohash inside a
+// magnet's xt parameter.  Matched case-insensitively (the spec allows
+// either case for the scheme/URN portions).
+const btihPrefix = "urn:btih:"
+
+// infohash length classes (in encoded characters):
+//   - v1 hex:    40 chars (20 bytes)
+//   - v2 hex:    64 chars (32 bytes)
+//   - v1 base32: 32 chars (20 bytes, RFC4648 unpadded)
+const (
+	hexLenV1    = 40
+	hexLenV2    = 64
+	base32LenV1 = 32
+)
+
+// parseInfohash extracts the normalised infohash from magnet, or "" when
+// the magnet carries no parseable xt=urn:btih:<hash>.  See the file
+// docstring for the full normalisation contract.
+//
+// The result is suitable as a dedup key: equal non-empty results denote
+// the same torrent.  v1 and v2 hashes land in distinct length buckets
+// (40 vs 64 hex) so they never collide.
+func parseInfohash(magnet string) string {
+	raw := extractBtih(magnet)
+	if raw == "" {
+		return ""
+	}
+	return normaliseHash(raw)
+}
+
+// extractBtih pulls the raw (un-normalised) hash out of the first
+// xt=urn:btih:<hash> parameter in the magnet.  Returns "" when there is
+// no magnet scheme or no btih xt parameter.
+//
+// Parsing is done by hand rather than via net/url because magnet "URIs"
+// are not strictly RFC-3986 query strings (the values are not
+// percent-encoded in practice and url.Parse is needlessly strict about
+// the opaque body); a split on '&'/';' over the part after '?' is the
+// robust, allocation-light approach the wider BitTorrent ecosystem uses.
+func extractBtih(magnet string) string {
+	if !hasMagnetScheme(magnet) {
+		return ""
+	}
+
+	// Everything after the first '?' is the parameter list.  A magnet with
+	// no '?' has no xt, so there's nothing to extract.
+	q := magnet[len(magnetScheme):]
+	if i := strings.IndexByte(q, '?'); i >= 0 {
+		q = q[i+1:]
+	} else {
+		return ""
+	}
+
+	// Parameters are '&'-separated; some producers use ';' as well, so we
+	// accept either by normalising ';' to '&' first.
+	q = strings.ReplaceAll(q, ";", "&")
+	for _, param := range strings.Split(q, "&") {
+		// xt is "exact topic"; multi-file v2 magnets may carry xt.1 / xt.2,
+		// but the single-hash form (xt=...) is what every source here emits.
+		// Match the key case-insensitively up to '='.
+		eq := strings.IndexByte(param, '=')
+		if eq < 0 {
+			continue
+		}
+		if !strings.EqualFold(param[:eq], "xt") {
+			continue
+		}
+		val := param[eq+1:]
+		if len(val) >= len(btihPrefix) && strings.EqualFold(val[:len(btihPrefix)], btihPrefix) {
+			return val[len(btihPrefix):]
+		}
+	}
+	return ""
+}
+
+// normaliseHash canonicalises a raw infohash string into the comparison
+// form: lowercase hex, with base32 v1 hashes decoded to 40-char hex.
+// Returns "" for any input that isn't a recognised v1/v2 hex or v1
+// base32 encoding.
+func normaliseHash(raw string) string {
+	raw = strings.TrimSpace(raw)
+
+	switch len(raw) {
+	case hexLenV1, hexLenV2:
+		// Hex v1 (40) or v2 (64).  Validate it really is hex before
+		// lower-casing so a 40-char non-hex blob doesn't masquerade as a
+		// v1 hash; keep the original length (no truncation between
+		// versions).
+		lower := strings.ToLower(raw)
+		if !isHex(lower) {
+			return ""
+		}
+		return lower
+	case base32LenV1:
+		// base32-encoded v1 hash → decode to 20 bytes → 40-char hex.
+		// RFC4648 base32 is upper-case A-Z2-7; upper-case the input so a
+		// lower-cased magnet still decodes.
+		decoded, err := base32.StdEncoding.DecodeString(strings.ToUpper(raw))
+		if err != nil {
+			return ""
+		}
+		return hex.EncodeToString(decoded)
+	default:
+		return ""
+	}
+}
+
+// isHex reports whether s is non-empty and made up solely of [0-9a-f].
+// Used on already-lowercased input, so upper-case hex digits are not
+// accepted here (the caller lower-cases first).
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}

--- a/go-api/internal/torrents/infohash_test.go
+++ b/go-api/internal/torrents/infohash_test.go
@@ -1,0 +1,149 @@
+// Package torrents — infohash_test.go
+//
+// Table-driven coverage for parseInfohash: v1 hex, v2 hex, base32→hex
+// normalisation, case-folding, the xt-key / urn-prefix case-insensitivity,
+// multi-parameter magnets, and every "no parseable hash" path (missing
+// scheme, missing xt, wrong length, non-hex, undecodable base32).
+package torrents
+
+import "testing"
+
+// knownV1Hex and knownV1Base32 are the SAME v1 infohash in the two
+// encodings sources emit.  The base32 form decodes to exactly this hex,
+// which is what lets dedup match a base32 source against a hex source.
+const (
+	knownV1Hex    = "c12fe1c06bba254a9dc9f519b335aa7c1367a88a"
+	knownV1Base32 = "YEX6DQDLXISUVHOJ6UM3GNNKPQJWPKEK"
+	// A v2 (SHA-256) infohash is 64 hex chars.
+	knownV2Hex = "caf1e1d3a3f2b9c4e5d6071829364554637281901a2b3c4d5e6f70819a2b3c4d"
+)
+
+func TestParseInfohash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		magnet string
+		want   string
+	}{
+		{
+			name:   "v1 hex lowercase",
+			magnet: "magnet:?xt=urn:btih:" + knownV1Hex + "&dn=Some.Anime",
+			want:   knownV1Hex,
+		},
+		{
+			name:   "v1 hex uppercase is lowercased",
+			magnet: "magnet:?xt=urn:btih:C12FE1C06BBA254A9DC9F519B335AA7C1367A88A",
+			want:   knownV1Hex,
+		},
+		{
+			name:   "v1 hex mixed case is lowercased",
+			magnet: "magnet:?xt=urn:btih:C12fe1C06bba254A9dc9F519b335AA7c1367a88A",
+			want:   knownV1Hex,
+		},
+		{
+			name:   "v1 base32 decodes to the SAME hex as the hex form",
+			magnet: "magnet:?xt=urn:btih:" + knownV1Base32 + "&dn=Some.Anime",
+			want:   knownV1Hex,
+		},
+		{
+			name:   "v1 base32 lowercased still decodes",
+			magnet: "magnet:?xt=urn:btih:yex6dqdlxisuvhoj6um3gnnkpqjwpkek",
+			want:   knownV1Hex,
+		},
+		{
+			name:   "v2 hash (64 hex) is preserved at full length, not truncated",
+			magnet: "magnet:?xt=urn:btih:" + knownV2Hex,
+			want:   knownV2Hex,
+		},
+		{
+			name:   "xt key is matched case-insensitively",
+			magnet: "magnet:?XT=urn:btih:" + knownV1Hex,
+			want:   knownV1Hex,
+		},
+		{
+			name:   "urn:btih prefix is matched case-insensitively",
+			magnet: "magnet:?xt=URN:BTIH:" + knownV1Hex,
+			want:   knownV1Hex,
+		},
+		{
+			name:   "btih xt found among other parameters",
+			magnet: "magnet:?dn=Anime&xt=urn:btih:" + knownV1Hex + "&tr=http%3A%2F%2Ftracker%2Fannounce",
+			want:   knownV1Hex,
+		},
+		{
+			name:   "semicolon-separated parameters are accepted",
+			magnet: "magnet:?dn=Anime;xt=urn:btih:" + knownV1Hex,
+			want:   knownV1Hex,
+		},
+		{
+			name:   "missing magnet scheme yields empty",
+			magnet: "https://nyaa.si/download/123.torrent",
+			want:   "",
+		},
+		{
+			name:   "magnet with no parameters yields empty",
+			magnet: "magnet:",
+			want:   "",
+		},
+		{
+			name:   "magnet with no xt parameter yields empty",
+			magnet: "magnet:?dn=Anime&tr=http%3A%2F%2Ftracker",
+			want:   "",
+		},
+		{
+			name:   "non-btih xt (ed2k) yields empty",
+			magnet: "magnet:?xt=urn:ed2k:31d6cfe0d16ae931b73c59d7e0c089c0",
+			want:   "",
+		},
+		{
+			name:   "wrong-length hex (39 chars) yields empty",
+			magnet: "magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88",
+			want:   "",
+		},
+		{
+			name:   "40 chars but non-hex (contains g/z) yields empty",
+			magnet: "magnet:?xt=urn:btih:g12fe1c06bba254a9dc9f519b335aa7c1367a88z",
+			want:   "",
+		},
+		{
+			name:   "32 chars but invalid base32 alphabet (contains 0/1/8/9) yields empty",
+			magnet: "magnet:?xt=urn:btih:00000000000000000000000000000018",
+			want:   "",
+		},
+		{
+			name:   "empty string yields empty",
+			magnet: "",
+			want:   "",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseInfohash(tc.magnet)
+			if got != tc.want {
+				t.Errorf("parseInfohash(%q) = %q, want %q", tc.magnet, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseInfohash_Base32EqualsHex locks in the core dedup invariant:
+// the base32 encoding and the hex encoding of one torrent normalise to
+// the identical string, so two sources emitting different encodings still
+// dedup together.
+func TestParseInfohash_Base32EqualsHex(t *testing.T) {
+	t.Parallel()
+
+	hexForm := parseInfohash("magnet:?xt=urn:btih:" + knownV1Hex)
+	b32Form := parseInfohash("magnet:?xt=urn:btih:" + knownV1Base32)
+
+	if hexForm == "" || b32Form == "" {
+		t.Fatalf("both encodings must parse: hex=%q base32=%q", hexForm, b32Form)
+	}
+	if hexForm != b32Form {
+		t.Errorf("base32 and hex must normalise equal: hex=%q base32=%q", hexForm, b32Form)
+	}
+}

--- a/go-api/internal/torrents/rank.go
+++ b/go-api/internal/torrents/rank.go
@@ -1,0 +1,236 @@
+// Package torrents — rank.go
+//
+// The normalise → dedup → rank pipeline the aggregator runs over the
+// merged, multi-source result before caching it.  Three pure functions,
+// each returning a fresh slice (the inputs are never mutated, per the
+// package's immutability convention):
+//
+//   - sourceRanks   : pre-computes a Source→score map from the registry
+//     so dedup and rank can break ties by source without re-reading
+//     Capabilities per comparison.  Higher score = preferred source.
+//   - dedupByInfohash : collapses rows that share a non-empty infohash,
+//     keeping the "best" copy (more seeders wins; nil seeders is the
+//     weakest; ties break on source score).  Rows with an empty hash are
+//     not deduplicable and pass through untouched.
+//   - rankItems      : stable-sorts the deduped rows by seeders desc
+//     (nil sinks to the bottom), then date desc, then source score.
+//
+// Why dedup needs source scores even though it has no Fetcher in hand:
+// at this stage we hold TorrentItems, not Sources, so the per-source
+// Priority (an aggregator concept) can't be read off the item.  We bridge
+// that by pre-baking the registry's source ordering into a map keyed by
+// the item's Source field.
+package torrents
+
+import (
+	"sort"
+	"time"
+)
+
+// sourceRanks builds a Source→score map from the registry's fan-out
+// order.  Score is a "higher is better" priority used as the final
+// tie-break in both dedup and rank.
+//
+// The ordering combines two signals, in this precedence:
+//  1. The source's advertised Capabilities.Priority (higher wins) — the
+//     forward-looking knob a richer source can set to outrank the RSS
+//     scrapes.
+//  2. Registration order as the tie-break within equal Priority (earlier
+//     registered = preferred), preserving the canonical garden → acg →
+//     nyaa order the package already documents.
+//
+// Sources that don't implement Capable advertise Priority 0 (via
+// CapabilitiesOf), so today — when none of garden/acg/nyaa set it — the
+// map degenerates to pure registration order, which is exactly the legacy
+// behaviour.
+//
+// The returned map gives the first-ranked source the highest score and
+// decreases by one per rank, so callers compare scores with a plain `>`.
+// A Source absent from the map (shouldn't happen for merged items, but
+// defensively) reads as 0 from a map lookup, i.e. lowest.
+func sourceRanks(reg *Registry) map[Source]int {
+	sources := reg.Sources()
+
+	// order records each source's registration index so we can use it as a
+	// stable secondary key when Priorities tie.
+	type ranked struct {
+		name     Source
+		priority int
+		regIndex int
+	}
+	ordered := make([]ranked, 0, len(sources))
+	for i, s := range sources {
+		ordered = append(ordered, ranked{
+			name:     s.Name(),
+			priority: CapabilitiesOf(s).Priority,
+			regIndex: i,
+		})
+	}
+
+	// Sort best-first: higher Priority wins; equal Priority keeps
+	// registration order (lower index first).
+	sort.SliceStable(ordered, func(a, b int) bool {
+		if ordered[a].priority != ordered[b].priority {
+			return ordered[a].priority > ordered[b].priority
+		}
+		return ordered[a].regIndex < ordered[b].regIndex
+	})
+
+	// Assign descending scores so the best source has the largest value.
+	ranks := make(map[Source]int, len(ordered))
+	for i, r := range ordered {
+		ranks[r.name] = len(ordered) - i
+	}
+	return ranks
+}
+
+// dedupByInfohash collapses items that share the same non-empty infohash,
+// keeping a single "best" representative per hash.  It also stamps each
+// kept item's Infohash field with the value parsed from its magnet (so
+// downstream/consumers see the normalised hash).
+//
+// Rules:
+//   - The hash is parsed fresh from each item's Magnet via parseInfohash
+//     — source-agnostic, independent of any pre-set Infohash field.
+//   - An item whose parsed hash is "" is NOT deduplicable: it passes
+//     through verbatim (its Infohash is left empty), in original order.
+//   - Among items sharing a hash, "better" is: more seeders wins (a known
+//     count beats nil; higher count beats lower); on a seeders tie the
+//     higher source score (from ranks) wins; if still tied the first-seen
+//     copy is kept (stable).
+//
+// Order of the survivors mirrors first-appearance order of each hash /
+// each empty-hash row, so a caller that does not rank afterwards still
+// gets a deterministic, merge-order-respecting slice.  (rankItems
+// re-sorts anyway; preserving order here keeps dedup independently
+// testable and side-effect-free.)
+//
+// Returns a new slice; the input is not mutated.
+func dedupByInfohash(items []TorrentItem, ranks map[Source]int) []TorrentItem {
+	out := make([]TorrentItem, 0, len(items))
+	// indexByHash maps a hash to the position of its current best copy in
+	// out, so we can replace in place when a better duplicate arrives
+	// without disturbing the relative order of the survivors.
+	indexByHash := make(map[string]int, len(items))
+
+	for _, it := range items {
+		hash := parseInfohash(it.Magnet)
+		if hash == "" {
+			// Not deduplicable — emit as-is, leaving Infohash empty.
+			out = append(out, it)
+			continue
+		}
+
+		// Stamp the normalised hash onto the kept copy.
+		candidate := it
+		candidate.Infohash = hash
+
+		pos, seen := indexByHash[hash]
+		if !seen {
+			indexByHash[hash] = len(out)
+			out = append(out, candidate)
+			continue
+		}
+
+		// A duplicate: keep whichever copy is better, in the SAME slot so
+		// survivor order is unchanged.
+		if betterItem(candidate, out[pos], ranks) {
+			out[pos] = candidate
+		}
+	}
+
+	return out
+}
+
+// betterItem reports whether a should replace b when both carry the same
+// infohash.  The ordering is: more seeders first (nil = unknown = worst),
+// then higher source score.  It is strict — equal-on-all-keys returns
+// false so the incumbent (first-seen) copy is retained.
+func betterItem(a, b TorrentItem, ranks map[Source]int) bool {
+	if c := compareSeeders(a.Seeders, b.Seeders); c != 0 {
+		return c > 0
+	}
+	return ranks[a.Source] > ranks[b.Source]
+}
+
+// compareSeeders orders two optional seeder counts: a known count is
+// always greater than nil ("unknown" sinks below any real number,
+// including 0), and between two known counts the larger is greater.
+// Returns >0 when a ranks above b, <0 when below, 0 when equal-rank
+// (both nil, or equal counts).
+func compareSeeders(a, b *int) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return -1
+	case b == nil:
+		return 1
+	case *a != *b:
+		if *a > *b {
+			return 1
+		}
+		return -1
+	default:
+		return 0
+	}
+}
+
+// rankItems returns a new slice sorted for presentation:
+//  1. Seeders descending — a higher known count first; nil (unknown)
+//     sinks to the bottom regardless of the other keys.
+//  2. Date descending — newer first.  Dates are parsed leniently (see
+//     parseItemDate); an unparseable / missing date sorts as the zero
+//     time, i.e. oldest, so well-formed dates float above it.
+//  3. Source score descending — the registry's preferred source wins the
+//     final tie.
+//
+// The sort is stable, so items equal on all three keys keep their input
+// (post-dedup, merge) order.  When every item has nil Seeders (the common
+// case today, since only garden can report seeders and only sometimes),
+// key 1 is inert and the result degrades cleanly to date-then-source
+// order.
+//
+// Returns a new slice; the input is not mutated.
+func rankItems(items []TorrentItem, ranks map[Source]int) []TorrentItem {
+	out := make([]TorrentItem, len(items))
+	copy(out, items)
+
+	sort.SliceStable(out, func(i, j int) bool {
+		if c := compareSeeders(out[i].Seeders, out[j].Seeders); c != 0 {
+			return c > 0
+		}
+		di, dj := parseItemDate(out[i].Date), parseItemDate(out[j].Date)
+		if !di.Equal(dj) {
+			return di.After(dj)
+		}
+		return ranks[out[i].Source] > ranks[out[j].Source]
+	})
+
+	return out
+}
+
+// itemDateLayouts are the timestamp formats the upstream sources emit.
+// RSS feeds (acg / nyaa) use RFC1123-style pubDate; garden's JSON uses
+// RFC3339.  Parsed in order; the first that matches wins.
+var itemDateLayouts = []string{
+	time.RFC1123Z, // "Mon, 02 Jan 2006 15:04:05 -0700"
+	time.RFC1123,  // "Mon, 02 Jan 2006 15:04:05 MST"
+	time.RFC3339,  // "2006-01-02T15:04:05Z07:00"
+}
+
+// parseItemDate leniently parses an item's Date pointer into a time.Time
+// for ordering.  A nil pointer, empty string, or unrecognised format
+// yields the zero time (sorts oldest) — never an error, since a bad date
+// must not break ranking of the rest.
+func parseItemDate(d *string) time.Time {
+	if d == nil || *d == "" {
+		return time.Time{}
+	}
+	for _, layout := range itemDateLayouts {
+		if t, err := time.Parse(layout, *d); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}

--- a/go-api/internal/torrents/rank_test.go
+++ b/go-api/internal/torrents/rank_test.go
@@ -1,0 +1,352 @@
+// Package torrents — rank_test.go
+//
+// Coverage for the dedup + rank pipeline:
+//   - dedupByInfohash: same-hash rows collapse keeping the higher-seeder
+//     copy; nil seeders loses to any known count; source priority breaks a
+//     seeder tie; empty-hash rows pass through untouched (never merged);
+//     base32 and hex encodings of one hash dedup together; survivor order
+//     follows first appearance; the input slice is not mutated.
+//   - rankItems: seeders desc with nil sunk to the bottom; date desc as the
+//     secondary key; source priority as the final tie-break; stable for
+//     fully-equal rows; the all-nil-seeders case degrades to date order.
+//   - sourceRanks: registration order by default; advertised Priority
+//     overrides registration order.
+package torrents
+
+import (
+	"context"
+	"testing"
+)
+
+// intPtr returns &n.  Local to this file — the seeder tests need an
+// *int and no shared helper exists (strPtr already lives in
+// garden_test.go for the *string fields).
+func intPtr(n int) *int { return &n }
+
+// magnetFor builds a minimal valid v1-hex magnet for a 40-hex infohash,
+// so dedup tests can drive parseInfohash off a realistic magnet string.
+func magnetFor(hexHash string) string {
+	return "magnet:?xt=urn:btih:" + hexHash + "&dn=test"
+}
+
+// Two distinct, valid v1 infohashes for the dedup tables.
+const (
+	hashA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	hashB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+// capSource is a test Fetcher that advertises a Capabilities.Priority,
+// so sourceRanks's priority-over-registration-order branch is exercised.
+// Its Fetch is never called by the rank tests (they operate on
+// pre-built item slices), but it satisfies the interface.
+type capSource struct {
+	name     Source
+	priority int
+}
+
+func (s capSource) Name() Source { return s.name }
+func (s capSource) Fetch(context.Context, string) ([]TorrentItem, error) {
+	return nil, nil
+}
+func (s capSource) Capabilities() Capabilities {
+	return Capabilities{Priority: s.priority}
+}
+
+// regWith builds a Registry from plain (no-Capabilities) sources in the
+// given order, so sourceRanks falls back to pure registration order.
+func regWith(names ...Source) *Registry {
+	fetchers := make([]Fetcher, 0, len(names))
+	for _, n := range names {
+		fetchers = append(fetchers, newFuncSource(n, func(context.Context, string) ([]TorrentItem, error) {
+			return nil, nil
+		}))
+	}
+	return NewRegistry(fetchers...)
+}
+
+// ---------------------------------------------------------------------------
+// sourceRanks
+// ---------------------------------------------------------------------------
+
+func TestSourceRanks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("registration order when no source sets Priority", func(t *testing.T) {
+		t.Parallel()
+		ranks := sourceRanks(regWith(SourceGarden, SourceAcg, SourceNyaa))
+		// garden registered first → highest score; nyaa last → lowest.
+		if !(ranks[SourceGarden] > ranks[SourceAcg] && ranks[SourceAcg] > ranks[SourceNyaa]) {
+			t.Errorf("expected garden > acg > nyaa, got %v", ranks)
+		}
+	})
+
+	t.Run("advertised Priority overrides registration order", func(t *testing.T) {
+		t.Parallel()
+		// nyaa registered LAST but advertises the highest Priority → it must
+		// outrank garden/acg despite its position.
+		reg := NewRegistry(
+			newFuncSource(SourceGarden, func(context.Context, string) ([]TorrentItem, error) { return nil, nil }),
+			newFuncSource(SourceAcg, func(context.Context, string) ([]TorrentItem, error) { return nil, nil }),
+			capSource{name: SourceNyaa, priority: 100},
+		)
+		ranks := sourceRanks(reg)
+		if !(ranks[SourceNyaa] > ranks[SourceGarden] && ranks[SourceNyaa] > ranks[SourceAcg]) {
+			t.Errorf("expected nyaa (high Priority) to outrank others, got %v", ranks)
+		}
+		// garden still beats acg via registration order (both Priority 0).
+		if !(ranks[SourceGarden] > ranks[SourceAcg]) {
+			t.Errorf("expected garden > acg on equal Priority, got %v", ranks)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// dedupByInfohash
+// ---------------------------------------------------------------------------
+
+func TestDedup(t *testing.T) {
+	t.Parallel()
+
+	// Default registry order garden > acg > nyaa for the priority tie-break.
+	ranks := sourceRanks(regWith(SourceGarden, SourceAcg, SourceNyaa))
+
+	t.Run("same hash collapses keeping the higher-seeder copy", func(t *testing.T) {
+		t.Parallel()
+		in := []TorrentItem{
+			{Title: "low", Magnet: magnetFor(hashA), Source: SourceGarden, Seeders: intPtr(5)},
+			{Title: "high", Magnet: magnetFor(hashA), Source: SourceNyaa, Seeders: intPtr(50)},
+		}
+		out := dedupByInfohash(in, ranks)
+		if len(out) != 1 {
+			t.Fatalf("expected 1 deduped item, got %d: %+v", len(out), out)
+		}
+		if out[0].Title != "high" || *out[0].Seeders != 50 {
+			t.Errorf("expected the 50-seeder copy to win, got %+v", out[0])
+		}
+		// The kept copy is stamped with the normalised hash.
+		if out[0].Infohash != hashA {
+			t.Errorf("expected Infohash %q stamped, got %q", hashA, out[0].Infohash)
+		}
+	})
+
+	t.Run("nil seeders loses to a known count (even zero)", func(t *testing.T) {
+		t.Parallel()
+		in := []TorrentItem{
+			{Title: "unknown", Magnet: magnetFor(hashA), Source: SourceGarden, Seeders: nil},
+			{Title: "zero", Magnet: magnetFor(hashA), Source: SourceNyaa, Seeders: intPtr(0)},
+		}
+		out := dedupByInfohash(in, ranks)
+		if len(out) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(out))
+		}
+		if out[0].Title != "zero" {
+			t.Errorf("a known 0-seeder count must beat nil/unknown, got %+v", out[0])
+		}
+	})
+
+	t.Run("source priority breaks a seeder tie", func(t *testing.T) {
+		t.Parallel()
+		// Same hash, same seeders → garden (higher registration priority)
+		// wins over nyaa even though nyaa appears second.
+		in := []TorrentItem{
+			{Title: "nyaa-copy", Magnet: magnetFor(hashA), Source: SourceNyaa, Seeders: intPtr(10)},
+			{Title: "garden-copy", Magnet: magnetFor(hashA), Source: SourceGarden, Seeders: intPtr(10)},
+		}
+		out := dedupByInfohash(in, ranks)
+		if len(out) != 1 {
+			t.Fatalf("expected 1 item, got %d", len(out))
+		}
+		if out[0].Source != SourceGarden {
+			t.Errorf("expected garden to win the seeder tie via priority, got %+v", out[0])
+		}
+	})
+
+	t.Run("empty-hash rows pass through and are never merged", func(t *testing.T) {
+		t.Parallel()
+		// Two magnet-less rows (no btih) plus one real hash.  The two
+		// empty-hash rows must BOTH survive (not collapsed into each other).
+		in := []TorrentItem{
+			{Title: "no-hash-1", Magnet: "magnet:?dn=a", Source: SourceAcg},
+			{Title: "real", Magnet: magnetFor(hashA), Source: SourceGarden, Seeders: intPtr(3)},
+			{Title: "no-hash-2", Magnet: "https://nyaa.si/x", Source: SourceNyaa},
+		}
+		out := dedupByInfohash(in, ranks)
+		if len(out) != 3 {
+			t.Fatalf("expected all 3 rows to survive (2 empty-hash + 1 real), got %d: %+v", len(out), out)
+		}
+		// Empty-hash rows keep an empty Infohash.
+		for _, it := range out {
+			if it.Title == "no-hash-1" || it.Title == "no-hash-2" {
+				if it.Infohash != "" {
+					t.Errorf("empty-hash row %q should keep empty Infohash, got %q", it.Title, it.Infohash)
+				}
+			}
+		}
+	})
+
+	t.Run("base32 and hex encodings of one hash dedup together", func(t *testing.T) {
+		t.Parallel()
+		in := []TorrentItem{
+			{Title: "hex", Magnet: magnetFor(knownV1Hex), Source: SourceNyaa, Seeders: intPtr(7)},
+			{Title: "base32", Magnet: "magnet:?xt=urn:btih:" + knownV1Base32, Source: SourceGarden, Seeders: intPtr(99)},
+		}
+		out := dedupByInfohash(in, ranks)
+		if len(out) != 1 {
+			t.Fatalf("base32 and hex of one torrent must collapse to 1, got %d: %+v", len(out), out)
+		}
+		if *out[0].Seeders != 99 {
+			t.Errorf("expected the 99-seeder copy to win across encodings, got %+v", out[0])
+		}
+		if out[0].Infohash != knownV1Hex {
+			t.Errorf("survivor should carry the normalised hex hash, got %q", out[0].Infohash)
+		}
+	})
+
+	t.Run("distinct hashes are both kept in first-seen order", func(t *testing.T) {
+		t.Parallel()
+		in := []TorrentItem{
+			{Title: "B", Magnet: magnetFor(hashB), Source: SourceGarden},
+			{Title: "A", Magnet: magnetFor(hashA), Source: SourceGarden},
+		}
+		out := dedupByInfohash(in, ranks)
+		if len(out) != 2 {
+			t.Fatalf("expected 2 distinct items, got %d", len(out))
+		}
+		if out[0].Title != "B" || out[1].Title != "A" {
+			t.Errorf("survivor order should follow first appearance, got %+v", out)
+		}
+	})
+
+	t.Run("does not mutate the input slice", func(t *testing.T) {
+		t.Parallel()
+		in := []TorrentItem{
+			{Title: "low", Magnet: magnetFor(hashA), Source: SourceGarden, Seeders: intPtr(5)},
+			{Title: "high", Magnet: magnetFor(hashA), Source: SourceNyaa, Seeders: intPtr(50)},
+		}
+		_ = dedupByInfohash(in, ranks)
+		// The originals must be untouched (no Infohash stamped onto them).
+		if in[0].Infohash != "" || in[1].Infohash != "" {
+			t.Errorf("dedup must not mutate input items, got %+v", in)
+		}
+		if in[0].Title != "low" || in[1].Title != "high" {
+			t.Errorf("dedup must not reorder/overwrite input, got %+v", in)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// rankItems
+// ---------------------------------------------------------------------------
+
+func TestRank(t *testing.T) {
+	t.Parallel()
+
+	ranks := sourceRanks(regWith(SourceGarden, SourceAcg, SourceNyaa))
+
+	t.Run("seeders desc with nil sunk to the bottom", func(t *testing.T) {
+		t.Parallel()
+		in := []TorrentItem{
+			{Title: "unknown", Source: SourceGarden, Seeders: nil},
+			{Title: "mid", Source: SourceGarden, Seeders: intPtr(20)},
+			{Title: "top", Source: SourceGarden, Seeders: intPtr(100)},
+			{Title: "zero", Source: SourceGarden, Seeders: intPtr(0)},
+		}
+		out := rankItems(in, ranks)
+		gotOrder := []string{out[0].Title, out[1].Title, out[2].Title, out[3].Title}
+		want := []string{"top", "mid", "zero", "unknown"}
+		for i := range want {
+			if gotOrder[i] != want[i] {
+				t.Fatalf("seeder ordering wrong: got %v, want %v", gotOrder, want)
+			}
+		}
+	})
+
+	t.Run("date desc breaks a seeder tie (or all-nil seeders)", func(t *testing.T) {
+		t.Parallel()
+		// All seeders nil → key 1 inert → falls through to date desc.
+		in := []TorrentItem{
+			{Title: "older", Source: SourceGarden, Date: strPtr("Mon, 01 Jan 2024 00:00:00 GMT")},
+			{Title: "newer", Source: SourceGarden, Date: strPtr("Wed, 01 Jan 2025 00:00:00 GMT")},
+			{Title: "no-date", Source: SourceGarden, Date: nil},
+		}
+		out := rankItems(in, ranks)
+		// newer first, then older, then the unparseable/nil date (oldest).
+		if out[0].Title != "newer" || out[1].Title != "older" || out[2].Title != "no-date" {
+			t.Errorf("date ordering wrong: %v", []string{out[0].Title, out[1].Title, out[2].Title})
+		}
+	})
+
+	t.Run("source priority is the final tie-break", func(t *testing.T) {
+		t.Parallel()
+		// Identical seeders + identical date → garden outranks acg outranks
+		// nyaa via the registry priority.
+		d := strPtr("Wed, 01 Jan 2025 00:00:00 GMT")
+		in := []TorrentItem{
+			{Title: "nyaa", Source: SourceNyaa, Seeders: intPtr(5), Date: d},
+			{Title: "acg", Source: SourceAcg, Seeders: intPtr(5), Date: d},
+			{Title: "garden", Source: SourceGarden, Seeders: intPtr(5), Date: d},
+		}
+		out := rankItems(in, ranks)
+		if out[0].Source != SourceGarden || out[1].Source != SourceAcg || out[2].Source != SourceNyaa {
+			t.Errorf("source tie-break wrong: %v",
+				[]Source{out[0].Source, out[1].Source, out[2].Source})
+		}
+	})
+
+	t.Run("stable for fully-equal rows", func(t *testing.T) {
+		t.Parallel()
+		// Same source, same seeders, same date → input order preserved.
+		d := strPtr("Wed, 01 Jan 2025 00:00:00 GMT")
+		in := []TorrentItem{
+			{Title: "first", Source: SourceGarden, Seeders: intPtr(5), Date: d},
+			{Title: "second", Source: SourceGarden, Seeders: intPtr(5), Date: d},
+			{Title: "third", Source: SourceGarden, Seeders: intPtr(5), Date: d},
+		}
+		out := rankItems(in, ranks)
+		if out[0].Title != "first" || out[1].Title != "second" || out[2].Title != "third" {
+			t.Errorf("stable sort should preserve input order for equal rows, got %v",
+				[]string{out[0].Title, out[1].Title, out[2].Title})
+		}
+	})
+
+	t.Run("all-nil seeders degrades cleanly to date then source order", func(t *testing.T) {
+		t.Parallel()
+		in := []TorrentItem{
+			{Title: "acg-newer", Source: SourceAcg, Date: strPtr("Wed, 01 Jan 2025 00:00:00 GMT")},
+			{Title: "garden-older", Source: SourceGarden, Date: strPtr("Mon, 01 Jan 2024 00:00:00 GMT")},
+		}
+		out := rankItems(in, ranks)
+		// Even though garden has higher source priority, the NEWER date wins
+		// the higher-precedence key, so acg-newer sorts first.
+		if out[0].Title != "acg-newer" {
+			t.Errorf("date must outrank source priority: got %v",
+				[]string{out[0].Title, out[1].Title})
+		}
+	})
+
+	t.Run("RFC3339 (garden) and RFC1123 (rss) dates compare correctly", func(t *testing.T) {
+		t.Parallel()
+		in := []TorrentItem{
+			{Title: "rss-2024", Source: SourceNyaa, Date: strPtr("Mon, 01 Jan 2024 00:00:00 GMT")},
+			{Title: "garden-2025", Source: SourceGarden, Date: strPtr("2025-01-01T00:00:00Z")},
+		}
+		out := rankItems(in, ranks)
+		if out[0].Title != "garden-2025" {
+			t.Errorf("cross-format date comparison wrong: got %v",
+				[]string{out[0].Title, out[1].Title})
+		}
+	})
+
+	t.Run("does not mutate the input slice", func(t *testing.T) {
+		t.Parallel()
+		in := []TorrentItem{
+			{Title: "low", Source: SourceGarden, Seeders: intPtr(1)},
+			{Title: "high", Source: SourceGarden, Seeders: intPtr(9)},
+		}
+		_ = rankItems(in, ranks)
+		if in[0].Title != "low" || in[1].Title != "high" {
+			t.Errorf("rankItems must not reorder the input, got %v",
+				[]string{in[0].Title, in[1].Title})
+		}
+	})
+}

--- a/go-api/internal/torrents/types.go
+++ b/go-api/internal/torrents/types.go
@@ -66,6 +66,28 @@ type TorrentItem struct {
 	Date     *string `json:"date"`
 	Source   Source  `json:"source"`
 	Provider *string `json:"provider,omitempty"`
+
+	// Seeders is the peer seed count when the source can report it.
+	// It is a pointer so the JSON discriminates three states:
+	//   - non-nil → a known count (may legitimately be 0 = "0 seeders")
+	//   - nil     → UNKNOWN (the source can't report seeders) — this is
+	//     the case for the RSS scrapes (acg / nyaa) and any garden row
+	//     missing the field.
+	// nil is deliberately NOT the same as 0: the ranker sinks "unknown"
+	// to the bottom rather than treating it as a genuine zero-seed
+	// torrent.  omitempty drops the key entirely when nil, matching the
+	// "key absent when upstream didn't set it" convention the other
+	// optional fields use.
+	Seeders *int `json:"seeders,omitempty"`
+
+	// Infohash is the normalised BitTorrent infohash parsed from Magnet
+	// (lowercase hex; base32 v1 hashes are decoded to 40-char hex; v1 is
+	// 40 hex chars, v2 is 64).  Empty when the magnet carries no parseable
+	// xt=urn:btih:<hash>.  It is the dedup key — two rows with the same
+	// non-empty Infohash are the same torrent regardless of which source
+	// surfaced them.  omitempty drops the key when no hash could be
+	// derived, keeping the wire shape stable for magnet-less rows.
+	Infohash string `json:"infohash,omitempty"`
 }
 
 // magnetScheme is the required prefix for any magnet URI.  Items whose


### PR DESCRIPTION
> **Stacked on #31** (`refactor/torrents-source-registry`) → #30. Sibling of the dmhy/mikan PR; merges conflict-free (`git merge-tree` exit 0). Merge order: #30 → #31 → this + dmhy/mikan → AnimeTosho.

## What
Aggregated magnet results are now **deduped by btih infohash** and **ranked by seeders**, on top of the new Source registry. Previously the merge was a naive concat (same release from two sources = two rows, no ordering).

## Changes
- **`types.go`**: `TorrentItem` gains `Seeders *int` (nil = unknown, never defaulted to 0) + `Infohash string`, both `omitempty` (RSS-only rows omit them — wire shape unchanged for existing consumers).
- **`infohash.go`** (new): `parseInfohash` — pulls `xt=urn:btih:<hash>` from the magnet (case-insensitive, multi-param), lowercases, decodes base32 v1 → 40-hex, buckets v1 (40) vs v2 (64) by length without truncation, `""` on unparseable.
- **`rank.go`** (new): `dedupByInfohash` (parses hash **from each magnet** so it's source-agnostic — empty-hash rows pass through, same-hash collapses keeping higher seeders / source priority) + `rankItems` (stable: seeders desc with nil sinking below a known 0 → date desc → source priority) + `sourceRanks`.
- **`aggregator.go`**: `Fetch` only — one `merged = rankItems(dedupByInfohash(merged, ranks), ranks)` step between merge and cache. `New`/registration untouched.

Source-priority tie-break uses `CapabilitiesOf(src).Priority` with registration order as the secondary key; with no `Capable` source today it degrades to the canonical garden>acg>nyaa order.

## Test plan
- [x] `go test -race ./internal/torrents/...` green (40+ new subtests; existing tests unmodified)
- [x] `go vet ./...` + `go build ./...` + gofmt clean
- Covers: same-hash merge keeps higher seeders; known 0 beats nil; base32↔hex dedups together; empty-hash passthrough; nil-seeder sink; cross-format date compare; input immutability.