### PR TITLE
feat(torrents): per-source outbound rate limiting

### DIFF
--- a/go-api/internal/torrents/aggregator.go
+++ b/go-api/internal/torrents/aggregator.go
@@ -29,9 +29,11 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
 
 	"github.com/lawrenceli0228/animego/go-api/internal/cache"
 )
@@ -120,6 +122,27 @@ type Aggregator struct {
 	// must Close it on Aggregator teardown) versus the caller
 	// supplying one via WithCache.  Close() consults this flag.
 	ownsCache bool
+
+	// sourceLimiters holds the per-source outbound rate limiter
+	// (*rate.Limiter), keyed by Source.  runOne paces each upstream call
+	// through limiterFor(src).Wait so the fan-out (variant expansion +
+	// concurrent multi-source queries) can't burst a single source hard
+	// enough to earn an IP ban.  See throttle.go.
+	//
+	// Deliberately a sync.Map whose ZERO VALUE is usable: it needs no
+	// initialisation in New(), so this throttle touches only runOne and
+	// this one field — the constructor (and the source registration that
+	// lives there) stays untouched.  Limiters are built lazily on first
+	// request to each source via LoadOrStore (concurrency-safe).
+	sourceLimiters sync.Map
+
+	// sourceRate / sourceBurst are optional per-Aggregator overrides for
+	// the per-source token bucket, set by WithSourceRate.  Zero means
+	// "unset" → limiterFor falls back to defaultSourceRate /
+	// defaultSourceBurst.  Keeping the default in the zero value is what
+	// lets New() stay untouched.
+	sourceRate  rate.Limit
+	sourceBurst int
 }
 
 // Option mutates an Aggregator during construction.  See New().
