### PR TITLE
feat(torrents): add dmhy + mikan sources via shared RSS parser

### DIFF
--- a/go-api/internal/anime/handlers_test.go
+++ b/go-api/internal/anime/handlers_test.go
@@ -870,14 +870,19 @@ func TestWatchers_AnilistIDPassedThrough(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 // newStubAggregator returns a torrents.Aggregator wired with all-static
-// stub fetchers via the test-only With{Garden,Acg,Nyaa}Fn options.  The
-// caller controls each source's payload independently.
+// stub fetchers via the test-only With{Garden,Acg,Nyaa,Dmhy,Mikan}Fn
+// options.  The caller controls garden/acg/nyaa payloads independently;
+// dmhy + mikan (also in the default registry) are stubbed to return
+// nothing so these handler tests stay off the network and assert only on
+// the caller-provided sources.
 func newStubAggregator(t *testing.T, garden, acg, nyaa []torrents.TorrentItem) *torrents.Aggregator {
 	t.Helper()
 	a, err := torrents.New(
 		torrents.WithGardenFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return garden, nil }),
 		torrents.WithAcgFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return acg, nil }),
 		torrents.WithNyaaFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nyaa, nil }),
+		torrents.WithDmhyFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nil, nil }),
+		torrents.WithMikanFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nil, nil }),
 	)
 	require.NoError(t, err)
 	t.Cleanup(a.Close)

--- a/go-api/internal/torrents/aggregator.go
+++ b/go-api/internal/torrents/aggregator.go
@@ -101,15 +101,20 @@ type Aggregator struct {
 	// it (test-only, so the short-TTL regression test doesn't wait minutes).
 	emptyCacheTTL time.Duration
 
-	// gardenFn / acgFn / nyaaFn hold the per-source override stubs set by
-	// WithGardenFn / WithAcgFn / WithNyaaFn.  In production New() also
-	// fills them with closures over the real source adapters, then folds
-	// them into the registry — so they double as the resolved fetcher for
-	// each built-in source.  Tests swap them to control fetch behaviour
-	// without an httptest server.
+	// gardenFn / acgFn / nyaaFn / dmhyFn / mikanFn hold the per-source
+	// override stubs set by WithGardenFn / WithAcgFn / WithNyaaFn /
+	// WithDmhyFn / WithMikanFn.  In production New() also fills them with
+	// closures over the real source adapters, then folds them into the
+	// registry — so they double as the resolved fetcher for each built-in
+	// source.  Tests swap them to control fetch behaviour without an
+	// httptest server (and, for dmhy/mikan, to keep the aggregator's own
+	// orchestration tests off the network now that those two are in the
+	// default registry).
 	gardenFn fetchFn
 	acgFn    fetchFn
 	nyaaFn   fetchFn
+	dmhyFn   fetchFn
+	mikanFn  fetchFn
 
 	// ownsCache marks whether New created the cache (and therefore
 	// must Close it on Aggregator teardown) versus the caller
@@ -194,6 +199,26 @@ func WithNyaaFn(f fetchFn) Option {
 	}
 }
 
+// WithDmhyFn overrides the share.dmhy.org source with a single-function
+// stub.  Test-only.  See WithGardenFn.  Because dmhy is in the default
+// registry, the aggregator's own orchestration tests use this to keep the
+// dmhy slot off the network.
+func WithDmhyFn(f fetchFn) Option {
+	return func(a *Aggregator) {
+		a.dmhyFn = f
+	}
+}
+
+// WithMikanFn overrides the mikanani.me source with a single-function
+// stub.  Test-only.  See WithGardenFn.  Because mikan is in the default
+// registry, the aggregator's own orchestration tests use this to keep the
+// mikan slot off the network.
+func WithMikanFn(f fetchFn) Option {
+	return func(a *Aggregator) {
+		a.mikanFn = f
+	}
+}
+
 // New constructs an Aggregator with sensible production defaults:
 //
 //   - 1-hour TTL cache sized to 500 entries
@@ -232,14 +257,18 @@ func New(opts ...Option) (*Aggregator, error) {
 	}
 
 	// Build the default fan-out registry in the canonical merge order:
-	// garden → acg → nyaa.  These are the real source adapters, binding
-	// a.httpClient + a.logger as they stood AFTER options were applied —
-	// so the gardenSource / acgSource / nyaaSource structs are the genuine
-	// production path, not dead code.
+	// garden → acg → nyaa → dmhy → mikan.  These are the real source
+	// adapters, binding a.httpClient + a.logger as they stood AFTER
+	// options were applied — so the source structs are the genuine
+	// production path, not dead code.  dmhy + mikan are appended last so
+	// the established garden/acg/nyaa ordering (which several tests assert)
+	// is unchanged; they share the same *http.Client as the others.
 	a.registry = NewRegistry(
 		gardenSource{client: a.httpClient, logger: a.logger},
 		acgSource{client: a.httpClient},
 		nyaaSource{client: a.httpClient},
+		dmhySource{client: a.httpClient},
+		mikanSource{client: a.httpClient},
 	)
 
 	// Apply any per-source override stubs (WithGardenFn / WithAcgFn /
@@ -251,6 +280,8 @@ func New(opts ...Option) (*Aggregator, error) {
 	a.gardenFn = a.resolveSource(SourceGarden, a.gardenFn)
 	a.acgFn = a.resolveSource(SourceAcg, a.acgFn)
 	a.nyaaFn = a.resolveSource(SourceNyaa, a.nyaaFn)
+	a.dmhyFn = a.resolveSource(SourceDmhy, a.dmhyFn)
+	a.mikanFn = a.resolveSource(SourceMikan, a.mikanFn)
 
 	return a, nil
 }

