### PR TITLE
feat(torrents): add AnimeTosho source (seeders + aid feed)

### DIFF
--- a/go-api/internal/anime/handlers_test.go
+++ b/go-api/internal/anime/handlers_test.go
@@ -870,11 +870,11 @@ func TestWatchers_AnilistIDPassedThrough(t *testing.T) {
 // -----------------------------------------------------------------------------
 
 // newStubAggregator returns a torrents.Aggregator wired with all-static
-// stub fetchers via the test-only With{Garden,Acg,Nyaa,Dmhy,Mikan}Fn
+// stub fetchers via the test-only With{Garden,Acg,Nyaa,Dmhy,Mikan,Tosho}Fn
 // options.  The caller controls garden/acg/nyaa payloads independently;
-// dmhy + mikan (also in the default registry) are stubbed to return
-// nothing so these handler tests stay off the network and assert only on
-// the caller-provided sources.
+// dmhy + mikan + tosho (also in the default registry) are stubbed to
+// return nothing so these handler tests stay off the network and assert
+// only on the caller-provided sources.
 func newStubAggregator(t *testing.T, garden, acg, nyaa []torrents.TorrentItem) *torrents.Aggregator {
 	t.Helper()
 	a, err := torrents.New(
@@ -883,6 +883,7 @@ func newStubAggregator(t *testing.T, garden, acg, nyaa []torrents.TorrentItem) *
 		torrents.WithNyaaFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nyaa, nil }),
 		torrents.WithDmhyFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nil, nil }),
 		torrents.WithMikanFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nil, nil }),
+		torrents.WithToshoFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nil, nil }),
 	)
 	require.NoError(t, err)
 	t.Cleanup(a.Close)

--- a/go-api/internal/torrents/aggregator.go
+++ b/go-api/internal/torrents/aggregator.go
@@ -101,20 +101,21 @@ type Aggregator struct {
 	// it (test-only, so the short-TTL regression test doesn't wait minutes).
 	emptyCacheTTL time.Duration
 
-	// gardenFn / acgFn / nyaaFn / dmhyFn / mikanFn hold the per-source
-	// override stubs set by WithGardenFn / WithAcgFn / WithNyaaFn /
-	// WithDmhyFn / WithMikanFn.  In production New() also fills them with
-	// closures over the real source adapters, then folds them into the
-	// registry — so they double as the resolved fetcher for each built-in
-	// source.  Tests swap them to control fetch behaviour without an
-	// httptest server (and, for dmhy/mikan, to keep the aggregator's own
-	// orchestration tests off the network now that those two are in the
-	// default registry).
+	// gardenFn / acgFn / nyaaFn / dmhyFn / mikanFn / toshoFn hold the
+	// per-source override stubs set by WithGardenFn / WithAcgFn /
+	// WithNyaaFn / WithDmhyFn / WithMikanFn / WithToshoFn.  In production
+	// New() also fills them with closures over the real source adapters,
+	// then folds them into the registry — so they double as the resolved
+	// fetcher for each built-in source.  Tests swap them to control fetch
+	// behaviour without an httptest server (and, for dmhy/mikan/tosho, to
+	// keep the aggregator's own orchestration tests off the network now
+	// that those are in the default registry).
 	gardenFn fetchFn
 	acgFn    fetchFn
 	nyaaFn   fetchFn
 	dmhyFn   fetchFn
 	mikanFn  fetchFn
+	toshoFn  fetchFn
 
 	// ownsCache marks whether New created the cache (and therefore
 	// must Close it on Aggregator teardown) versus the caller
@@ -219,6 +220,17 @@ func WithMikanFn(f fetchFn) Option {
 	}
 }
 
+// WithToshoFn overrides the feed.animetosho.org source with a
+// single-function stub.  Test-only.  See WithGardenFn.  Because tosho is
+// in the default registry, the aggregator's own orchestration tests (and
+// the anime handler tests) use this to keep the tosho slot off the
+// network.
+func WithToshoFn(f fetchFn) Option {
+	return func(a *Aggregator) {
+		a.toshoFn = f
+	}
+}
+
 // New constructs an Aggregator with sensible production defaults:
 //
 //   - 1-hour TTL cache sized to 500 entries
@@ -257,18 +269,22 @@ func New(opts ...Option) (*Aggregator, error) {
 	}
 
 	// Build the default fan-out registry in the canonical merge order:
-	// garden → acg → nyaa → dmhy → mikan.  These are the real source
-	// adapters, binding a.httpClient + a.logger as they stood AFTER
+	// garden → acg → nyaa → dmhy → mikan → tosho.  These are the real
+	// source adapters, binding a.httpClient + a.logger as they stood AFTER
 	// options were applied — so the source structs are the genuine
-	// production path, not dead code.  dmhy + mikan are appended last so
-	// the established garden/acg/nyaa ordering (which several tests assert)
-	// is unchanged; they share the same *http.Client as the others.
+	// production path, not dead code.  dmhy + mikan + tosho are appended
+	// last so the established garden/acg/nyaa ordering (which several tests
+	// assert) is unchanged; they share the same *http.Client as the others.
+	// tosho carries a.logger (like garden) because its JSON fetch emits the
+	// same silent-failure tripwire, and it is the one source advertising
+	// Capable (SupportsSeeders + Priority).
 	a.registry = NewRegistry(
 		gardenSource{client: a.httpClient, logger: a.logger},
 		acgSource{client: a.httpClient},
 		nyaaSource{client: a.httpClient},
 		dmhySource{client: a.httpClient},
 		mikanSource{client: a.httpClient},
+		animeToshoSource{client: a.httpClient, logger: a.logger},
 	)
 
 	// Apply any per-source override stubs (WithGardenFn / WithAcgFn /
@@ -282,6 +298,7 @@ func New(opts ...Option) (*Aggregator, error) {
 	a.nyaaFn = a.resolveSource(SourceNyaa, a.nyaaFn)
 	a.dmhyFn = a.resolveSource(SourceDmhy, a.dmhyFn)
 	a.mikanFn = a.resolveSource(SourceMikan, a.mikanFn)
+	a.toshoFn = a.resolveSource(SourceTosho, a.toshoFn)
 
 	return a, nil
 }