@@ -421,6 +444,21 @@ func (a *Aggregator) Fetch(ctx context.Context, q string) ([]TorrentItem, error)
 func (a *Aggregator) runOne(parent context.Context, src Fetcher, q string) []TorrentItem {
 	ctx, cancel := context.WithTimeout(parent, perSourceTimeout)
 	defer cancel()
+
+	// Per-source outbound throttle (throttle.go).  Wait blocks until this
+	// source's token bucket admits the request or ctx is done; with the
+	// default burst the first request for a source passes through instantly,
+	// so a single-request-per-source query is never paced — only a burst
+	// past the bucket depth is.  Wait consumes the per-source ctx budget, so
+	// a cancelled/expired ctx makes it return that error; we treat that
+	// exactly like any other source failure (log + empty slice) rather than
+	// letting it panic or propagate.
+	if err := a.limiterFor(src.Name()).Wait(ctx); err != nil {
+		if a.logger != nil {
+			a.logger.Warn("torrents: source rate-limit wait aborted", "source", string(src.Name()), "error", err.Error())
+		}
+		return nil
+	}
 
 	items, err := src.Fetch(ctx, q)
 	if err != nil {

--- a/go-api/internal/torrents/throttle.go
+++ b/go-api/internal/torrents/throttle.go
@@ -1,0 +1,122 @@
+// Package torrents — throttle.go
+//
+// Per-source outbound rate limiting for the fan-out aggregator.
+//
+// Why this exists.  A single user query already fans out one request per
+// registered source (garden / acg / nyaa / dmhy / mikan).  Two forces
+// amplify that fan-out into something an upstream can read as abuse and
+// answer with an IP ban:
+//
+//   - Variant expansion: a query can expand into several title variants,
+//     each issued against every source.
+//   - Multi-source bursts: several concurrent queries land at once and
+//     every source sees the sum of all of them simultaneously.
+//
+// The aggregator's per-source ctx.WithTimeout (perSourceTimeout) bounds
+// how long one request may run, but it does nothing about how MANY
+// requests hit a source per second.  This file adds that missing bound: a
+// token-bucket limiter PER SOURCE, so each upstream sees a smooth,
+// bounded outbound rate regardless of how the fan-out above stacks up.
+//
+// Design mirrors internal/anilist/client.go's throttle (golang.org/x/time/rate
+// token bucket + limiter.Wait(ctx)), with one deliberate difference: the
+// magnet sources are not policed nearly as strictly as AniList's 90 req/min
+// cap, so the default here is looser (a few req/s with a small burst)
+// instead of AniList's 700ms / burst-1.  A single in-flight request per
+// source per query must pass through with ZERO added latency — only
+// genuine bursts are paced.
+//
+// Ownership note: the limiter container is a sync.Map field on Aggregator
+// whose ZERO VALUE is ready to use.  That is intentional — it means New()
+// needs no initialisation for it, so this feature touches only runOne and
+// one struct field, leaving the constructor (and the source registration
+// that happens there) untouched.
+package torrents
+
+import (
+	"golang.org/x/time/rate"
+)
+
+// defaultSourceRate is the steady-state token refill rate applied to EACH
+// source independently.  At ~2 tokens/second a source's bucket replenishes
+// one allowance every 500ms once drained.
+//
+// This is deliberately looser than anilist's 700ms / burst-1: the magnet
+// RSS sources do not advertise (and are not observed to enforce) anything
+// like AniList's documented 90 req/min ceiling, so policing them that
+// tightly would needlessly serialise legitimate variant fan-out.  ~2 req/s
+// still smooths a runaway burst enough to keep us off an upstream's ban
+// radar.  Tunable here, the same way perSourceTimeout lives as a constant.
+const defaultSourceRate rate.Limit = 2
+
+// defaultSourceBurst is the bucket depth — the number of requests a single
+// source will admit instantly before the steady-state rate starts pacing
+// them.  3 is chosen so the common case (one in-flight request per source
+// for a single query, occasionally two or three when a query expands into
+// a couple of title variants) passes through with no added latency, while
+// a sustained flood past the burst is throttled to defaultSourceRate.
+//
+// Burst MUST be >= 1 or NewLimiter would admit nothing and Wait would block
+// forever; limiterFor clamps it defensively.
+const defaultSourceBurst = 3
+
+// limiterFor returns the *rate.Limiter governing outbound requests to src,
+// lazily constructing it on first use and caching it in the Aggregator's
+// sourceLimiters map so every later request to the same source shares one
+// bucket.
+//
+// Concurrency: sourceLimiters is a sync.Map, so concurrent runOne
+// goroutines (the fan-out fires all sources at once) can race to create the
+// same source's limiter safely.  LoadOrStore guarantees exactly one limiter
+// per source wins — a redundant *rate.Limiter built by a losing racer is
+// simply discarded, never observed by Wait.
+//
+// The rate/burst come from the per-Aggregator overrides (sourceRate /
+// sourceBurst) when set via WithSourceRate, else from the package defaults.
+// Reading zero-valued fields here is what lets New() stay untouched: an
+// Aggregator built without WithSourceRate has sourceRate == 0 /
+// sourceBurst == 0 and transparently falls back to the constants below.
+func (a *Aggregator) limiterFor(src Source) *rate.Limiter {
+	if existing, ok := a.sourceLimiters.Load(src); ok {
+		return existing.(*rate.Limiter)
+	}
+
+	r := a.sourceRate
+	if r <= 0 {
+		r = defaultSourceRate
+	}
+	burst := a.sourceBurst
+	if burst < 1 {
+		burst = defaultSourceBurst
+	}
+
+	// LoadOrStore so two goroutines creating the limiter for the same
+	// source converge on a single shared bucket; the loser's freshly-built
+	// limiter is dropped.
+	actual, _ := a.sourceLimiters.LoadOrStore(src, rate.NewLimiter(r, burst))
+	return actual.(*rate.Limiter)
+}
+
+// WithSourceRate overrides the per-source outbound rate limit.  Optional —
+// production runs on the package defaults (defaultSourceRate /
+// defaultSourceBurst).  Provided so the rate can be tuned (e.g. tightened
+// for a flaky upstream) or, in tests, sped up so rate-limit behaviour can be
+// asserted in microseconds instead of the half-second the production rate
+// implies.
+//
+// r is tokens per second (rate.Limit); pass rate.Every(d) at the call site
+// if you prefer to think in intervals.  burst is the bucket depth; values
+// < 1 are clamped up to the default by limiterFor so a misconfigured caller
+// can never deadlock Wait.  A burst of 0 passed here is treated as "unset"
+// and falls back to the default — pass an explicit positive burst to take
+// effect.
+//
+// Mirrors the WithEmptyCacheTTL / WithGardenFn affordance pattern already in
+// this package: it sets struct fields that New() applies through its
+// existing option loop, so the constructor body itself is unchanged.
+func WithSourceRate(r rate.Limit, burst int) Option {
+	return func(a *Aggregator) {
+		a.sourceRate = r
+		a.sourceBurst = burst
+	}
+}

--- a/go-api/internal/torrents/throttle_test.go
+++ b/go-api/internal/torrents/throttle_test.go
@@ -1,0 +1,239 @@
+// Package torrents — throttle_test.go
+//
+// Covers the per-source outbound rate limiter (throttle.go) and the
+// runOne integration points that drive it:
+//
+//   - limiterFor caches one *rate.Limiter per source (same source → same
+//     instance; different sources → independent instances)
+//   - the zero-value sourceLimiters map is usable without New() (the whole
+//     point of the sync.Map design)
+//   - default rate/burst apply when WithSourceRate is unset, and an
+//     out-of-range burst is clamped so Wait can never deadlock
+//   - within the burst, consecutive same-source requests are admitted with
+//     ZERO added latency (a single-request-per-source query is never paced)
+//   - once the burst is drained, further same-source requests are spaced by
+//     the configured interval (the actual throttle)
+//   - different sources throttle independently (draining A doesn't pace B)
+//   - runOne treats a cancelled ctx during Wait as a source failure: empty
+//     slice, no panic, fetcher never invoked, warning logged
+//
+// All timing tests use WithSourceRate with a fast rate so they assert in
+// sub-millisecond windows rather than the half-second the production rate
+// implies — the existing aggregator tests deliberately do NOT touch the
+// limiter and run on the (instant-for-one-request) defaults.
+package torrents
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+)
+
+// ---------------------------------------------------------------------------
+// limiterFor: lazy construction, caching, per-source isolation
+// ---------------------------------------------------------------------------
+
+// A zero-value Aggregator must be enough to hand out limiters — that is the
+// contract that lets New() stay untouched (sync.Map zero value is usable).
+func TestLimiterFor_ZeroValueAggregator_UsableWithoutNew(t *testing.T) {
+	t.Parallel()
+
+	var a Aggregator // no New(), no initialisation
+
+	lim := a.limiterFor(SourceGarden)
+	require.NotNil(t, lim)
+	// Default burst applies → the first request is admitted immediately.
+	assert.True(t, lim.Allow(), "first request within default burst should be admitted")
+}
+
+// Same source → same cached limiter; different sources → different limiters.
+func TestLimiterFor_CachesPerSourceAndIsolates(t *testing.T) {
+	t.Parallel()
+
+	var a Aggregator
+
+	garden1 := a.limiterFor(SourceGarden)
+	garden2 := a.limiterFor(SourceGarden)
+	acg := a.limiterFor(SourceAcg)
+
+	assert.Same(t, garden1, garden2, "same source must return the identical cached *rate.Limiter")
+	assert.NotSame(t, garden1, acg, "different sources must get independent limiters")
+}
+
+// Defaults are applied when WithSourceRate is unset.
+func TestLimiterFor_AppliesDefaults(t *testing.T) {
+	t.Parallel()
+
+	var a Aggregator
+	lim := a.limiterFor(SourceNyaa)
+
+	assert.Equal(t, defaultSourceRate, lim.Limit(), "unset rate should fall back to the package default")
+	assert.Equal(t, defaultSourceBurst, lim.Burst(), "unset burst should fall back to the package default")
+}
+
+// WithSourceRate overrides take effect; an out-of-range burst is clamped up
+// to the default so Wait can never deadlock on a zero/negative bucket.
+func TestLimiterFor_WithSourceRate_OverridesAndClampsBurst(t *testing.T) {
+	t.Parallel()
+
+	t.Run("override applied", func(t *testing.T) {
+		t.Parallel()
+		var a Aggregator
+		WithSourceRate(rate.Limit(50), 7)(&a)
+
+		lim := a.limiterFor(SourceGarden)
+		assert.Equal(t, rate.Limit(50), lim.Limit())
+		assert.Equal(t, 7, lim.Burst())
+	})
+
+	t.Run("non-positive burst clamps to default", func(t *testing.T) {
+		t.Parallel()
+		var a Aggregator
+		WithSourceRate(rate.Limit(50), 0)(&a) // 0 == "unset" → default burst
+
+		lim := a.limiterFor(SourceGarden)
+		assert.Equal(t, defaultSourceBurst, lim.Burst(), "burst<1 must clamp up so NewLimiter admits at least one token")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Throttle behaviour: burst is free, past-burst is paced
+// ---------------------------------------------------------------------------
+
+// Within the burst, consecutive same-source Waits return with ~no latency.
+// This is the guarantee that a single (or low-variant) query is never slowed.
+func TestThrottle_WithinBurst_NoBlocking(t *testing.T) {
+	t.Parallel()
+
+	var a Aggregator
+	// Slow steady-state rate but a burst of 3: the first 3 requests should
+	// still be instant even though the refill is deliberately glacial.
+	WithSourceRate(rate.Every(time.Hour), 3)(&a)
+	lim := a.limiterFor(SourceGarden)
+
+	ctx := context.Background()
+	start := time.Now()
+	for i := 0; i < 3; i++ {
+		require.NoError(t, lim.Wait(ctx))
+	}
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 20*time.Millisecond,
+		"the first burst-worth of requests must pass through with no added latency, got %s", elapsed)
+}
+
+// Once the burst is drained, further same-source requests are spaced by the
+// configured interval — the actual back-pressure that keeps a source off a
+// ban list.  Uses a fast rate (burst 1) so the test asserts in a few ms.
+func TestThrottle_PastBurst_PacedByRate(t *testing.T) {
+	t.Parallel()
+
+	const interval = 5 * time.Millisecond
+	var a Aggregator
+	WithSourceRate(rate.Every(interval), 1)(&a) // burst 1: 2nd request must wait ~interval
+	lim := a.limiterFor(SourceGarden)
+
+	ctx := context.Background()
+
+	start := time.Now()
+	require.NoError(t, lim.Wait(ctx)) // consumes the single burst token instantly
+	firstElapsed := time.Since(start)
+	assert.Less(t, firstElapsed, interval,
+		"first request (burst token) should be instant, got %s", firstElapsed)
+
+	start2 := time.Now()
+	require.NoError(t, lim.Wait(ctx)) // must wait for the bucket to refill
+	secondElapsed := time.Since(start2)
+
+	// Allow scheduler slop on the lower bound (token buckets can release a
+	// hair early); the key assertion is that it was NOT instant.
+	assert.GreaterOrEqual(t, secondElapsed, interval/2,
+		"second request past the burst must be paced by the refill interval, got %s", secondElapsed)
+}
+
+// Draining source A's bucket must not pace source B — the limiters are
+// independent, so a hot upstream can't stall a cold one.
+func TestThrottle_DifferentSourcesIndependent(t *testing.T) {
+	t.Parallel()
+
+	const interval = 50 * time.Millisecond
+	var a Aggregator
+	WithSourceRate(rate.Every(interval), 1)(&a)
+
+	ctx := context.Background()
+
+	// Drain garden's single token.
+	require.NoError(t, a.limiterFor(SourceGarden).Wait(ctx))
+
+	// acg is a different source: its first token is still available, so this
+	// must be instant despite garden being drained.
+	start := time.Now()
+	require.NoError(t, a.limiterFor(SourceAcg).Wait(ctx))
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, interval/2,
+		"a different source must not be paced by a drained one, got %s", elapsed)
+}
+
+// ---------------------------------------------------------------------------
+// runOne integration: cancelled ctx during Wait is handled gracefully
+// ---------------------------------------------------------------------------
+
+// When the limiter Wait sees an already-cancelled ctx it returns an error;
+// runOne must absorb that exactly like any other source failure — empty
+// slice, no panic, the fetcher never runs, and a warning is logged.
+func TestRunOne_WaitCtxCancelled_GracefulEmptyAndLogged(t *testing.T) {
+	t.Parallel()
+
+	log := &testLogger{}
+	// Bare struct is sufficient: runOne only touches a.logger + the limiter
+	// fields, and this keeps the test fully offline (no registry/network).
+	a := &Aggregator{logger: log}
+
+	fetchCalled := false
+	src := newFuncSource(SourceGarden, func(_ context.Context, _ string) ([]TorrentItem, error) {
+		fetchCalled = true
+		return []TorrentItem{stubItem(SourceGarden)}, nil
+	})
+
+	// Cancel before runOne so the very first limiter.Wait returns ctx.Err().
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var out []TorrentItem
+	require.NotPanics(t, func() {
+		out = a.runOne(ctx, src, "naruto")
+	})
+
+	assert.Empty(t, out, "a cancelled Wait must yield an empty result, not a partial/garbage slice")
+	assert.False(t, fetchCalled, "the fetcher must never run once the throttle Wait has failed")
+
+	_, found := log.findEntry("rate-limit wait aborted")
+	assert.True(t, found, "the aborted-Wait warning should be logged for oncall visibility")
+}
+
+// Counterpart to the cancel test: a healthy ctx within the burst lets runOne
+// fetch normally with no throttle-induced delay — proves the happy path the
+// existing aggregator tests rely on is preserved through the new Wait call.
+func TestRunOne_WithinBurst_FetchesWithoutDelay(t *testing.T) {
+	t.Parallel()
+
+	a := &Aggregator{} // no logger needed; default limiter
+
+	src := newFuncSource(SourceGarden, func(_ context.Context, _ string) ([]TorrentItem, error) {
+		return []TorrentItem{stubItem(SourceGarden)}, nil
+	})
+
+	start := time.Now()
+	out := a.runOne(context.Background(), src, "naruto")
+	elapsed := time.Since(start)
+
+	require.Len(t, out, 1)
+	assert.Equal(t, SourceGarden, out[0].Source)
+	assert.Less(t, elapsed, 20*time.Millisecond,
+		"first request within the default burst must not be paced, got %s", elapsed)
+}


### PR DESCRIPTION
> Part of the magnet live-path stack. Base is the integration branch. Independent of the AnimeTosho PR (merges conflict-free, `git merge-tree` exit 0).

## What
Per-source outbound throttle so the title-variant expansion × 6 sources (request fan-out jumps from 3 to up to ~24/query) doesn't get our single egress IP banned by nyaa/acg/dmhy/mikan. Prevents the silent-death failure mode (source bans IP → feature returns empty forever).

## Changes
- **`throttle.go`** (new): `limiterFor(src)` lazily builds + caches a `*rate.Limiter` per source in a `sync.Map` (zero-value-ready, so `New()` is untouched) via `LoadOrStore`. Defaults: `2 req/s`, burst `3` (looser than AniList's 700ms/burst-1 — these RSS sources don't advertise tight caps; burst 3 lets a single query's 1-req-per-source + a few variants pass with zero added latency, sustained floods smooth to 2/s). Optional `WithSourceRate(r, burst)` for tuning/fast tests.
- **`aggregator.go`**: 3 minimal hunks — imports (`sync`, `x/time/rate`), one `sync.Map` field, and `runOne` (`limiterFor(src).Wait(ctx)` before fetch; a Wait error from ctx cancel/expiry is handled like any source failure → log + empty). `New`/`Fetch`/`types.go`/test-helpers untouched.

## Test plan
- [x] `go test -race ./internal/torrents/...` green (existing tests unmodified + not slowed — first per-source request consumes the burst token instantly)
- [x] `go vet ./...` + `go build ./...` + gofmt clean
- `throttle_test.go` (8 tests): per-source caching/isolation, within-burst no-block, past-burst paced, cancelled-ctx Wait → empty/no-panic/logged.