--- a/go-api/internal/torrents/aggregator_test.go
+++ b/go-api/internal/torrents/aggregator_test.go
@@ -32,9 +32,21 @@ import (
 
 // newTestAggregator constructs an Aggregator with a fast cache and
 // per-test stubs.  Returns the aggregator + a teardown closure.
+//
+// dmhy + mikan are in the default registry (New) but no orchestration
+// test below stubs them, so they would otherwise hit the live network
+// here.  We prepend empty-returning no-op stubs for both BEFORE the
+// caller's opts so every Fetch-driven test stays offline and its
+// garden/acg/nyaa assertions are unchanged; a test that wants to drive
+// dmhy/mikan can still pass its own WithDmhyFn/WithMikanFn after these
+// (later options win).
 func newTestAggregator(t *testing.T, opts ...Option) *Aggregator {
 	t.Helper()
-	a, err := New(opts...)
+	base := []Option{
+		WithDmhyFn(staticFn(nil, nil)),
+		WithMikanFn(staticFn(nil, nil)),
+	}
+	a, err := New(append(base, opts...)...)
 	require.NoError(t, err)
 	t.Cleanup(a.Close)
 	return a

--- a/go-api/internal/torrents/default_registry_test.go
+++ b/go-api/internal/torrents/default_registry_test.go
@@ -1,0 +1,66 @@
+// Package torrents — default_registry_test.go
+//
+// Locks in the default fan-out registry that New() builds now that dmhy
+// and mikan are registered: the canonical merge order must be
+// garden → acg → nyaa → dmhy → mikan (the first three unchanged so the
+// existing order-sensitive tests keep holding; the two new sources
+// appended last).  Also verifies the default dmhyFn / mikanFn are wired
+// (non-nil) when no override is supplied, mirroring the gardenFn /
+// acgFn / nyaaFn default-wiring contract.
+package torrents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_DefaultRegistry_OrderAndNewSources(t *testing.T) {
+	t.Parallel()
+
+	a, err := New()
+	require.NoError(t, err)
+	t.Cleanup(a.Close)
+
+	got := a.registry.Sources()
+	names := make([]Source, len(got))
+	for i, s := range got {
+		names[i] = s.Name()
+	}
+
+	assert.Equal(t,
+		[]Source{SourceGarden, SourceAcg, SourceNyaa, SourceDmhy, SourceMikan},
+		names,
+		"default registry order: garden → acg → nyaa → dmhy → mikan (new sources appended last)",
+	)
+}
+
+func TestNew_DefaultDmhyMikanFnsWired(t *testing.T) {
+	t.Parallel()
+
+	a, err := New()
+	require.NoError(t, err)
+	t.Cleanup(a.Close)
+
+	require.NotNil(t, a.dmhyFn, "default dmhyFn should be wired to the real adapter")
+	require.NotNil(t, a.mikanFn, "default mikanFn should be wired to the real adapter")
+}
+
+// WithDmhyFn / WithMikanFn must override IN PLACE — the new source keeps
+// its appended position so merge order is unchanged.
+func TestNew_WithDmhyMikanFn_PreservesPosition(t *testing.T) {
+	t.Parallel()
+
+	a, err := New(
+		WithDmhyFn(staticFn([]TorrentItem{stubItem(SourceDmhy)}, nil)),
+		WithMikanFn(staticFn([]TorrentItem{stubItem(SourceMikan)}, nil)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(a.Close)
+
+	got := a.registry.Sources()
+	require.Len(t, got, 5)
+	assert.Equal(t, SourceDmhy, got[3].Name(), "dmhy override keeps position 3")
+	assert.Equal(t, SourceMikan, got[4].Name(), "mikan override keeps position 4")
+}

--- a/go-api/internal/torrents/dmhy.go
+++ b/go-api/internal/torrents/dmhy.go
@@ -1,0 +1,117 @@
+// Package torrents — dmhy.go
+//
+// 动漫花园 (share.dmhy.org) direct RSS fetcher.  dmhy is the canonical
+// Chinese-sub release tracker; animes.garden (garden.go) already
+// aggregates a dmhy mirror, but hitting dmhy directly catches releases
+// the aggregator hasn't ingested yet and is resilient to garden being
+// down.
+//
+// Endpoint shape:
+//
+//	GET https://share.dmhy.org/topics/rss/rss.xml?keyword=<q>
+//
+//	<rss version="2.0">
+//	  <channel>
+//	    <item>
+//	      <title>[字幕组] 番名 - 01 [1080p]</title>
+//	      <link>https://share.dmhy.org/topics/view/...</link>
+//	      <pubDate>Sat, 01 Jan 2026 00:00:00 +0800</pubDate>
+//	      <enclosure url="magnet:?xt=urn:btih:...&amp;dn=..."
+//	                 type="application/x-bittorrent" length="0"/>
+//	    </item>
+//	  </channel>
+//	</rss>
+//
+// The magnet sits DIRECTLY in <enclosure url="..."> (simpler than nyaa,
+// which has to synthesise one from an infohash).  dmhy XML-escapes the
+// magnet's "&" as "&amp;" on the wire; encoding/xml decodes that back to
+// "&" automatically, so the resolved url is already a usable magnet —
+// no manual unescape (which would double-decode and corrupt a literal
+// &amp;).
+//
+// Mapping:
+//   - title  → item.title
+//   - magnet → item.enclosure.url (must start with "magnet:", else drop)
+//   - size   → FormatBytes(item.enclosure.length); dmhy often sends
+//     length="0" → FormatBytes returns "" (no size), which is fine.
+//   - fansub → ParseFansub(title)
+//   - date   → item.pubDate
+//   - source → SourceDmhy
+//
+// No seeders (RSS gives none) and no provider.  Does NOT implement
+// Capable — like the other RSS scrapes it has no special capabilities.
+package torrents
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// SourceDmhy is share.dmhy.org — direct RSS of the 动漫花园 tracker.
+// Declared here (not types.go) because dmhy is this file's source.
+const SourceDmhy Source = "dmhy"
+
+// dmhyEndpoint is the share.dmhy.org keyword-search RSS endpoint.  The
+// query term rides on ?keyword=<q>.
+const dmhyEndpoint = "https://share.dmhy.org/topics/rss/rss.xml"
+
+// dmhySource is the Fetcher adapter for share.dmhy.org.  Thin struct in
+// the gardenSource mould: it binds the shared *http.Client and delegates
+// to FetchDmhy.  Being an RSS scrape it does NOT implement Capable.
+type dmhySource struct {
+	client *http.Client
+}
+
+func (s dmhySource) Name() Source { return SourceDmhy }
+
+func (s dmhySource) Fetch(ctx context.Context, q string) ([]TorrentItem, error) {
+	return FetchDmhy(ctx, s.client, q)
+}
+
+// FetchDmhy hits dmhy's keyword RSS feed, parses the shared RSS
+// envelope, and returns the filtered TorrentItems.  Error behaviour
+// matches the other fetchers (network/non-2xx/decode → (nil, err)) via
+// the shared fetchRSS helper.
+func FetchDmhy(ctx context.Context, httpClient *http.Client, q string) ([]TorrentItem, error) {
+	endpoint, err := buildDmhyURL(q)
+	if err != nil {
+		return nil, fmt.Errorf("dmhy: build url: %w", err)
+	}
+
+	feed, err := fetchRSS(ctx, httpClient, "dmhy", endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return mapRSSItems(feed.Items, SourceDmhy, dmhyMagnet, dmhySize), nil
+}
+
+// buildDmhyURL composes dmhy's RSS URL with ?keyword=<q>.  url.Values
+// handles escaping for queries with spaces / brackets / CJK characters.
+func buildDmhyURL(q string) (string, error) {
+	u, err := url.Parse(dmhyEndpoint)
+	if err != nil {
+		return "", err
+	}
+	vals := u.Query()
+	vals.Set("keyword", q)
+	u.RawQuery = vals.Encode()
+	return u.String(), nil
+}
+
+// dmhyMagnet resolves the magnet for a dmhy item: it's the enclosure
+// url verbatim (already a decoded magnet URI).  Non-magnet values are
+// filtered out downstream by mapRSSItems via hasMagnetScheme.
+func dmhyMagnet(it rssItem) string {
+	return it.Enclosure.URL
+}
+
+// dmhySize formats the enclosure @length byte count.  dmhy commonly
+// sends length="0", in which case FormatBytes returns "" — an empty
+// Size string, the same "no size available" signal the other fetchers
+// produce.
+func dmhySize(it rssItem) string {
+	return FormatBytes(it.Enclosure.Length)
+}

--- a/go-api/internal/torrents/dmhy_test.go
+++ b/go-api/internal/torrents/dmhy_test.go
@@ -1,0 +1,228 @@
+// Package torrents — dmhy_test.go
+//
+// Covers FetchDmhy (and its shared rss.go plumbing):
+//   - happy path: enclosure-magnet parsing, with the wire-level &amp;
+//     in the magnet URL auto-decoded back to & by encoding/xml
+//   - fansub bracket parse + CJK title survival
+//   - length="0" → empty Size (FormatBytes returns "")
+//   - non-magnet enclosure / missing title → item dropped
+//   - empty channel → empty slice, no error
+//   - error paths: non-2xx, transport error, malformed XML
+//   - request is built with ?keyword=<q>
+//
+// Fixtures are small hand-written XML modelled on real share.dmhy.org
+// output; nothing here touches the network (newRewriteClient redirects
+// to an httptest server — same trick acgrip/nyaa tests use).
+package torrents
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time: dmhySource satisfies Fetcher; like the other RSS
+// scrapes it must NOT implement Capable (no seeders / special budget).
+var _ Fetcher = dmhySource{}
+
+func TestDmhySource_DoesNotImplementCapable(t *testing.T) {
+	t.Parallel()
+	if _, ok := any(dmhySource{}).(Capable); ok {
+		t.Fatal("dmhySource should NOT implement Capable")
+	}
+	assert.Equal(t, Capabilities{}, CapabilitiesOf(dmhySource{}))
+	assert.Equal(t, SourceDmhy, dmhySource{}.Name())
+}
+
+// dmhyRSSHeader / Footer wrap the per-test <item> blocks in the dmhy
+// RSS envelope.  dmhy uses a plain RSS 2.0 feed (no custom namespace).
+const dmhyRSSHeader = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>share.dmhy.org</title>`
+
+const dmhyRSSFooter = `
+  </channel>
+</rss>`
+
+// ---------------------------------------------------------------------------
+// FetchDmhy — happy path: magnet straight from the enclosure
+// ---------------------------------------------------------------------------
+
+func TestFetchDmhy_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	// The magnet's "&" are XML-escaped as "&amp;" on the wire, exactly
+	// as dmhy sends them.  encoding/xml must decode them back to a
+	// usable magnet with literal "&" separators.
+	const body = dmhyRSSHeader + `
+    <item>
+      <title>[喵萌奶茶屋] 葬送的芙莉莲 / Sousou no Frieren - 01 [1080p]</title>
+      <link>https://share.dmhy.org/topics/view/1.html</link>
+      <pubDate>Sat, 01 Jan 2026 00:00:00 +0800</pubDate>
+      <enclosure url="magnet:?xt=urn:btih:aaaa1111&amp;dn=Frieren&amp;tr=udp://tracker.example:80" type="application/x-bittorrent" length="1500000000"/>
+    </item>
+    <item>
+      <title>[Sub] Show - 02</title>
+      <link>https://share.dmhy.org/topics/view/2.html</link>
+      <pubDate>Sat, 01 Jan 2026 01:00:00 +0800</pubDate>
+      <enclosure url="magnet:?xt=urn:btih:bbbb2222" type="application/x-bittorrent" length="0"/>
+    </item>` + dmhyRSSFooter
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "frieren", r.URL.Query().Get("keyword"))
+		assert.Equal(t, "AnimeGo/1.0", r.Header.Get("User-Agent"))
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchDmhy(context.Background(), httpClient, "frieren")
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	it := items[0]
+	assert.Equal(t, "[喵萌奶茶屋] 葬送的芙莉莲 / Sousou no Frieren - 01 [1080p]", it.Title)
+	// The &amp; entities must be decoded to literal & in the magnet.
+	assert.Equal(t, "magnet:?xt=urn:btih:aaaa1111&dn=Frieren&tr=udp://tracker.example:80", it.Magnet)
+	assert.NotContains(t, it.Magnet, "&amp;", "XML entity must be decoded, not left as &amp;")
+	assert.Equal(t, "1.5 GB", it.Size)
+	require.NotNil(t, it.Fansub)
+	assert.Equal(t, "喵萌奶茶屋", *it.Fansub)
+	assert.Equal(t, SourceDmhy, it.Source)
+	assert.Nil(t, it.Provider, "dmhy never sets provider")
+	require.NotNil(t, it.Date)
+	assert.Equal(t, "Sat, 01 Jan 2026 00:00:00 +0800", *it.Date)
+
+	// Second item: length="0" → FormatBytes returns "" (no size).
+	assert.Equal(t, "magnet:?xt=urn:btih:bbbb2222", items[1].Magnet)
+	assert.Equal(t, "", items[1].Size, `length="0" yields an empty Size`)
+}
+
+// ---------------------------------------------------------------------------
+// FetchDmhy — non-magnet enclosure / missing title are dropped
+// ---------------------------------------------------------------------------
+
+func TestFetchDmhy_NonMagnetAndMissingTitleDropped(t *testing.T) {
+	t.Parallel()
+
+	const body = dmhyRSSHeader + `
+    <item>
+      <title>[X] HTTP enclosure, not a magnet</title>
+      <link>https://share.dmhy.org/topics/view/1.html</link>
+      <pubDate>Sat, 01 Jan 2026 00:00:00 +0800</pubDate>
+      <enclosure url="https://share.dmhy.org/some.torrent" type="application/x-bittorrent" length="100"/>
+    </item>
+    <item>
+      <title></title>
+      <link>https://share.dmhy.org/topics/view/2.html</link>
+      <pubDate>Sat, 01 Jan 2026 00:00:00 +0800</pubDate>
+      <enclosure url="magnet:?xt=urn:btih:cccc3333" type="application/x-bittorrent" length="100"/>
+    </item>
+    <item>
+      <title>[Y] Valid</title>
+      <link>https://share.dmhy.org/topics/view/3.html</link>
+      <pubDate>Sat, 01 Jan 2026 00:00:00 +0800</pubDate>
+      <enclosure url="magnet:?xt=urn:btih:dddd4444" type="application/x-bittorrent" length="100"/>
+    </item>` + dmhyRSSFooter
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchDmhy(context.Background(), httpClient, "x")
+	require.NoError(t, err)
+	require.Len(t, items, 1, "only the magnet-bearing item with a title survives")
+	assert.Equal(t, "[Y] Valid", items[0].Title)
+	assert.Equal(t, "magnet:?xt=urn:btih:dddd4444", items[0].Magnet)
+}
+
+// ---------------------------------------------------------------------------
+// FetchDmhy — empty channel
+// ---------------------------------------------------------------------------
+
+func TestFetchDmhy_EmptyChannel(t *testing.T) {
+	t.Parallel()
+
+	const body = dmhyRSSHeader + dmhyRSSFooter
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchDmhy(context.Background(), httpClient, "no-results")
+	require.NoError(t, err)
+	assert.Empty(t, items, "empty channel produces an empty slice without error")
+}
+
+// ---------------------------------------------------------------------------
+// FetchDmhy — error paths
+// ---------------------------------------------------------------------------
+
+func TestFetchDmhy_Non2xxStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchDmhy(context.Background(), httpClient, "x")
+	require.Error(t, err)
+	assert.Empty(t, items)
+	assert.Contains(t, err.Error(), "dmhy")
+}
+
+func TestFetchDmhy_TransportError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	httpClient := newRewriteClient(url)
+	items, err := FetchDmhy(context.Background(), httpClient, "x")
+	require.Error(t, err)
+	assert.Empty(t, items)
+}
+
+func TestFetchDmhy_MalformedXML(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<not-xml`))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	_, err := FetchDmhy(context.Background(), httpClient, "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode")
+}
+
+// ---------------------------------------------------------------------------
+// buildDmhyURL — keyword param encoding
+// ---------------------------------------------------------------------------
+
+func TestBuildDmhyURL_EncodesKeyword(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildDmhyURL("葬送的 芙莉莲")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(got, dmhyEndpoint+"?"), "endpoint base preserved")
+	assert.Contains(t, got, "keyword=", "keyword param present")
+	// Spaces / CJK must be percent-encoded, never raw.
+	assert.NotContains(t, got, "葬送", "CJK must be percent-encoded")
+	assert.NotContains(t, got, " ", "spaces must be percent-encoded")
+}

--- a/go-api/internal/torrents/mikan.go
+++ b/go-api/internal/torrents/mikan.go
@@ -1,0 +1,240 @@
+// Package torrents — mikan.go
+//
+// Mikan Project (mikanani.me) keyword-search RSS fetcher.  Mikan is a
+// popular Chinese-sub aggregator with broad coverage; its keyword search
+// catches releases the other sources miss.
+//
+// Endpoint shape:
+//
+//	GET https://mikanani.me/RSS/Search?searchstr=<q>
+//
+//	<rss version="2.0" xmlns:torrent="https://mikanani.me/0.1/">
+//	  <channel>
+//	    <item>
+//	      <title>[字幕组] 番名 - 01</title>
+//	      <link>https://mikanani.me/Home/Episode/<40-hex-infohash></link>
+//	      <enclosure type="application/x-bittorrent" length="0"
+//	         url="https://mikanani.me/Download/<date>/<40-hex-infohash>.torrent"/>
+//	      <torrent xmlns="https://mikanani.me/0.1/">
+//	        <link>...</link>
+//	        <contentLength>1500000000</contentLength>   <!-- bytes -->
+//	        <pubDate>2026-01-01T12:00:00</pubDate>
+//	      </torrent>
+//	    </item>
+//	  </channel>
+//	</rss>
+//
+// Two Mikan-specific quirks the shared rss.go can't cover generically:
+//
+//  1. No magnet in the feed.  The <enclosure url> is a .torrent file,
+//     but its filename — and the <link> path — embed the 40-hex
+//     infohash (".../Download/<date>/<HASH>.torrent",
+//     ".../Episode/<HASH>").  We regex the hash out and synthesise a
+//     magnet via buildNyaaMagnet (reusing nyaa.go's tracker-baked
+//     builder rather than duplicating it).  Enclosure url is tried
+//     first, then <link> as a fallback.
+//
+//  2. Size lives in the namespaced <torrent><contentLength> (bytes),
+//     not the enclosure @length (which Mikan sends as 0).  Go's
+//     encoding/xml resolves the namespace by full URI, so the field tag
+//     uses "https://mikanani.me/0.1/ contentLength".
+//
+// Mapping:
+//   - title  → item.title
+//   - magnet → buildNyaaMagnet(hashFrom(enclosure.url|link), title, link)
+//   - size   → FormatBytes(torrent.contentLength)  (bytes → "X.X GB")
+//   - fansub → ParseFansub(title)
+//   - date   → item.pubDate (channel-level; falls back to namespaced
+//     torrent pubDate when the channel one is absent)
+//   - source → SourceMikan
+//
+// No seeders, no provider; does NOT implement Capable.
+package torrents
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+)
+
+// SourceMikan is mikanani.me — keyword-search RSS of the Mikan Project
+// aggregator.  Declared here (not types.go) because Mikan is this file's
+// source.
+const SourceMikan Source = "mikan"
+
+// mikanEndpoint is Mikan's keyword-search RSS endpoint.  The term rides
+// on ?searchstr=<q>.
+const mikanEndpoint = "https://mikanani.me/RSS/Search"
+
+// mikanNamespaceURI is the XML namespace for Mikan's <torrent> element
+// and its children.  encoding/xml resolves namespaced tags by full URI,
+// not by the "torrent:" alias declared on <rss>.
+const mikanNamespaceURI = "https://mikanani.me/0.1/"
+
+// infoHashRE matches a 40-hex-character BitTorrent v1 infohash anywhere
+// in a string.  Mikan embeds it in the .torrent download URL and the
+// episode <link>; FindString returns the first match (the hash) or "".
+// Anchored to exactly 40 hex chars so surrounding path segments / dates
+// can't widen or shorten the capture.
+var infoHashRE = regexp.MustCompile(`[0-9a-fA-F]{40}`)
+
+// mikanTorrentExt is Mikan's namespaced <torrent> element, carrying the
+// byte-accurate size (and a fallback pubDate).  Kept separate from the
+// shared rssItem so the generic envelope stays source-agnostic.
+type mikanTorrentExt struct {
+	ContentLength string `xml:"https://mikanani.me/0.1/ contentLength"`
+	PubDate       string `xml:"https://mikanani.me/0.1/ pubDate"`
+}
+
+// mikanItem is one <item> in Mikan's feed: the shared RSS fields plus the
+// namespaced <torrent> extension.  Embedding rssItem keeps the common
+// title/link/pubDate/enclosure decode identical to the other sources.
+type mikanItem struct {
+	rssItem
+	Torrent mikanTorrentExt `xml:"https://mikanani.me/0.1/ torrent"`
+}
+
+// mikanFeed is Mikan's <rss> envelope.  Decoded separately from the
+// shared rssFeed because each item carries the namespaced <torrent>
+// extension above.
+type mikanFeed struct {
+	XMLName xml.Name    `xml:"rss"`
+	Items   []mikanItem `xml:"channel>item"`
+}
+
+// mikanSource is the Fetcher adapter for mikanani.me.  Thin struct in the
+// gardenSource mould binding the shared *http.Client and delegating to
+// FetchMikan.  Being an RSS scrape it does NOT implement Capable.
+type mikanSource struct {
+	client *http.Client
+}
+
+func (s mikanSource) Name() Source { return SourceMikan }
+
+func (s mikanSource) Fetch(ctx context.Context, q string) ([]TorrentItem, error) {
+	return FetchMikan(ctx, s.client, q)
+}
+
+// FetchMikan hits Mikan's keyword-search RSS feed, parses the envelope
+// (with the namespaced <torrent> extension), synthesises magnets from
+// the embedded infohash, and returns the filtered TorrentItems.
+//
+// Error behaviour matches the other fetchers (network/non-2xx/decode →
+// (nil, err)).  The HTTP fetch reuses the shared User-Agent + status
+// handling but decodes into mikanFeed (not the shared rssFeed) because
+// of the namespaced size element.
+func FetchMikan(ctx context.Context, httpClient *http.Client, q string) ([]TorrentItem, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	endpoint, err := buildMikanURL(q)
+	if err != nil {
+		return nil, fmt.Errorf("mikan: build url: %w", err)
+	}
+
+	feed, err := fetchMikanFeed(ctx, httpClient, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return mapMikanItems(feed.Items), nil
+}
+
+// fetchMikanFeed performs the HTTP GET + decode into mikanFeed, mirroring
+// fetchRSS's error contract but for Mikan's namespaced envelope.  Kept
+// local because the shared fetchRSS hard-codes the plain rssFeed shape
+// and Mikan needs the <torrent> extension.
+func fetchMikanFeed(ctx context.Context, httpClient *http.Client, endpoint string) (*mikanFeed, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("mikan: build request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("mikan: http do: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("mikan: upstream status %d", res.StatusCode)
+	}
+
+	var feed mikanFeed
+	if err := xml.NewDecoder(res.Body).Decode(&feed); err != nil {
+		return nil, fmt.Errorf("mikan: decode response: %w", err)
+	}
+	return &feed, nil
+}
+
+// buildMikanURL composes Mikan's RSS URL with ?searchstr=<q>.
+func buildMikanURL(q string) (string, error) {
+	u, err := url.Parse(mikanEndpoint)
+	if err != nil {
+		return "", err
+	}
+	vals := u.Query()
+	vals.Set("searchstr", q)
+	u.RawQuery = vals.Encode()
+	return u.String(), nil
+}
+
+// mapMikanItems converts Mikan items into TorrentItems: recover the
+// infohash, synthesise a magnet via buildNyaaMagnet, format the size
+// from the namespaced contentLength, and apply the same title/magnet
+// filter the other sources use.
+func mapMikanItems(items []mikanItem) []TorrentItem {
+	out := make([]TorrentItem, 0, len(items))
+	for _, it := range items {
+		hash := mikanInfoHash(it)
+		// buildNyaaMagnet returns the raw link (a non-magnet https URL)
+		// when the hash is empty, so hasMagnetScheme drops those — same
+		// filter the other sources apply.
+		magnet := buildNyaaMagnet(hash, it.Title, it.Link)
+		if it.Title == "" || !hasMagnetScheme(magnet) {
+			continue
+		}
+
+		out = append(out, TorrentItem{
+			Title:  it.Title,
+			Magnet: magnet,
+			Size:   FormatBytes(it.Torrent.ContentLength),
+			Fansub: ParseFansub(it.Title),
+			Date:   mikanDate(it),
+			Source: SourceMikan,
+		})
+	}
+	return out
+}
+
+// mikanInfoHash extracts the 40-hex infohash for an item.  Mikan embeds
+// it in the .torrent enclosure URL (preferred) and the episode <link>
+// (fallback); the first 40-hex run in either is the hash.  Returns ""
+// when neither carries one — which makes buildNyaaMagnet fall through to
+// the non-magnet link and the item gets filtered out.
+func mikanInfoHash(it mikanItem) string {
+	if h := infoHashRE.FindString(it.Enclosure.URL); h != "" {
+		return h
+	}
+	return infoHashRE.FindString(it.Link)
+}
+
+// mikanDate prefers the channel-level <pubDate> and falls back to the
+// namespaced <torrent><pubDate> when the channel one is absent, so a
+// missing top-level date still yields a usable timestamp.  stringPtr
+// maps "" → nil (JSON null), matching the other sources.
+func mikanDate(it mikanItem) *string {
+	if it.PubDate != "" {
+		return stringPtr(it.PubDate)
+	}
+	return stringPtr(it.Torrent.PubDate)
+}

--- a/go-api/internal/torrents/mikan_test.go
+++ b/go-api/internal/torrents/mikan_test.go
@@ -1,0 +1,324 @@
+// Package torrents — mikan_test.go
+//
+// Covers FetchMikan and its Mikan-specific mapping:
+//   - happy path: .torrent enclosure URL → 40-hex infohash → magnet via
+//     buildNyaaMagnet (hash + url-encoded title + both nyaa trackers)
+//   - size from the namespaced <torrent><contentLength> (bytes →
+//     FormatBytes), NOT the enclosure @length (which Mikan sends as 0)
+//   - infohash fallback: when the enclosure URL lacks a hash, recover it
+//     from the episode <link>
+//   - no hash anywhere → item dropped (buildNyaaMagnet returns the
+//     non-magnet link → filtered)
+//   - missing title → dropped
+//   - date fallback to namespaced torrent pubDate when channel pubDate
+//     is absent
+//   - error paths: non-2xx, transport error, malformed XML
+//   - request is built with ?searchstr=<q>
+//
+// Fixtures are small hand-written XML modelled on real mikanani.me
+// output (including the xmlns:torrent="https://mikanani.me/0.1/"
+// namespace); nothing here touches the network.
+package torrents
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time: mikanSource satisfies Fetcher; like the other RSS
+// scrapes it must NOT implement Capable.
+var _ Fetcher = mikanSource{}
+
+func TestMikanSource_DoesNotImplementCapable(t *testing.T) {
+	t.Parallel()
+	if _, ok := any(mikanSource{}).(Capable); ok {
+		t.Fatal("mikanSource should NOT implement Capable")
+	}
+	assert.Equal(t, Capabilities{}, CapabilitiesOf(mikanSource{}))
+	assert.Equal(t, SourceMikan, mikanSource{}.Name())
+}
+
+// 40-hex infohashes reused across the fixtures.
+const (
+	mikanHashA = "0123456789abcdef0123456789abcdef01234567"
+	mikanHashB = "ffffffffffffffffffffffffffffffffffffffff"
+)
+
+// mikanRSSHeader / Footer wrap per-test <item> blocks.  The
+// xmlns:torrent URI must match mikanNamespaceURI in mikan.go or
+// encoding/xml will not resolve the <torrent><contentLength> element.
+const mikanRSSHeader = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torrent="https://mikanani.me/0.1/">
+  <channel>
+    <title>Mikan Project</title>`
+
+const mikanRSSFooter = `
+  </channel>
+</rss>`
+
+// ---------------------------------------------------------------------------
+// FetchMikan — happy path: infohash from .torrent URL → magnet
+// ---------------------------------------------------------------------------
+
+func TestFetchMikan_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	const body = mikanRSSHeader + `
+    <item>
+      <title>[喵萌奶茶屋] 番名 - 01 [1080p]</title>
+      <link>https://mikanani.me/Home/Episode/` + mikanHashA + `</link>
+      <enclosure type="application/x-bittorrent" length="0"
+        url="https://mikanani.me/Download/20260101/` + mikanHashA + `.torrent"/>
+      <torrent xmlns="https://mikanani.me/0.1/">
+        <link>https://mikanani.me/Home/Episode/` + mikanHashA + `</link>
+        <contentLength>1500000000</contentLength>
+        <pubDate>2026-01-01T12:00:00</pubDate>
+      </torrent>
+    </item>` + mikanRSSFooter
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "frieren", r.URL.Query().Get("searchstr"))
+		assert.Equal(t, "AnimeGo/1.0", r.Header.Get("User-Agent"))
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchMikan(context.Background(), httpClient, "frieren")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	it := items[0]
+	assert.Equal(t, "[喵萌奶茶屋] 番名 - 01 [1080p]", it.Title)
+	assert.Equal(t, SourceMikan, it.Source)
+	assert.Nil(t, it.Provider, "mikan never sets provider")
+
+	// Size comes from the namespaced contentLength (bytes), not the
+	// enclosure length="0".
+	assert.Equal(t, "1.5 GB", it.Size, "size must come from <torrent><contentLength>, not enclosure length=0")
+
+	// Magnet must be synthesised via buildNyaaMagnet: hash + url-encoded
+	// title + BOTH nyaa trackers.
+	assert.True(t, strings.HasPrefix(it.Magnet, "magnet:?xt=urn:btih:"+mikanHashA),
+		"magnet must embed the infohash from the .torrent URL")
+	assert.Contains(t, it.Magnet, "&dn=")
+	assert.Contains(t, it.Magnet, "&tr=http%3A%2F%2Fnyaa.tracker.wf%3A7777%2Fannounce")
+	assert.Contains(t, it.Magnet, "&tr=http%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce")
+
+	// &dn= must decode back to the original title.
+	dn := extractMagnetParam(t, it.Magnet, "dn")
+	assert.Equal(t, "[喵萌奶茶屋] 番名 - 01 [1080p]", dn)
+
+	require.NotNil(t, it.Fansub)
+	assert.Equal(t, "喵萌奶茶屋", *it.Fansub)
+	require.NotNil(t, it.Date)
+	assert.Equal(t, "2026-01-01T12:00:00", *it.Date, "channel pubDate absent → falls back to torrent pubDate")
+}
+
+// ---------------------------------------------------------------------------
+// FetchMikan — infohash recovered from <link> when enclosure URL lacks one
+// ---------------------------------------------------------------------------
+
+func TestFetchMikan_InfoHashFallbackToLink(t *testing.T) {
+	t.Parallel()
+
+	// Enclosure URL has NO 40-hex hash; the episode <link> does.
+	const body = mikanRSSHeader + `
+    <item>
+      <title>[Sub] Fallback - 02</title>
+      <link>https://mikanani.me/Home/Episode/` + mikanHashB + `</link>
+      <enclosure type="application/x-bittorrent" length="0"
+        url="https://mikanani.me/Download/20260101/file.torrent"/>
+      <torrent xmlns="https://mikanani.me/0.1/">
+        <contentLength>800000000</contentLength>
+        <pubDate>2026-01-02T00:00:00</pubDate>
+      </torrent>
+    </item>` + mikanRSSFooter
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchMikan(context.Background(), httpClient, "x")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.True(t, strings.HasPrefix(items[0].Magnet, "magnet:?xt=urn:btih:"+mikanHashB),
+		"infohash must be recovered from <link> when the enclosure URL has none")
+	assert.Equal(t, "800 MB", items[0].Size)
+}
+
+// ---------------------------------------------------------------------------
+// FetchMikan — no hash anywhere / missing title → dropped
+// ---------------------------------------------------------------------------
+
+func TestFetchMikan_NoHashAndMissingTitleDropped(t *testing.T) {
+	t.Parallel()
+
+	const body = mikanRSSHeader + `
+    <item>
+      <title>[X] No hash in URL or link</title>
+      <link>https://mikanani.me/Home/Episode/not-a-hash</link>
+      <enclosure type="application/x-bittorrent" length="0"
+        url="https://mikanani.me/Download/20260101/file.torrent"/>
+      <torrent xmlns="https://mikanani.me/0.1/">
+        <contentLength>100</contentLength>
+      </torrent>
+    </item>
+    <item>
+      <title></title>
+      <link>https://mikanani.me/Home/Episode/` + mikanHashA + `</link>
+      <enclosure type="application/x-bittorrent" length="0"
+        url="https://mikanani.me/Download/20260101/` + mikanHashA + `.torrent"/>
+      <torrent xmlns="https://mikanani.me/0.1/">
+        <contentLength>100</contentLength>
+      </torrent>
+    </item>
+    <item>
+      <title>[Y] Valid</title>
+      <link>https://mikanani.me/Home/Episode/` + mikanHashB + `</link>
+      <enclosure type="application/x-bittorrent" length="0"
+        url="https://mikanani.me/Download/20260101/` + mikanHashB + `.torrent"/>
+      <torrent xmlns="https://mikanani.me/0.1/">
+        <contentLength>100</contentLength>
+      </torrent>
+    </item>` + mikanRSSFooter
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchMikan(context.Background(), httpClient, "x")
+	require.NoError(t, err)
+	require.Len(t, items, 1, "only the hash-bearing item with a title survives")
+	assert.Equal(t, "[Y] Valid", items[0].Title)
+}
+
+// ---------------------------------------------------------------------------
+// FetchMikan — channel pubDate preferred over torrent pubDate
+// ---------------------------------------------------------------------------
+
+func TestFetchMikan_ChannelPubDatePreferred(t *testing.T) {
+	t.Parallel()
+
+	const body = mikanRSSHeader + `
+    <item>
+      <title>[Sub] Has both dates - 03</title>
+      <link>https://mikanani.me/Home/Episode/` + mikanHashA + `</link>
+      <pubDate>Sat, 03 Jan 2026 09:00:00 GMT</pubDate>
+      <enclosure type="application/x-bittorrent" length="0"
+        url="https://mikanani.me/Download/20260103/` + mikanHashA + `.torrent"/>
+      <torrent xmlns="https://mikanani.me/0.1/">
+        <contentLength>100</contentLength>
+        <pubDate>2026-01-03T09:00:00</pubDate>
+      </torrent>
+    </item>` + mikanRSSFooter
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchMikan(context.Background(), httpClient, "x")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.NotNil(t, items[0].Date)
+	assert.Equal(t, "Sat, 03 Jan 2026 09:00:00 GMT", *items[0].Date,
+		"channel-level pubDate wins over the namespaced torrent pubDate")
+}
+
+// ---------------------------------------------------------------------------
+// FetchMikan — error paths
+// ---------------------------------------------------------------------------
+
+func TestFetchMikan_Non2xxStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchMikan(context.Background(), httpClient, "x")
+	require.Error(t, err)
+	assert.Empty(t, items)
+	assert.Contains(t, err.Error(), "mikan")
+}
+
+func TestFetchMikan_TransportError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	httpClient := newRewriteClient(url)
+	_, err := FetchMikan(context.Background(), httpClient, "x")
+	require.Error(t, err)
+}
+
+func TestFetchMikan_MalformedXML(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<oops>`))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	_, err := FetchMikan(context.Background(), httpClient, "x")
+	require.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// buildMikanURL — searchstr param encoding
+// ---------------------------------------------------------------------------
+
+func TestBuildMikanURL_EncodesSearchstr(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildMikanURL("葬送的 芙莉莲")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(got, mikanEndpoint+"?"), "endpoint base preserved")
+	assert.Contains(t, got, "searchstr=", "searchstr param present")
+	assert.NotContains(t, got, "葬送", "CJK must be percent-encoded")
+	assert.NotContains(t, got, " ", "spaces must be percent-encoded")
+}
+
+// ---------------------------------------------------------------------------
+// mikanInfoHash — unit coverage of the extraction precedence
+// ---------------------------------------------------------------------------
+
+func TestMikanInfoHash_PrefersEnclosureThenLink(t *testing.T) {
+	t.Parallel()
+
+	// Enclosure hash wins when both are present.
+	withBoth := mikanItem{Torrent: mikanTorrentExt{}}
+	withBoth.Enclosure.URL = "https://mikanani.me/Download/x/" + mikanHashA + ".torrent"
+	withBoth.Link = "https://mikanani.me/Home/Episode/" + mikanHashB
+	assert.Equal(t, mikanHashA, mikanInfoHash(withBoth), "enclosure URL hash takes precedence")
+
+	// Falls back to link when enclosure has none.
+	linkOnly := mikanItem{}
+	linkOnly.Enclosure.URL = "https://mikanani.me/Download/x/file.torrent"
+	linkOnly.Link = "https://mikanani.me/Home/Episode/" + mikanHashB
+	assert.Equal(t, mikanHashB, mikanInfoHash(linkOnly), "falls back to <link> hash")
+
+	// Neither → empty.
+	none := mikanItem{}
+	none.Enclosure.URL = "https://mikanani.me/Download/x/file.torrent"
+	none.Link = "https://mikanani.me/Home/Episode/none"
+	assert.Equal(t, "", mikanInfoHash(none), "no 40-hex anywhere → empty")
+}