--- a/go-api/internal/torrents/aggregator_test.go
+++ b/go-api/internal/torrents/aggregator_test.go
@@ -33,18 +33,19 @@ import (
 // newTestAggregator constructs an Aggregator with a fast cache and
 // per-test stubs.  Returns the aggregator + a teardown closure.
 //
-// dmhy + mikan are in the default registry (New) but no orchestration
-// test below stubs them, so they would otherwise hit the live network
-// here.  We prepend empty-returning no-op stubs for both BEFORE the
-// caller's opts so every Fetch-driven test stays offline and its
-// garden/acg/nyaa assertions are unchanged; a test that wants to drive
-// dmhy/mikan can still pass its own WithDmhyFn/WithMikanFn after these
-// (later options win).
+// dmhy + mikan + tosho are in the default registry (New) but no
+// orchestration test below stubs them, so they would otherwise hit the
+// live network here.  We prepend empty-returning no-op stubs for all three
+// BEFORE the caller's opts so every Fetch-driven test stays offline and
+// its garden/acg/nyaa assertions are unchanged; a test that wants to drive
+// dmhy/mikan/tosho can still pass its own WithDmhyFn/WithMikanFn/WithToshoFn
+// after these (later options win).
 func newTestAggregator(t *testing.T, opts ...Option) *Aggregator {
 	t.Helper()
 	base := []Option{
 		WithDmhyFn(staticFn(nil, nil)),
 		WithMikanFn(staticFn(nil, nil)),
+		WithToshoFn(staticFn(nil, nil)),
 	}
 	a, err := New(append(base, opts...)...)
 	require.NoError(t, err)

--- a/go-api/internal/torrents/animetosho.go
+++ b/go-api/internal/torrents/animetosho.go
@@ -1,0 +1,280 @@
+// Package torrents — animetosho.go
+//
+// AnimeTosho (feed.animetosho.org) JSON fetcher.  AnimeTosho is a
+// mirror/index that, uniquely among this package's sources, reports a
+// live seeders/leechers count — so it is the one source that can feed the
+// ranker a real "best copy" signal instead of nil.  It also exposes an
+// AniDB-id feed, letting a later handler pull a show's entire release
+// history by ID rather than fuzzy keyword matching.
+//
+// Endpoint shape (JSON, no Cloudflare — HK can dial it directly):
+//
+//	GET https://feed.animetosho.org/json?q=<keyword>&only_tor=1
+//	GET https://feed.animetosho.org/json?aid=<AniDB-id>&only_tor=1
+//
+//	[
+//	  {
+//	    "title": "[SubsPlease] ... (1080p) [HASH].mkv",
+//	    "magnet_uri": "magnet:?xt=urn:btih:...&tr=...",   // ready to use
+//	    "info_hash": "0123...abcdef",
+//	    "seeders": 42,
+//	    "leechers": 3,
+//	    "total_size": 1500000000,                          // bytes
+//	    "timestamp": 1735689600,                           // unix seconds
+//	    "anidb_aid": 17389
+//	  }
+//	]
+//
+// only_tor=1 restricts the feed to torrent rows (the only kind we map).
+//
+// Mapping:
+//   - title    → title
+//   - magnet   → magnet_uri (verbatim; already a usable magnet — rows
+//     without a "magnet:" scheme are dropped, same filter as every source)
+//   - infohash → info_hash
+//   - seeders  → &seeders (the one source that populates this)
+//   - size     → FormatBytes(total_size)   (bytes → "X.X GB")
+//   - date     → RFC3339(timestamp)         (so rank.go's RFC3339 layout
+//     parses it for date ordering; 0 / negative → nil)
+//   - source   → SourceTosho
+//
+// Unlike the RSS scrapes this source DOES implement Capable
+// (SupportsSeeders) and advertises a positive Priority so its
+// seeder-bearing rows win ranker tie-breaks over the seeder-less sources.
+package torrents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SourceTosho is feed.animetosho.org — JSON index that reports seeders
+// and exposes an AniDB-id feed.  Declared here (not types.go) because
+// AnimeTosho is this file's source.
+const SourceTosho Source = "tosho"
+
+// toshoEndpoint is AnimeTosho's JSON feed.  Both the keyword search
+// (?q=) and the AniDB-id feed (?aid=) ride on this path.
+const toshoEndpoint = "https://feed.animetosho.org/json"
+
+// toshoPriority is the ranker Priority AnimeTosho advertises via
+// Capabilities.  It is a modest positive value: every other source in
+// this package advertises 0 (the neutral default), so any positive
+// number makes Tosho's rows win the source tie-break in dedup/rank — the
+// intent being "when the same torrent is surfaced by Tosho and a
+// seeder-less source, prefer the copy that carries a real seeder count".
+const toshoPriority = 10
+
+// animeToshoSource is the Fetcher adapter for feed.animetosho.org.  Thin
+// struct in the gardenSource mould: it binds the shared *http.Client +
+// optional Logger and delegates to FetchAnimeTosho.
+//
+// It carries a logger (like gardenSource, unlike the RSS scrapes) so the
+// JSON silent-failure tripwire (200 OK + zero rows for a non-empty query)
+// is searchable.  It also implements Capable — see Capabilities below.
+type animeToshoSource struct {
+	client *http.Client
+	logger Logger
+}
+
+func (s animeToshoSource) Name() Source { return SourceTosho }
+
+func (s animeToshoSource) Fetch(ctx context.Context, q string) ([]TorrentItem, error) {
+	return FetchAnimeTosho(ctx, s.client, s.logger, q)
+}
+
+// Capabilities advertises that AnimeTosho can populate a seeder count and
+// that its rows should outrank the seeder-less sources on a tie.  This is
+// the only Capable implementation in the package — the RSS scrapes and
+// garden deliberately stay on the zero default.
+func (s animeToshoSource) Capabilities() Capabilities {
+	return Capabilities{
+		SupportsSeeders: true,
+		Priority:        toshoPriority,
+	}
+}
+
+// toshoEntry is the minimal field set decoded from each object in the
+// AnimeTosho JSON array.  Unknown fields are dropped by encoding/json —
+// AnimeTosho carries many more columns we don't need, and new ones must
+// not break the decode.
+type toshoEntry struct {
+	Title     string `json:"title"`
+	MagnetURI string `json:"magnet_uri"`
+	InfoHash  string `json:"info_hash"`
+	Seeders   *int   `json:"seeders"`
+	TotalSize int64  `json:"total_size"`
+	Timestamp int64  `json:"timestamp"`
+	AnidbAID  int    `json:"anidb_aid"`
+}
+
+// FetchAnimeTosho hits AnimeTosho's JSON feed for a keyword search,
+// decodes the array, maps each entry to a TorrentItem, and returns the
+// filtered slice.
+//
+// Error behaviour matches the other fetchers:
+//   - Network / transport error → (nil, err)
+//   - Non-2xx status            → (nil, err) carrying the status
+//   - Decode failure            → (nil, wrapped json error)
+//   - Rows without a magnet: prefix are filtered out (silent drop)
+//
+// Silent-failure tripwire: a 200 with zero mapped rows for a non-empty
+// query is the "tosho quietly broke" signal (schema change, route moved);
+// it is logged via the optional Logger (nil skips logging), mirroring
+// FetchGarden.
+func FetchAnimeTosho(ctx context.Context, httpClient *http.Client, log Logger, q string) ([]TorrentItem, error) {
+	endpoint, err := buildToshoSearchURL(q)
+	if err != nil {
+		return nil, fmt.Errorf("tosho: build url: %w", err)
+	}
+
+	items, err := fetchTosho(ctx, httpClient, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Silent-failure tripwire — same shape as FetchGarden's.
+	if len(items) == 0 && strings.TrimSpace(q) != "" && log != nil {
+		log.Warn("tosho: zero-result for non-empty query", "query", q)
+	}
+
+	return items, nil
+}
+
+// FetchAnimeToshoByAniDB hits AnimeTosho's JSON feed for a show's full
+// AniDB-id feed (?aid=<aid>), decodes the array, and returns the mapped
+// TorrentItems.  This is the ID-keyed counterpart to FetchAnimeTosho's
+// keyword search — a later handler can use it to list a show's entire
+// release history without fuzzy title matching.
+//
+// Exported for that future handler; nothing wires it into the aggregator
+// in this change (the aggregator fan-out is keyword-only).  Error
+// behaviour matches FetchAnimeTosho minus the zero-result tripwire (an
+// empty aid feed is a legitimate "no releases for this id", not a
+// breakage signal).
+func FetchAnimeToshoByAniDB(ctx context.Context, httpClient *http.Client, aid int) ([]TorrentItem, error) {
+	endpoint, err := buildToshoAniDBURL(aid)
+	if err != nil {
+		return nil, fmt.Errorf("tosho: build aid url: %w", err)
+	}
+	return fetchTosho(ctx, httpClient, endpoint)
+}
+
+// fetchTosho performs the shared HTTP GET + JSON decode + mapping for both
+// the keyword and AniDB-id endpoints.  Centralised so the two public entry
+// points share one transport/error path (the only difference between them
+// is the URL and the keyword-only tripwire layered on top by the caller).
+func fetchTosho(ctx context.Context, httpClient *http.Client, endpoint string) ([]TorrentItem, error) {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("tosho: build request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/json")
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("tosho: http do: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("tosho: upstream status %d", res.StatusCode)
+	}
+
+	var entries []toshoEntry
+	if err := json.NewDecoder(res.Body).Decode(&entries); err != nil {
+		return nil, fmt.Errorf("tosho: decode response: %w", err)
+	}
+
+	return mapToshoEntries(entries), nil
+}
+
+// buildToshoSearchURL composes the keyword-search URL: ?q=<q>&only_tor=1.
+// url.Values handles escaping so spaces / brackets / CJK survive intact.
+func buildToshoSearchURL(q string) (string, error) {
+	u, err := url.Parse(toshoEndpoint)
+	if err != nil {
+		return "", err
+	}
+	vals := u.Query()
+	vals.Set("q", q)
+	vals.Set("only_tor", "1")
+	u.RawQuery = vals.Encode()
+	return u.String(), nil
+}
+
+// buildToshoAniDBURL composes the AniDB-id feed URL: ?aid=<aid>&only_tor=1.
+func buildToshoAniDBURL(aid int) (string, error) {
+	u, err := url.Parse(toshoEndpoint)
+	if err != nil {
+		return "", err
+	}
+	vals := u.Query()
+	vals.Set("aid", strconv.Itoa(aid))
+	vals.Set("only_tor", "1")
+	u.RawQuery = vals.Encode()
+	return u.String(), nil
+}
+
+// mapToshoEntries converts decoded AnimeTosho entries into TorrentItems
+// and filters out rows without a usable magnet URI.  Extracted so the
+// field-mapping (especially the seeders + timestamp handling) is unit
+// testable independently of the HTTP plumbing.
+func mapToshoEntries(entries []toshoEntry) []TorrentItem {
+	out := make([]TorrentItem, 0, len(entries))
+	for _, e := range entries {
+		if e.Title == "" || !hasMagnetScheme(e.MagnetURI) {
+			continue
+		}
+
+		out = append(out, TorrentItem{
+			Title:    e.Title,
+			Magnet:   e.MagnetURI,
+			Size:     FormatBytes(strconv.FormatInt(e.TotalSize, 10)),
+			Date:     toshoDate(e.Timestamp),
+			Source:   SourceTosho,
+			Seeders:  copySeeders(e.Seeders),
+			Infohash: strings.ToLower(strings.TrimSpace(e.InfoHash)),
+		})
+	}
+	return out
+}
+
+// toshoDate formats a unix-seconds timestamp as RFC3339 (UTC) so rank.go's
+// RFC3339 layout can parse it for date ordering.  A non-positive timestamp
+// (absent / zero) yields nil → JSON null, matching the "no date" signal the
+// other sources produce via stringPtr("").
+func toshoDate(ts int64) *string {
+	if ts <= 0 {
+		return nil
+	}
+	s := time.Unix(ts, 0).UTC().Format(time.RFC3339)
+	return &s
+}
+
+// copySeeders returns a fresh *int copy of the decoded seeders pointer so
+// the TorrentItem never aliases the decoder's storage.  nil (the source
+// omitted seeders) stays nil — the ranker treats that as "unknown" and
+// sinks it, distinct from a genuine 0.
+func copySeeders(s *int) *int {
+	if s == nil {
+		return nil
+	}
+	v := *s
+	return &v
+}

--- a/go-api/internal/torrents/animetosho_test.go
+++ b/go-api/internal/torrents/animetosho_test.go
@@ -1,0 +1,384 @@
+// Package torrents — animetosho_test.go
+//
+// Covers FetchAnimeTosho / FetchAnimeToshoByAniDB and the mapping:
+//   - happy path: full field mapping incl. seeders, infohash, size from
+//     bytes, and unix timestamp → RFC3339 date
+//   - magnet filter: rows without a "magnet:" magnet_uri (and titleless
+//     rows) are dropped
+//   - schema gaps: entries missing optional fields (seeders absent,
+//     timestamp 0, no info_hash) map without panicking
+//   - aid feed: ?aid=<id> request shape + an empty aid feed → empty slice
+//   - empty array → empty slice, no error; zero-result tripwire fires on a
+//     non-empty keyword query (but NOT on the aid feed)
+//   - error paths: non-2xx, transport error, malformed JSON
+//   - Capable: animeToshoSource advertises SupportsSeeders + a positive
+//     Priority (the only Capable source in the package)
+//
+// Fixtures are small hand-written JSON modelled on real
+// feed.animetosho.org output; nothing here touches the network
+// (newRewriteClient redirects to an httptest server — same trick the other
+// source tests use, and it preserves path + query so we can assert on q /
+// aid / only_tor).
+package torrents
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time: animeToshoSource satisfies Fetcher AND — unlike every other
+// source in the package — Capable.
+var (
+	_ Fetcher = animeToshoSource{}
+	_ Capable = animeToshoSource{}
+)
+
+// ---------------------------------------------------------------------------
+// Capable — tosho is the one source that advertises seeders + priority
+// ---------------------------------------------------------------------------
+
+func TestAnimeToshoSource_ImplementsCapable(t *testing.T) {
+	t.Parallel()
+
+	caps := CapabilitiesOf(animeToshoSource{})
+	assert.True(t, caps.SupportsSeeders, "tosho must advertise SupportsSeeders")
+	assert.Greater(t, caps.Priority, 0, "tosho must advertise a positive Priority so its seeder rows win ties")
+	assert.Equal(t, SourceTosho, animeToshoSource{}.Name())
+}
+
+// ---------------------------------------------------------------------------
+// FetchAnimeTosho — happy path: full field mapping incl. seeders + date
+// ---------------------------------------------------------------------------
+
+func TestFetchAnimeTosho_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	// timestamp 1735689600 == 2025-01-01T00:00:00Z.
+	const body = `[
+	  {
+	    "title": "[SubsPlease] Frieren - 01 (1080p) [ABCD].mkv",
+	    "magnet_uri": "magnet:?xt=urn:btih:AAAA1111&dn=Frieren&tr=udp://tracker.example:80",
+	    "info_hash": "AAAA1111",
+	    "seeders": 42,
+	    "leechers": 3,
+	    "total_size": 1500000000,
+	    "timestamp": 1735689600,
+	    "anidb_aid": 17389
+	  },
+	  {
+	    "title": "[Group] Show - 02",
+	    "magnet_uri": "magnet:?xt=urn:btih:bbbb2222",
+	    "info_hash": "BBBB2222",
+	    "seeders": 0,
+	    "total_size": 0,
+	    "timestamp": 0
+	  }
+	]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "frieren", r.URL.Query().Get("q"))
+		assert.Equal(t, "1", r.URL.Query().Get("only_tor"))
+		assert.Equal(t, "AnimeGo/1.0", r.Header.Get("User-Agent"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchAnimeTosho(context.Background(), httpClient, nil, "frieren")
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+
+	it := items[0]
+	assert.Equal(t, "[SubsPlease] Frieren - 01 (1080p) [ABCD].mkv", it.Title)
+	assert.Equal(t, "magnet:?xt=urn:btih:AAAA1111&dn=Frieren&tr=udp://tracker.example:80", it.Magnet)
+	assert.Equal(t, SourceTosho, it.Source)
+	assert.Equal(t, "1.5 GB", it.Size, "total_size bytes → FormatBytes")
+	assert.Equal(t, "aaaa1111", it.Infohash, "info_hash normalised to lowercase")
+	require.NotNil(t, it.Seeders, "tosho reports seeders")
+	assert.Equal(t, 42, *it.Seeders)
+	require.NotNil(t, it.Date)
+	assert.Equal(t, "2025-01-01T00:00:00Z", *it.Date, "unix timestamp → RFC3339 UTC (parseable by rank.go)")
+	assert.Nil(t, it.Provider, "tosho never sets provider")
+
+	// Second row: seeders 0 is a genuine known-zero (NOT nil), total_size 0
+	// → empty Size, timestamp 0 → nil Date.
+	second := items[1]
+	require.NotNil(t, second.Seeders, `"seeders":0 is a known zero, not unknown`)
+	assert.Equal(t, 0, *second.Seeders)
+	assert.Equal(t, "", second.Size, `total_size 0 → empty Size`)
+	assert.Nil(t, second.Date, "timestamp 0 → nil Date")
+}
+
+// ---------------------------------------------------------------------------
+// FetchAnimeTosho — non-magnet / titleless rows are dropped
+// ---------------------------------------------------------------------------
+
+func TestFetchAnimeTosho_NonMagnetAndTitlelessDropped(t *testing.T) {
+	t.Parallel()
+
+	const body = `[
+	  {
+	    "title": "[X] http link, not a magnet",
+	    "magnet_uri": "https://animetosho.org/view/1",
+	    "info_hash": "1111",
+	    "total_size": 100
+	  },
+	  {
+	    "title": "",
+	    "magnet_uri": "magnet:?xt=urn:btih:2222",
+	    "info_hash": "2222",
+	    "total_size": 100
+	  },
+	  {
+	    "title": "[Y] Valid",
+	    "magnet_uri": "magnet:?xt=urn:btih:3333",
+	    "info_hash": "3333",
+	    "total_size": 100
+	  }
+	]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchAnimeTosho(context.Background(), httpClient, nil, "x")
+	require.NoError(t, err)
+	require.Len(t, items, 1, "only the magnet-bearing item with a title survives")
+	assert.Equal(t, "[Y] Valid", items[0].Title)
+	assert.Equal(t, "magnet:?xt=urn:btih:3333", items[0].Magnet)
+}
+
+// ---------------------------------------------------------------------------
+// FetchAnimeTosho — schema gaps must not panic
+// ---------------------------------------------------------------------------
+
+func TestFetchAnimeTosho_MissingFieldsNoPanic(t *testing.T) {
+	t.Parallel()
+
+	// A row carrying only the two required fields (title + magnet_uri):
+	// seeders absent, no info_hash, no total_size, no timestamp, plus an
+	// unknown extra column the decoder must ignore.
+	const body = `[
+	  {
+	    "title": "[Z] Bare row",
+	    "magnet_uri": "magnet:?xt=urn:btih:cafe",
+	    "some_future_field": {"nested": true}
+	  }
+	]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+
+	var items []TorrentItem
+	var err error
+	require.NotPanics(t, func() {
+		items, err = FetchAnimeTosho(context.Background(), httpClient, nil, "z")
+	}, "missing optional fields must not panic")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+
+	it := items[0]
+	assert.Equal(t, "[Z] Bare row", it.Title)
+	assert.Nil(t, it.Seeders, "absent seeders → nil (unknown), not 0")
+	assert.Equal(t, "", it.Size, "absent total_size → empty Size")
+	assert.Nil(t, it.Date, "absent timestamp → nil Date")
+	assert.Equal(t, "", it.Infohash, "absent info_hash → empty Infohash")
+}
+
+// ---------------------------------------------------------------------------
+// FetchAnimeTosho — empty array + zero-result tripwire
+// ---------------------------------------------------------------------------
+
+func TestFetchAnimeTosho_EmptyArray(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchAnimeTosho(context.Background(), httpClient, nil, "no-results")
+	require.NoError(t, err)
+	assert.Empty(t, items, "empty array produces an empty slice without error")
+}
+
+func TestFetchAnimeTosho_ZeroResultTripwireFires(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	log := &testLogger{}
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchAnimeTosho(context.Background(), httpClient, log, "frieren")
+	require.NoError(t, err)
+	assert.Empty(t, items)
+
+	entry, ok := log.findEntry("zero-result")
+	require.True(t, ok, "a 200 + zero rows for a non-empty query should warn")
+	require.GreaterOrEqual(t, len(entry.args), 2)
+	assert.Equal(t, "query", entry.args[0])
+	assert.Equal(t, "frieren", entry.args[1])
+}
+
+// ---------------------------------------------------------------------------
+// FetchAnimeToshoByAniDB — request shape + empty feed, no tripwire
+// ---------------------------------------------------------------------------
+
+func TestFetchAnimeToshoByAniDB_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	const body = `[
+	  {
+	    "title": "[SubsPlease] Frieren - 03",
+	    "magnet_uri": "magnet:?xt=urn:btih:dead",
+	    "info_hash": "DEAD",
+	    "seeders": 7,
+	    "total_size": 700000000,
+	    "timestamp": 1735689600,
+	    "anidb_aid": 17389
+	  }
+	]`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "17389", r.URL.Query().Get("aid"), "aid feed rides on ?aid=")
+		assert.Equal(t, "1", r.URL.Query().Get("only_tor"))
+		assert.Empty(t, r.URL.Query().Get("q"), "aid feed must not send a keyword")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchAnimeToshoByAniDB(context.Background(), httpClient, 17389)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "[SubsPlease] Frieren - 03", items[0].Title)
+	require.NotNil(t, items[0].Seeders)
+	assert.Equal(t, 7, *items[0].Seeders)
+	assert.Equal(t, SourceTosho, items[0].Source)
+}
+
+func TestFetchAnimeToshoByAniDB_EmptyFeed(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchAnimeToshoByAniDB(context.Background(), httpClient, 999999)
+	require.NoError(t, err)
+	assert.Empty(t, items, "an empty aid feed is a legitimate no-results, not an error")
+}
+
+// ---------------------------------------------------------------------------
+// FetchAnimeTosho — error paths
+// ---------------------------------------------------------------------------
+
+func TestFetchAnimeTosho_Non2xxStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	items, err := FetchAnimeTosho(context.Background(), httpClient, nil, "x")
+	require.Error(t, err)
+	assert.Empty(t, items)
+	assert.Contains(t, err.Error(), "tosho")
+}
+
+func TestFetchAnimeTosho_TransportError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // server gone → dial fails
+
+	httpClient := newRewriteClient(url)
+	items, err := FetchAnimeTosho(context.Background(), httpClient, nil, "x")
+	require.Error(t, err)
+	assert.Empty(t, items)
+}
+
+func TestFetchAnimeTosho_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	defer srv.Close()
+
+	httpClient := newRewriteClient(srv.URL)
+	_, err := FetchAnimeTosho(context.Background(), httpClient, nil, "x")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode")
+}
+
+// ---------------------------------------------------------------------------
+// URL builders — query-param encoding
+// ---------------------------------------------------------------------------
+
+func TestBuildToshoSearchURL_EncodesQuery(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildToshoSearchURL("葬送的 芙莉莲")
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(got, toshoEndpoint+"?"), "endpoint base preserved")
+	assert.Contains(t, got, "only_tor=1", "only_tor flag present")
+	assert.Contains(t, got, "q=", "q param present")
+	assert.NotContains(t, got, "葬送", "CJK must be percent-encoded")
+	assert.NotContains(t, got, " ", "spaces must be percent-encoded")
+}
+
+func TestBuildToshoAniDBURL_EncodesID(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildToshoAniDBURL(17389)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(got, toshoEndpoint+"?"), "endpoint base preserved")
+	assert.Contains(t, got, "aid=17389", "aid param present")
+	assert.Contains(t, got, "only_tor=1", "only_tor flag present")
+	assert.NotContains(t, got, "q=", "aid feed must not carry a keyword param")
+}
+
+// ---------------------------------------------------------------------------
+// toshoDate — unix → RFC3339 / nil for non-positive
+// ---------------------------------------------------------------------------
+
+func TestToshoDate(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, toshoDate(0), "timestamp 0 → nil")
+	assert.Nil(t, toshoDate(-5), "negative timestamp → nil")
+
+	got := toshoDate(1735689600)
+	require.NotNil(t, got)
+	assert.Equal(t, "2025-01-01T00:00:00Z", *got)
+
+	// The formatted date must round-trip through rank.go's parser so date
+	// ordering works for tosho rows.
+	parsed := parseItemDate(got)
+	assert.False(t, parsed.IsZero(), "rank.go must be able to parse the tosho date")
+	assert.Equal(t, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), parsed.UTC())
+}

--- a/go-api/internal/torrents/default_registry_test.go
+++ b/go-api/internal/torrents/default_registry_test.go
@@ -1,9 +1,9 @@
 // Package torrents — default_registry_test.go
 //
-// Locks in the default fan-out registry that New() builds now that dmhy
-// and mikan are registered: the canonical merge order must be
-// garden → acg → nyaa → dmhy → mikan (the first three unchanged so the
-// existing order-sensitive tests keep holding; the two new sources
+// Locks in the default fan-out registry that New() builds now that dmhy,
+// mikan and tosho are registered: the canonical merge order must be
+// garden → acg → nyaa → dmhy → mikan → tosho (the first three unchanged so
+// the existing order-sensitive tests keep holding; the newer sources
 // appended last).  Also verifies the default dmhyFn / mikanFn are wired
 // (non-nil) when no override is supplied, mirroring the gardenFn /
 // acgFn / nyaaFn default-wiring contract.
@@ -30,9 +30,9 @@ func TestNew_DefaultRegistry_OrderAndNewSources(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		[]Source{SourceGarden, SourceAcg, SourceNyaa, SourceDmhy, SourceMikan},
+		[]Source{SourceGarden, SourceAcg, SourceNyaa, SourceDmhy, SourceMikan, SourceTosho},
 		names,
-		"default registry order: garden → acg → nyaa → dmhy → mikan (new sources appended last)",
+		"default registry order: garden → acg → nyaa → dmhy → mikan → tosho (new sources appended last)",
 	)
 }
 
@@ -60,7 +60,8 @@ func TestNew_WithDmhyMikanFn_PreservesPosition(t *testing.T) {
 	t.Cleanup(a.Close)
 
 	got := a.registry.Sources()
-	require.Len(t, got, 5)
+	require.Len(t, got, 6)
 	assert.Equal(t, SourceDmhy, got[3].Name(), "dmhy override keeps position 3")
 	assert.Equal(t, SourceMikan, got[4].Name(), "mikan override keeps position 4")
+	assert.Equal(t, SourceTosho, got[5].Name(), "tosho stays appended at position 5")
 }


### PR DESCRIPTION
> Part of the magnet live-path stack. Base is the integration branch (registry + dedup/seeders + dmhy/mikan + anidb). See the merge runbook in the tracking notes.

## What
Adds **AnimeTosho** (`feed.animetosho.org/json`) as a 6th source — the **only source that carries seeder counts**, so the seeders ranking (from the dedup PR) finally has real data to sort on. Registered last: `garden→acg→nyaa→dmhy→mikan→tosho`.

## Changes
- **`animetosho.go`** (new): `animeToshoSource` implements `Fetcher` + `Capable{SupportsSeeders:true, Priority:10}` (positive priority → its seeded rows win ranker tie-breaks). Maps `magnet_uri`→Magnet, `info_hash`→Infohash, `seeders`→`*int` (0 stays known-zero, absent stays nil), `total_size`→Size, unix `timestamp`→RFC3339 Date (so `rank.go` can parse it).
- Exports **`FetchAnimeToshoByAniDB(ctx, client, aid int)`** (hits `?aid=`) for the upcoming handler aid-feed wiring — not yet called by any handler.
- **`aggregator.go`**: `New()` registers tosho + `toshoFn`/`WithToshoFn` (mirrors dmhy/mikan). `runOne`/`Fetch` untouched.
- Test helpers + `default_registry_test.go` updated for the 6th source.

## Test plan
- [x] `go test -race ./internal/torrents/...` + `./internal/anime/...` green (fixture-based JSON, no network)
- [x] `go vet ./...` + `go build ./...` + gofmt clean
- Covers: field mapping incl. seeders; aid-feed empty → empty; missing fields → no panic; non-magnet rows dropped.