--- a/go-api/internal/torrents/rss.go
+++ b/go-api/internal/torrents/rss.go
@@ -1,0 +1,159 @@
+// Package torrents — rss.go
+//
+// Shared RSS-2.0 parsing primitives for the enclosure-style feeds
+// (acg.rip / dmhy / Mikan).  acg.rip, dmhy and Mikan all speak the same
+// <rss><channel><item> envelope with a <title> / <link> / <pubDate> /
+// <enclosure> per item; the only thing that differs between them is how
+// the magnet URI is obtained:
+//
+//   - acg.rip : magnet sits directly in <enclosure url="magnet:...">.
+//   - dmhy    : same as acg.rip — magnet directly in the enclosure url
+//     (XML-escaped as &amp; on the wire, auto-decoded by encoding/xml).
+//   - Mikan   : enclosure points at a .torrent file (no magnet); the
+//     40-hex infohash is recovered from the .torrent URL / <link> and a
+//     magnet is synthesised via buildNyaaMagnet (see mikan.go).
+//
+// This file owns the generic envelope (rssFeed / rssItem) plus the two
+// pieces of cross-source logic worth sharing: the HTTP fetch+decode loop
+// (fetchRSS) and the per-item → TorrentItem mapping (mapRSSItems), the
+// latter parametrised by a magnet-resolver so each source plugs in its
+// own "where's the magnet" rule without re-implementing the
+// filter/fansub/date plumbing.
+//
+// acgrip.go is deliberately left on its own decode path so this
+// extraction cannot perturb its existing, separately-tested behaviour —
+// dmhy.go and mikan.go are the consumers here.
+package torrents
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// rssEnclosure mirrors the RSS <enclosure> element.  url carries either
+// the magnet URI directly (acg.rip / dmhy) or an https link to a
+// .torrent file (Mikan); length is the byte count some feeds put here.
+// Both are decoded with XML entities already resolved by encoding/xml,
+// so a wire value of "magnet:?xt=...&amp;dn=..." arrives as a proper
+// "magnet:?xt=...&dn=..." with no manual unescape needed (and none
+// wanted — unescaping again would corrupt a genuinely literal &amp;).
+type rssEnclosure struct {
+	URL    string `xml:"url,attr"`
+	Length string `xml:"length,attr"`
+	Type   string `xml:"type,attr"`
+}
+
+// rssItem is one <item> in a generic RSS-2.0 feed.  Unknown child
+// elements (custom namespaces, per-source extras) are silently ignored
+// by encoding/xml — sources that need a namespaced element (e.g. Mikan's
+// <torrent><contentLength>) embed this struct and add their own fields
+// rather than bloating the shared shape.
+type rssItem struct {
+	Title     string       `xml:"title"`
+	Link      string       `xml:"link"`
+	PubDate   string       `xml:"pubDate"`
+	Enclosure rssEnclosure `xml:"enclosure"`
+}
+
+// rssFeed is the top-level <rss> envelope.  Only <channel><item>
+// elements are decoded; channel metadata is ignored.
+type rssFeed struct {
+	XMLName xml.Name  `xml:"rss"`
+	Items   []rssItem `xml:"channel>item"`
+}
+
+// magnetResolver derives the magnet URI for one parsed RSS item.
+//
+// Returning a non-magnet string (or "") causes mapRSSItems to drop the
+// item via hasMagnetScheme — the same filtering every legacy fetcher
+// applies.  This is the single seam by which each source supplies its
+// own magnet rule:
+//   - dmhy   : return the enclosure url as-is (it's already a magnet).
+//   - Mikan  : recover the infohash from the .torrent url/link and
+//     synthesise a magnet via buildNyaaMagnet.
+type magnetResolver func(item rssItem) string
+
+// sizeResolver derives the human-readable size string for one parsed
+// item.  Sources differ on where the size lives (enclosure @length vs a
+// namespaced element) and what unit it's in, so each supplies its own;
+// returning "" yields an empty Size, matching the legacy fetchers'
+// behaviour when no size is available.
+type sizeResolver func(item rssItem) string
+
+// fetchRSS performs the shared HTTP GET + RSS decode used by the
+// enclosure-style sources.  It mirrors the error contract of the legacy
+// per-source fetchers exactly so partial-failure tolerance in the
+// aggregator is unchanged:
+//   - network/transport error → (nil, wrapped err)
+//   - non-2xx status          → (nil, err carrying the status)
+//   - XML decode failure       → (nil, wrapped xml err)
+//
+// name is the short source tag used only to prefix error messages
+// (e.g. "dmhy", "mikan") so an oncall grep can attribute a failure.
+// The User-Agent header matches the rest of the package for parity in
+// upstream logs.
+func fetchRSS(ctx context.Context, httpClient *http.Client, name, endpoint string) (*rssFeed, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%s: build request: %w", name, err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s: http do: %w", name, err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("%s: upstream status %d", name, res.StatusCode)
+	}
+
+	var feed rssFeed
+	if err := xml.NewDecoder(res.Body).Decode(&feed); err != nil {
+		return nil, fmt.Errorf("%s: decode response: %w", name, err)
+	}
+	return &feed, nil
+}
+
+// mapRSSItems converts parsed RSS items into TorrentItems using the
+// supplied per-source magnet/size resolvers, applying the filtering and
+// field-mapping rules shared by every enclosure-style source:
+//
+//   - drop items with an empty title OR a non-magnet resolved URI
+//     (hasMagnetScheme), exactly as acg.rip / nyaa / garden do;
+//   - fansub via ParseFansub on the title;
+//   - date via stringPtr on <pubDate> (nil → JSON null when absent);
+//   - source stamped from the caller's Source constant.
+//
+// Size comes from the size resolver so each source controls its own unit
+// handling (enclosure @length bytes vs a namespaced contentLength).
+func mapRSSItems(items []rssItem, src Source, magnet magnetResolver, size sizeResolver) []TorrentItem {
+	out := make([]TorrentItem, 0, len(items))
+	for _, it := range items {
+		m := magnet(it)
+		if it.Title == "" || !hasMagnetScheme(m) {
+			continue
+		}
+
+		out = append(out, TorrentItem{
+			Title:  it.Title,
+			Magnet: m,
+			Size:   size(it),
+			Fansub: ParseFansub(it.Title),
+			Date:   stringPtr(it.PubDate),
+			Source: src,
+		})
+	}
+	return out
+}

--- a/go-api/internal/torrents/rss_test.go
+++ b/go-api/internal/torrents/rss_test.go
@@ -1,0 +1,87 @@
+// Package torrents — rss_test.go
+//
+// Direct unit coverage of the shared RSS mapping helper (mapRSSItems) —
+// the filtering + field-mapping seam that dmhy and mikan plug their
+// magnet/size resolvers into.  The HTTP fetch loop (fetchRSS) is covered
+// transitively by the dmhy fixture tests; here we pin the pure mapping
+// rules without any network/XML plumbing.
+package torrents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// identityMagnet returns the enclosure URL verbatim (the dmhy rule),
+// constMagnet/constSize are tiny resolvers for the table cases.
+func identityMagnet(it rssItem) string { return it.Enclosure.URL }
+
+func TestMapRSSItems_FilterAndMapping(t *testing.T) {
+	t.Parallel()
+
+	items := []rssItem{
+		// kept: magnet + title
+		{
+			Title:   "[GroupA] Show - 01",
+			PubDate: "Sat, 01 Jan 2026 00:00:00 GMT",
+			Enclosure: rssEnclosure{
+				URL:    "magnet:?xt=urn:btih:aaa",
+				Length: "1500000000",
+			},
+		},
+		// dropped: non-magnet URL
+		{
+			Title:     "[GroupB] HTTP only",
+			Enclosure: rssEnclosure{URL: "https://example/x.torrent"},
+		},
+		// dropped: empty title even though magnet present
+		{
+			Title:     "",
+			Enclosure: rssEnclosure{URL: "magnet:?xt=urn:btih:bbb"},
+		},
+	}
+
+	out := mapRSSItems(items, SourceDmhy, identityMagnet, func(it rssItem) string {
+		return FormatBytes(it.Enclosure.Length)
+	})
+
+	require.Len(t, out, 1, "only the titled magnet item survives")
+	it := out[0]
+	assert.Equal(t, "[GroupA] Show - 01", it.Title)
+	assert.Equal(t, "magnet:?xt=urn:btih:aaa", it.Magnet)
+	assert.Equal(t, "1.5 GB", it.Size)
+	assert.Equal(t, SourceDmhy, it.Source)
+	require.NotNil(t, it.Fansub)
+	assert.Equal(t, "GroupA", *it.Fansub)
+	require.NotNil(t, it.Date)
+	assert.Equal(t, "Sat, 01 Jan 2026 00:00:00 GMT", *it.Date)
+	assert.Nil(t, it.Provider, "RSS sources never set provider")
+}
+
+// Empty / no-PubDate items must yield a nil Date (JSON null), matching
+// the other fetchers via stringPtr.
+func TestMapRSSItems_MissingDateIsNil(t *testing.T) {
+	t.Parallel()
+
+	items := []rssItem{{
+		Title:     "[G] No date",
+		Enclosure: rssEnclosure{URL: "magnet:?xt=urn:btih:ccc"},
+	}}
+
+	out := mapRSSItems(items, SourceDmhy, identityMagnet, func(rssItem) string { return "" })
+	require.Len(t, out, 1)
+	assert.Nil(t, out[0].Date, "absent pubDate → nil Date")
+	assert.Equal(t, "", out[0].Size)
+}
+
+// An empty input slice yields a non-nil empty slice (never nil), so the
+// aggregator can append unconditionally.
+func TestMapRSSItems_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	out := mapRSSItems(nil, SourceDmhy, identityMagnet, func(rssItem) string { return "" })
+	assert.NotNil(t, out)
+	assert.Empty(t, out)
+}


### PR DESCRIPTION
> **Stacked on #31** (`refactor/torrents-source-registry`) → #30. Sibling of the dedup/rank PR; merges conflict-free (`git merge-tree` exit 0).

## What
Two new magnet sources for better Chinese-sub coverage, registered into the default registry (order `garden→acg→nyaa→dmhy→mikan`):
- **dmhy** (`share.dmhy.org` RSS, `?keyword=`): magnet straight from `<enclosure url="magnet:...">`. An independent copy of the largest CN fansub board (garden already aggregates dmhy, but a direct source survives garden breaking).
- **mikan** (`mikanani.me` RSS, `?searchstr=`): the de-facto CN fansub aggregator. Feed gives a `.torrent` enclosure (no magnet) but the **40-hex infohash is in the `.torrent` URL** — regexed out and turned into a magnet by reusing `buildNyaaMagnet`. No `.torrent` download needed.
- **`rss.go`** (new): shared RSS-2.0 parser (envelope + `fetchRSS` + `mapRSSItems` parametrised by per-source magnet/size resolvers) — dmhy + mikan consume it; `acgrip.go` is left on its own path so acg behavior/tests are provably unperturbed.

## Heads-up for the reviewer (necessary deviation)
The CI/sandbox has live egress and both hosts return real data, so registering them in the default `New()` made existing `torrents.New(...)` tests (that don't stub them) hit the network and break exact-count assertions. To keep the suite **offline + green**, this adds `WithDmhyFn`/`WithMikanFn` option setters (mirroring the existing `WithGardenFn/WithAcgFn/WithNyaaFn` pattern) and a one-line no-op stub in the two test helpers (`newTestAggregator`, `newStubAggregator`). Every existing assertion is preserved verbatim — only the two new live sources are neutralized in tests, exactly as the other three already are.

## Test plan
- [x] `go test -race ./internal/torrents/...` + `./internal/anime/...` green (fixture-based, no network)
- [x] `go vet ./...` + `go build ./...` + gofmt clean
- Covers: dmhy enclosure-magnet parse; mikan `.torrent`-URL → infohash → magnet; non-magnet/missing-field tolerance; default registry order.