### PR TITLE
feat(torrents): resolve title variants + AniDB feed by anilistId

### DIFF
--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -462,7 +462,7 @@ func main() {
 		r.Get("/seasonal", seasonalSvc.Handler())
 		r.Get("/yearly-top", anime.YearlyTop(q, yearlyTopCache))
 		r.Get("/trending", anime.Trending(q, trendingCache))
-		r.Get("/torrents", anime.Torrents(torrentsAgg))
+		r.Get("/torrents", anime.Torrents(torrentsAgg, q))
 		r.Get("/search", searchSvc.Handler())
 		r.Get("/schedule", scheduleSvc.Handler())
 		r.Get("/{anilistId}/watchers", anime.Watchers(q))

--- a/go-api/internal/anime/handlers.go
+++ b/go-api/internal/anime/handlers.go
@@ -15,12 +15,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/lawrenceli0228/animego/go-api/internal/cache"
@@ -331,28 +334,109 @@ func Watchers(q dbgen.Querier) http.HandlerFunc {
 	}
 }
 
-// Torrents implements GET /api/anime/torrents — 3-source magnet aggregator
-// (animes.garden + acg.rip + nyaa.si) wired into internal/torrents.
-// Replaces anime.controller.js:291-325 — the per-source partial-tolerance
-// + per-query 1h cache live in the aggregator package.
+// maxTorrentVariants caps how many title variants the anilistId path expands
+// into.  An anime has at most four cached titles (romaji / native / english /
+// chinese); even after de-duplication four is the ceiling, but the cap is
+// explicit so a future extra title column can't silently widen the
+// variants × sources fan-out.
+const maxTorrentVariants = 4
+
+// TorrentsDB is the slice of dbgen.Querier the Torrents handler needs —
+// just the by-anilist-id input lookup.  Declared at the use site (small
+// interface) so handler tests can supply a one-method fake without the full
+// Querier surface.
+type TorrentsDB interface {
+	GetTorrentQueryInputsByAnilistID(ctx context.Context, anilistID int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error)
+}
+
+// Torrents implements GET /api/anime/torrents — multi-source magnet
+// aggregator (animes.garden + acg.rip + nyaa.si + dmhy + mikan + AnimeTosho)
+// wired into internal/torrents.  Replaces anime.controller.js:291-325 — the
+// per-source partial-tolerance + per-query 1h cache live in the aggregator
+// package.
+//
+// Two entry points share one response shape:
+//
+//   - ?anilistId=N (primary): resolve the anime's four cached titles into
+//     deduped search variants and, when the id map carries an AniDB id, pull
+//     AnimeTosho's complete aid feed alongside the keyword fan-out.  Server
+//     -side title resolution is what unlocks full coverage — the client no
+//     longer has to guess a single keyword.
+//   - ?q=<keyword> (fallback): the legacy single-keyword fan-out, unchanged.
+//
+// Resolution precedence: anilistId wins when both are present (the richer
+// path).  Neither present → 400.
 //
 // Query parameters:
 //
-//	q  required, 1..200 chars
+//	anilistId  optional; integer AniList id (primary path)
+//	q          optional; 1..200 chars (fallback path)
 //
 // Response envelope:
 //
-//	{"data":[{"title":..., "magnet":..., "size":..., "fansub":..., "date":..., "source":..., "provider":...}, ...]}
-func Torrents(agg *torrents.Aggregator) http.HandlerFunc {
+//	{"data":[{"title":..., "magnet":..., "size":..., "fansub":..., "date":..., "source":..., "seeders":..., "infohash":..., "provider":...}, ...]}
+func Torrents(agg *torrents.Aggregator, db TorrentsDB) http.HandlerFunc {
 	const maxQueryLen = 200
 
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx, cancel := context.WithTimeout(req.Context(), queryTimeout)
 		defer cancel()
 
-		q := req.URL.Query().Get("q")
-		if q == "" {
-			// Express: 'Missing query'
+		qs := req.URL.Query()
+		rawAnilistID := qs.Get("anilistId")
+		q := qs.Get("q")
+
+		var (
+			items []torrents.TorrentItem
+			err   error
+		)
+
+		switch {
+		case rawAnilistID != "":
+			// Primary path: resolve titles + anidb_id by id, then fan out
+			// over the variant set.  An unparseable id is a client error.
+			id, convErr := strconv.Atoi(rawAnilistID)
+			if convErr != nil {
+				httpx.Fail(w, httpx.NewError(
+					http.StatusBadRequest,
+					httpx.CodeValidationError,
+					"无效的番剧 ID",
+				))
+				return
+			}
+
+			row, lookupErr := db.GetTorrentQueryInputsByAnilistID(ctx, int32(id))
+			if lookupErr != nil {
+				if errors.Is(lookupErr, pgx.ErrNoRows) {
+					httpx.Fail(w, httpx.NewError(
+						http.StatusNotFound,
+						httpx.CodeNotFound,
+						"番剧不存在",
+					))
+					return
+				}
+				httpx.Fail(w, httpx.WrapError(lookupErr, http.StatusInternalServerError, httpx.CodeServerError, "query failed"))
+				return
+			}
+
+			variants := buildTorrentVariants(row)
+			items, err = agg.FetchForAnime(ctx, variants, row.AnidbID)
+
+		case q != "":
+			// Fallback path: single-keyword fan-out (legacy behaviour).
+			if len(q) > maxQueryLen {
+				// Express: 'Query too long'
+				httpx.Fail(w, httpx.NewError(
+					http.StatusBadRequest,
+					httpx.CodeValidationError,
+					"Query too long",
+				))
+				return
+			}
+			items, err = agg.Fetch(ctx, q)
+
+		default:
+			// Neither param — Express: 'Missing query'.
 			httpx.Fail(w, httpx.NewError(
 				http.StatusBadRequest,
 				httpx.CodeValidationError,
@@ -360,17 +444,7 @@ func Torrents(agg *torrents.Aggregator) http.HandlerFunc {
 			))
 			return
 		}
-		if len(q) > maxQueryLen {
-			// Express: 'Query too long'
-			httpx.Fail(w, httpx.NewError(
-				http.StatusBadRequest,
-				httpx.CodeValidationError,
-				"Query too long",
-			))
-			return
-		}
 
-		items, err := agg.Fetch(ctx, q)
 		if err != nil {
 			httpx.Fail(w, httpx.WrapError(err, http.StatusInternalServerError, httpx.CodeServerError, "torrents fetch failed"))
 			return
@@ -381,6 +455,47 @@ func Torrents(agg *torrents.Aggregator) http.HandlerFunc {
 
 		httpx.Data(w, http.StatusOK, items)
 	}
+}
+
+// buildTorrentVariants turns an anime's four cached titles into the deduped
+// search-variant set FetchForAnime fans out over.  Rules:
+//
+//   - Only non-nil, non-blank titles contribute (each is trimmed).
+//   - De-duplication is case-insensitive (romaji and english are often the
+//     same string in different cases; native and chinese can coincide for
+//     CJK-original shows) — the FIRST spelling seen is kept so the variant
+//     reads naturally in logs.
+//   - The set is capped at maxTorrentVariants to bound the
+//     variants × sources fan-out.
+//
+// Simplified/traditional Chinese folding is deliberately NOT done here yet
+// (YAGNI — no evidence the upstreams index both forms differently enough to
+// justify the conversion table).  TODO: revisit if zh-Hant titles start
+// missing zh-Hans-indexed releases.
+func buildTorrentVariants(row dbgen.GetTorrentQueryInputsByAnilistIDRow) []string {
+	candidates := []*string{row.TitleRomaji, row.TitleNative, row.TitleEnglish, row.TitleChinese}
+
+	out := make([]string, 0, maxTorrentVariants)
+	seen := make(map[string]struct{}, maxTorrentVariants)
+	for _, c := range candidates {
+		if c == nil {
+			continue
+		}
+		t := strings.TrimSpace(*c)
+		if t == "" {
+			continue
+		}
+		key := strings.ToLower(t)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, t)
+		if len(out) == maxTorrentVariants {
+			break
+		}
+	}
+	return out
 }
 
 // -----------------------------------------------------------------------------

--- a/go-api/internal/anime/handlers_test.go
+++ b/go-api/internal/anime/handlers_test.go
@@ -7,11 +7,15 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -58,6 +62,7 @@ type fakeQuerier struct {
 	getTrendingWithCountsFn func(ctx context.Context, limit int32) ([]dbgen.GetTrendingWithCountsRow, error)
 	getWatchersFn           func(ctx context.Context, id int32, limit int32) ([]dbgen.GetWatchersRow, error)
 	countWatchersFn         func(ctx context.Context, id int32) (int64, error)
+	getTorrentQueryInputsFn func(ctx context.Context, anilistID int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error)
 }
 
 func (f *fakeQuerier) GetCompletedGems(ctx context.Context, limit int32) ([]dbgen.GetCompletedGemsRow, error) {
@@ -107,6 +112,13 @@ func (f *fakeQuerier) CountWatchers(ctx context.Context, id int32) (int64, error
 		return 0, errors.New("fakeQuerier: CountWatchers not set")
 	}
 	return f.countWatchersFn(ctx, id)
+}
+
+func (f *fakeQuerier) GetTorrentQueryInputsByAnilistID(ctx context.Context, anilistID int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error) {
+	if f.getTorrentQueryInputsFn == nil {
+		return dbgen.GetTorrentQueryInputsByAnilistIDRow{}, errors.New("fakeQuerier: GetTorrentQueryInputsByAnilistID not set")
+	}
+	return f.getTorrentQueryInputsFn(ctx, anilistID)
 }
 
 // -----------------------------------------------------------------------------
@@ -895,7 +907,7 @@ func TestTorrents_MissingQuery(t *testing.T) {
 
 	agg := newStubAggregator(t, nil, nil, nil)
 	rec := httptest.NewRecorder()
-	Torrents(agg).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents", nil))
+	Torrents(agg, &fakeQuerier{}).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents", nil))
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, rec.Body.String(), "Missing query")
@@ -909,7 +921,7 @@ func TestTorrents_QueryTooLong(t *testing.T) {
 	rec := httptest.NewRecorder()
 	longQ := strings.Repeat("a", 201)
 	rec = httptest.NewRecorder()
-	Torrents(agg).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?q="+longQ, nil))
+	Torrents(agg, &fakeQuerier{}).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?q="+longQ, nil))
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, rec.Body.String(), "Query too long")
@@ -934,7 +946,7 @@ func TestTorrents_HappyPath(t *testing.T) {
 	)
 
 	rec := httptest.NewRecorder()
-	Torrents(agg).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?q=naruto", nil))
+	Torrents(agg, &fakeQuerier{}).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?q=naruto", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	body := rec.Body.String()
@@ -956,11 +968,236 @@ func TestTorrents_EmptyResults(t *testing.T) {
 
 	agg := newStubAggregator(t, nil, nil, nil)
 	rec := httptest.NewRecorder()
-	Torrents(agg).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?q=zzzz", nil))
+	Torrents(agg, &fakeQuerier{}).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?q=zzzz", nil))
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	// Empty array, not null.
 	assert.Equal(t, `{"data":[]}`, rec.Body.String())
+}
+
+// -----------------------------------------------------------------------------
+// Torrents ?anilistId — server-side variant resolution + AniDB aid feed.
+// -----------------------------------------------------------------------------
+
+// animeRewriteTransport rewrites every outgoing request's scheme+host to the
+// test server while preserving path + query.  Mirrors the torrents package's
+// test-only rewrite trick (which is unexported, so it's re-declared here) so
+// the AnimeTosho aid-feed call — which hits a hard-coded production endpoint —
+// can be redirected at an httptest server and its ?aid= query inspected.
+type animeRewriteTransport struct {
+	target string
+}
+
+func (t animeRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	u, err := url.Parse(t.target)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.Scheme = u.Scheme
+	req.URL.Host = u.Host
+	req.Host = u.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func newRewriteClient(target string) *http.Client {
+	return &http.Client{Transport: animeRewriteTransport{target: target}}
+}
+
+// capturingAggregator returns a torrents.Aggregator whose garden stub records
+// the query string it is called with (one call per variant in the fan-out),
+// plus an httptest server that records whether AnimeTosho's aid feed was
+// requested (and with which aid).  acg / nyaa / dmhy / mikan are stubbed
+// empty so only the garden capture and the aid-feed probe matter.
+//
+// Returns the aggregator, a function yielding the captured variant queries,
+// and a function yielding the aid the feed was requested with (-1 if never).
+func capturingAggregator(t *testing.T) (*torrents.Aggregator, func() []string, func() int) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var seenQueries []string
+	gotAid := -1
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if aid := r.URL.Query().Get("aid"); aid != "" {
+			mu.Lock()
+			if n, err := strconv.Atoi(aid); err == nil {
+				gotAid = n
+			}
+			mu.Unlock()
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	gardenFn := func(_ context.Context, q string) ([]torrents.TorrentItem, error) {
+		mu.Lock()
+		seenQueries = append(seenQueries, q)
+		mu.Unlock()
+		return nil, nil
+	}
+
+	a, err := torrents.New(
+		torrents.WithGardenFn(gardenFn),
+		torrents.WithAcgFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nil, nil }),
+		torrents.WithNyaaFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nil, nil }),
+		torrents.WithDmhyFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nil, nil }),
+		torrents.WithMikanFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nil, nil }),
+		// tosho keyword source stubbed empty; the aid feed (separate code
+		// path) is routed to srv via the rewrite client below.
+		torrents.WithToshoFn(func(_ context.Context, _ string) ([]torrents.TorrentItem, error) { return nil, nil }),
+		torrents.WithHTTPClient(newRewriteClient(srv.URL)),
+	)
+	require.NoError(t, err)
+	t.Cleanup(a.Close)
+
+	queries := func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]string, len(seenQueries))
+		copy(out, seenQueries)
+		return out
+	}
+	aid := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return gotAid
+	}
+	return a, queries, aid
+}
+
+func strptr(s string) *string { return &s }
+
+func TestTorrents_ByAnilistID_ResolvesVariantsAndAidFeed(t *testing.T) {
+	t.Parallel()
+
+	anidb := int32(17389)
+	q := &fakeQuerier{
+		getTorrentQueryInputsFn: func(_ context.Context, id int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error) {
+			assert.Equal(t, int32(21), id, "anilistId path-parsed and passed to the lookup")
+			return dbgen.GetTorrentQueryInputsByAnilistIDRow{
+				TitleRomaji:  strptr("One Piece"),
+				TitleNative:  strptr("ワンピース"),
+				TitleEnglish: strptr("One Piece"), // dup of romaji (case-equal) → folded out
+				TitleChinese: strptr("海贼王"),
+				AnidbID:      &anidb,
+			}, nil
+		},
+	}
+
+	agg, queries, aidSeen := capturingAggregator(t)
+	rec := httptest.NewRecorder()
+	Torrents(agg, q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?anilistId=21", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, `{"data":[]}`, rec.Body.String(), "all sources empty → empty envelope")
+
+	// Variants: romaji + native + chinese (english deduped against romaji).
+	got := queries()
+	assert.ElementsMatch(t, []string{"One Piece", "ワンピース", "海贼王"}, got,
+		"each distinct title fans out once; the case-equal english dup is folded")
+	assert.Len(t, got, 3, "exactly three distinct variants (no dup)")
+
+	assert.Equal(t, 17389, aidSeen(), "anidb_id resolved → AnimeTosho aid feed requested")
+}
+
+func TestTorrents_ByAnilistID_NoAnidb_DegradesNoFeed(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		getTorrentQueryInputsFn: func(_ context.Context, _ int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error) {
+			return dbgen.GetTorrentQueryInputsByAnilistIDRow{
+				TitleRomaji: strptr("Bleach"),
+				AnidbID:     nil, // not in id map / no anidb id
+			}, nil
+		},
+	}
+
+	agg, queries, aidSeen := capturingAggregator(t)
+	rec := httptest.NewRecorder()
+	Torrents(agg, q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?anilistId=99", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"Bleach"}, queries(), "single title → single variant fan-out")
+	assert.Equal(t, -1, aidSeen(), "nil anidb_id → no aid feed requested (degrade to keyword-only)")
+}
+
+func TestTorrents_ByAnilistID_NotFound_404(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		getTorrentQueryInputsFn: func(_ context.Context, _ int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error) {
+			return dbgen.GetTorrentQueryInputsByAnilistIDRow{}, pgx.ErrNoRows
+		},
+	}
+
+	agg := newStubAggregator(t, nil, nil, nil)
+	rec := httptest.NewRecorder()
+	Torrents(agg, q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?anilistId=404404", nil))
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), `"NOT_FOUND"`)
+	require.Contains(t, rec.Body.String(), "番剧不存在")
+}
+
+func TestTorrents_ByAnilistID_Invalid_400(t *testing.T) {
+	t.Parallel()
+
+	// DB must never be consulted for an unparseable id.
+	q := &fakeQuerier{
+		getTorrentQueryInputsFn: func(_ context.Context, _ int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error) {
+			t.Fatal("lookup must not run for an invalid anilistId")
+			return dbgen.GetTorrentQueryInputsByAnilistIDRow{}, nil
+		},
+	}
+
+	agg := newStubAggregator(t, nil, nil, nil)
+	rec := httptest.NewRecorder()
+	Torrents(agg, q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?anilistId=abc", nil))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), `"VALIDATION_ERROR"`)
+	require.Contains(t, rec.Body.String(), "无效的番剧 ID")
+}
+
+func TestTorrents_ByAnilistID_DBError_500(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		getTorrentQueryInputsFn: func(_ context.Context, _ int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error) {
+			return dbgen.GetTorrentQueryInputsByAnilistIDRow{}, errors.New("simulated postgres failure")
+		},
+	}
+
+	agg := newStubAggregator(t, nil, nil, nil)
+	rec := httptest.NewRecorder()
+	Torrents(agg, q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?anilistId=21", nil))
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Contains(t, rec.Body.String(), `"SERVER_ERROR"`)
+	require.NotContains(t, rec.Body.String(), "simulated postgres failure", "body must not leak cause")
+}
+
+// anilistId takes precedence over q when both are present (the richer path).
+func TestTorrents_AnilistIDWinsOverQ(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	q := &fakeQuerier{
+		getTorrentQueryInputsFn: func(_ context.Context, id int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error) {
+			called = true
+			assert.Equal(t, int32(21), id)
+			return dbgen.GetTorrentQueryInputsByAnilistIDRow{TitleRomaji: strptr("Resolved")}, nil
+		},
+	}
+
+	agg, queries, _ := capturingAggregator(t)
+	rec := httptest.NewRecorder()
+	Torrents(agg, q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/torrents?anilistId=21&q=ignored", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, called, "anilistId path runs even when q is also present")
+	assert.Equal(t, []string{"Resolved"}, queries(), "the resolved title is used, not the raw q")
 }
 
 // -----------------------------------------------------------------------------

--- a/go-api/internal/db/gen/anime_cache.sql.go
+++ b/go-api/internal/db/gen/anime_cache.sql.go
@@ -896,6 +896,48 @@ func (q *Queries) GetTitleChineseByAnilistIDs(ctx context.Context, dollar_1 []in
 	return items, nil
 }
 
+const getTorrentQueryInputsByAnilistID = `-- name: GetTorrentQueryInputsByAnilistID :one
+SELECT
+    a.title_romaji,
+    a.title_native,
+    a.title_english,
+    a.title_chinese,
+    m.anidb_id
+FROM anime_cache a
+LEFT JOIN bgm_id_map m ON m.anilist_id = a.anilist_id
+WHERE a.anilist_id = $1
+`
+
+type GetTorrentQueryInputsByAnilistIDRow struct {
+	TitleRomaji  *string `json:"titleRomaji"`
+	TitleNative  *string `json:"titleNative"`
+	TitleEnglish *string `json:"titleEnglish"`
+	TitleChinese *string `json:"titleChinese"`
+	AnidbID      *int32  `json:"anidbId"`
+}
+
+// Resolves the inputs the magnet aggregator needs to search by AniList id
+// instead of a raw keyword.  Backs the /api/anime/torrents?anilistId=N path:
+// the handler turns the four titles into deduped search variants and uses
+// anidb_id (when present) to pull AnimeTosho's complete aid feed.
+//
+// LEFT JOIN bgm_id_map so a row missing from the id map (or with a NULL
+// anidb_id) still returns its titles — anidb_id comes back NULL and the
+// handler degrades to keyword-only (no aid feed).  pgx.ErrNoRows means "no
+// such anime cached" → handler 404s.
+func (q *Queries) GetTorrentQueryInputsByAnilistID(ctx context.Context, anilistID int32) (GetTorrentQueryInputsByAnilistIDRow, error) {
+	row := q.db.QueryRow(ctx, getTorrentQueryInputsByAnilistID, anilistID)
+	var i GetTorrentQueryInputsByAnilistIDRow
+	err := row.Scan(
+		&i.TitleRomaji,
+		&i.TitleNative,
+		&i.TitleEnglish,
+		&i.TitleChinese,
+		&i.AnidbID,
+	)
+	return i, err
+}
+
 const getTrendingWithCounts = `-- name: GetTrendingWithCounts :many
 SELECT
     a.anilist_id,

--- a/go-api/internal/db/gen/querier.go
+++ b/go-api/internal/db/gen/querier.go
@@ -259,6 +259,16 @@ type Querier interface {
 	// schedule items need.  bangumi_version is included so the caller can
 	// decide whether to enqueue v1 enrichment for unenriched entries.
 	GetTitleChineseByAnilistIDs(ctx context.Context, dollar_1 []int32) ([]GetTitleChineseByAnilistIDsRow, error)
+	// Resolves the inputs the magnet aggregator needs to search by AniList id
+	// instead of a raw keyword.  Backs the /api/anime/torrents?anilistId=N path:
+	// the handler turns the four titles into deduped search variants and uses
+	// anidb_id (when present) to pull AnimeTosho's complete aid feed.
+	//
+	// LEFT JOIN bgm_id_map so a row missing from the id map (or with a NULL
+	// anidb_id) still returns its titles — anidb_id comes back NULL and the
+	// handler degrades to keyword-only (no aid feed).  pgx.ErrNoRows means "no
+	// such anime cached" → handler 404s.
+	GetTorrentQueryInputsByAnilistID(ctx context.Context, anilistID int32) (GetTorrentQueryInputsByAnilistIDRow, error)
 	// Most-subscribed anime with their cached metadata, ordered by watcher
 	// count desc.  Backs /api/anime/trending and replaces the
 	// Subscription.aggregate + AnimeCache.find round-trip in

--- a/go-api/internal/db/queries/anime_cache.sql
+++ b/go-api/internal/db/queries/anime_cache.sql
@@ -269,6 +269,26 @@ SELECT anilist_id, title_chinese, bangumi_version
 FROM anime_cache
 WHERE anilist_id = ANY($1::int[]);
 
+-- name: GetTorrentQueryInputsByAnilistID :one
+-- Resolves the inputs the magnet aggregator needs to search by AniList id
+-- instead of a raw keyword.  Backs the /api/anime/torrents?anilistId=N path:
+-- the handler turns the four titles into deduped search variants and uses
+-- anidb_id (when present) to pull AnimeTosho's complete aid feed.
+--
+-- LEFT JOIN bgm_id_map so a row missing from the id map (or with a NULL
+-- anidb_id) still returns its titles — anidb_id comes back NULL and the
+-- handler degrades to keyword-only (no aid feed).  pgx.ErrNoRows means "no
+-- such anime cached" → handler 404s.
+SELECT
+    a.title_romaji,
+    a.title_native,
+    a.title_english,
+    a.title_chinese,
+    m.anidb_id
+FROM anime_cache a
+LEFT JOIN bgm_id_map m ON m.anilist_id = a.anilist_id
+WHERE a.anilist_id = $1;
+
 -- name: GetAnimeForBangumiSearch :one
 -- Phase 1 worker uses titleNative (primary) → titleRomaji (fallback) as
 -- the keyword for Bangumi search.  Mirrors anilist.service.js V1

--- a/go-api/internal/torrents/aggregator.go
+++ b/go-api/internal/torrents/aggregator.go
@@ -28,6 +28,8 @@ package torrents
 import (
 	"context"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -392,6 +394,120 @@ func (a *Aggregator) Fetch(ctx context.Context, q string) ([]TorrentItem, error)
 		return cached, nil
 	}
 
+	merged, err := a.fanOut(ctx, q)
+	if err != nil {
+		// fanOut only surfaces an error when the parent ctx was cancelled
+		// before any goroutine completed (runOne never returns non-nil).
+		// Propagate as-is.
+		return nil, err
+	}
+
+	// Normalise → dedup → rank → cache.  Shared with FetchForAnime so the
+	// single-query and multi-variant paths collapse duplicates and apply the
+	// quality-aware TTL identically.
+	merged = a.finalise(merged)
+	a.cacheResult(key, merged)
+
+	return merged, nil
+}
+
+// FetchForAnime is the id-keyed counterpart to Fetch: instead of a single
+// caller-supplied keyword it runs the registry fan-out once PER title
+// variant and, when anidbID is non-nil, folds in AnimeTosho's complete
+// AniDB-id feed (?aid=).  The combined rows are deduped (by infohash, so
+// the inevitable overlap between AnimeTosho's keyword hits and its aid
+// feed collapses harmlessly) and ranked by seeders exactly like Fetch.
+//
+// Behaviour:
+//
+//  1. Variants are trimmed of surrounding whitespace and empties dropped.
+//     With no usable variant AND no anidbID there is nothing to search →
+//     return [] immediately (no upstream calls, no cache).
+//  2. Cache key is the sorted-join of the cleaned variant set plus the
+//     optional aid, so a show whose four titles produce the same variant
+//     set shares ONE cache entry rather than caching each variant
+//     separately.  A hit returns the cached slice as-is.
+//  3. Cache miss → fan out the registry over every variant concurrently
+//     (errgroup), plus one AnimeTosho aid-feed call when anidbID != nil.
+//     Per-variant / per-source failures are absorbed exactly as in Fetch
+//     (logged, treated as empty) — only a parent-ctx cancellation surfaces
+//     as a top-level error.
+//  4. Merge → dedup → rank → cache, sharing finalise + cacheResult with
+//     Fetch (same quality-aware TTL: long for a non-empty result, short
+//     for an all-source miss).
+//
+// The per-source outbound throttle (runOne → limiterFor) still paces each
+// upstream, so even though this issues variants × sources requests the
+// token buckets keep any single source's outbound rate bounded.
+func (a *Aggregator) FetchForAnime(ctx context.Context, variants []string, anidbID *int32) ([]TorrentItem, error) {
+	clean := cleanVariants(variants)
+	if len(clean) == 0 && anidbID == nil {
+		// Nothing to search on — neither a keyword variant nor an aid feed.
+		return []TorrentItem{}, nil
+	}
+
+	key := animeCacheKey(clean, anidbID)
+	if cached, hit := a.cache.Get(key); hit {
+		return cached, nil
+	}
+
+	// Collect every variant's fan-out result plus the optional aid feed into
+	// position-indexed slots so the merge order is deterministic regardless
+	// of which goroutine finishes first: variants in their (cleaned) order,
+	// then the aid feed last.
+	results := make([][]TorrentItem, len(clean)+1)
+
+	g, gctx := errgroup.WithContext(ctx)
+	for i, v := range clean {
+		i, v := i, v
+		g.Go(func() error {
+			items, err := a.fanOut(gctx, v)
+			if err != nil {
+				return err
+			}
+			results[i] = items
+			return nil
+		})
+	}
+	if anidbID != nil {
+		aid := int(*anidbID)
+		g.Go(func() error {
+			results[len(clean)] = a.runToshoAniDB(gctx, aid)
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		// Only a parent-ctx cancellation reaches here (fanOut/runToshoAniDB
+		// absorb per-source failures).  Propagate as-is.
+		return nil, err
+	}
+
+	total := 0
+	for _, r := range results {
+		total += len(r)
+	}
+	merged := make([]TorrentItem, 0, total)
+	for _, r := range results {
+		merged = append(merged, r...)
+	}
+
+	merged = a.finalise(merged)
+	a.cacheResult(key, merged)
+
+	return merged, nil
+}
+
+// fanOut runs the registry fan-out for a SINGLE query q: one goroutine per
+// registered source (errgroup, per-source 8s timeout + partial-failure
+// tolerance via runOne), merged in registration order.  It does NOT dedup,
+// rank, or cache — the callers (Fetch for one query, FetchForAnime for many
+// variants) own that so a multi-variant result is deduped across variants
+// rather than within each.
+//
+// Returns (nil, ctx.Err()) only when the caller's context is cancelled
+// before any goroutine completes — per-source failures are never errors.
+func (a *Aggregator) fanOut(ctx context.Context, q string) ([]TorrentItem, error) {
 	sources := a.registry.Sources()
 
 	// errgroup.WithContext gives each goroutine a derived context that
@@ -428,28 +544,64 @@ func (a *Aggregator) Fetch(ctx context.Context, q string) ([]TorrentItem, error)
 	for _, r := range results {
 		merged = append(merged, r...)
 	}
+	return merged, nil
+}
 
-	// Normalise → dedup → rank, in that order, before caching.  parseInfohash
-	// runs off each row's magnet (source-agnostic), so the same torrent
-	// surfaced by two sources collapses to a single best copy, and the
-	// survivors come back ordered by seeders (nil sinks last) → date → source
-	// priority.  ranks is derived from the registry once and threaded through
-	// both passes so the per-source tie-break is consistent.  All three
-	// helpers return fresh slices (immutability), so `merged` is never
-	// mutated in place.
+// finalise runs the normalise → dedup → rank pipeline over a merged,
+// multi-source (and, for FetchForAnime, multi-variant) slice before it is
+// cached/returned.  parseInfohash runs off each row's magnet
+// (source-agnostic), so the same torrent surfaced by two sources — or by
+// AnimeTosho's keyword search and its aid feed — collapses to a single best
+// copy, and the survivors come back ordered by seeders (nil sinks last) →
+// date → source priority.  ranks is derived from the registry once and
+// threaded through both passes so the per-source tie-break is consistent.
+// Both helpers return fresh slices (immutability), so the input is never
+// mutated in place.
+func (a *Aggregator) finalise(merged []TorrentItem) []TorrentItem {
 	ranks := sourceRanks(a.registry)
-	merged = rankItems(dedupByInfohash(merged, ranks), ranks)
+	return rankItems(dedupByInfohash(merged, ranks), ranks)
+}
 
-	// Quality-aware TTL: a non-empty result is stable for the full hour;
-	// an empty one (every source missed) is cached only briefly so a
-	// transient upstream blip doesn't pin the query empty for an hour.
+// cacheResult writes a finalised slice under key with the quality-aware
+// TTL: a non-empty result is stable for the full hour; an empty one (every
+// source missed) is cached only briefly (emptyCacheTTL) so a transient
+// upstream blip doesn't pin the query empty for an hour.  Shared by Fetch
+// and FetchForAnime so both paths cache identically.
+func (a *Aggregator) cacheResult(key string, merged []TorrentItem) {
 	if len(merged) > 0 {
 		a.cache.Set(key, merged)
 	} else {
 		a.cache.SetWithTTL(key, merged, a.emptyCacheTTL)
 	}
+}
 
-	return merged, nil
+// runToshoAniDB wraps the AnimeTosho aid-feed fetch (FetchAnimeToshoByAniDB)
+// with the same per-source timeout + partial-failure tripwire runOne applies
+// to a registry source.  It is NOT a registry Fetcher (the aid feed is keyed
+// by an integer id, not the query string the Fetcher interface carries), so
+// it gets its own thin wrapper here that mirrors runOne's contract: always
+// return a non-nil-safe slice (empty on failure) and never panic.  The
+// throttle uses SourceTosho's bucket so the aid feed shares the keyword
+// source's outbound rate budget.
+func (a *Aggregator) runToshoAniDB(parent context.Context, aid int) []TorrentItem {
+	ctx, cancel := context.WithTimeout(parent, perSourceTimeout)
+	defer cancel()
+
+	if err := a.limiterFor(SourceTosho).Wait(ctx); err != nil {
+		if a.logger != nil {
+			a.logger.Warn("torrents: tosho aid-feed rate-limit wait aborted", "aid", aid, "error", err.Error())
+		}
+		return nil
+	}
+
+	items, err := FetchAnimeToshoByAniDB(ctx, a.httpClient, aid)
+	if err != nil {
+		if a.logger != nil {
+			a.logger.Warn("torrents: tosho aid-feed failed", "aid", aid, "error", err.Error())
+		}
+		return nil
+	}
+	return items
 }
 
 // runOne wraps a single Fetcher with the per-source 8s timeout and the
@@ -485,4 +637,44 @@ func (a *Aggregator) runOne(parent context.Context, src Fetcher, q string) []Tor
 		return nil
 	}
 	return items
+}
+
+// cleanVariants trims surrounding whitespace from each variant and drops
+// empties, preserving input order.  Case-insensitive de-duplication is the
+// handler's job (it builds the variant set from the four titles and caps it
+// at 4 before calling FetchForAnime); this is the defensive
+// trim-and-drop-empty pass so a stray "" or "  " variant never issues a
+// pointless fan-out.  Returns a fresh slice; the input is not mutated.
+func cleanVariants(variants []string) []string {
+	out := make([]string, 0, len(variants))
+	for _, v := range variants {
+		if t := strings.TrimSpace(v); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// animeCacheKey builds the FetchForAnime cache key from a cleaned variant
+// set plus the optional AniDB id.  The variants are lower-cased and SORTED
+// before joining so a show whose titles arrive in any order — or whose
+// variant set is identical to another request's — collapses to ONE cache
+// entry rather than caching per variant or per ordering.  The aid (when
+// present) is appended so a keyword-only request and an aid-augmented one
+// for the same titles don't collide (the aid feed can add rows the keyword
+// search misses).  A leading marker namespaces these keys away from Fetch's
+// single-query keys so a one-keyword Fetch and a single-variant
+// FetchForAnime never alias.
+func animeCacheKey(clean []string, anidbID *int32) string {
+	lowered := make([]string, len(clean))
+	for i, v := range clean {
+		lowered[i] = strings.ToLower(v)
+	}
+	sort.Strings(lowered)
+
+	key := "anime:" + strings.Join(lowered, "\x00")
+	if anidbID != nil {
+		key += "|aid=" + strconv.Itoa(int(*anidbID))
+	}
+	return key
 }

--- a/go-api/internal/torrents/aggregator_foranime_test.go
+++ b/go-api/internal/torrents/aggregator_foranime_test.go
@@ -1,0 +1,351 @@
+// Package torrents — aggregator_foranime_test.go
+//
+// Covers FetchForAnime, the id-keyed counterpart to Fetch:
+//   - variant fan-out: each cleaned variant runs the registry fan-out once,
+//     so an N-variant call invokes every source N times
+//   - cross-variant dedup: the same infohash surfaced under two variants
+//     collapses to a single row
+//   - AniDB aid feed: a non-nil anidbID folds AnimeTosho's ?aid= feed into
+//     the result (and overlap with a keyword hit dedups by infohash)
+//   - shared cache: a second call with the same variant set (in any order)
+//     is served from cache — the fetchers do NOT re-run, and a one-keyword
+//     Fetch never aliases a single-variant FetchForAnime
+//   - degrade paths: nil anidbID issues no aid feed; an empty variant set
+//     with no aid short-circuits to [] with zero upstream calls
+//   - empty-result short TTL still applies via the shared cacheResult path
+//
+// Registry sources are stubbed via the existing WithXxxFn options; the aid
+// feed (FetchAnimeToshoByAniDB, not a registry Fetcher) is exercised through
+// an injected rewrite client pointed at an httptest server.
+package torrents
+
+import (
+	"context"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// magnetWith builds a magnet carrying a valid 40-hex v1 infohash derived
+// from an arbitrary seed string.  The seed is hex-encoded (so any input
+// yields valid hex digits, unlike pasting the seed in raw) and then padded /
+// truncated to exactly 40 chars so parseInfohash accepts it.  Equal seeds
+// produce equal hashes → drives cross-source / cross-variant dedup
+// deterministically.
+func magnetWith(seed string) string {
+	h := hex.EncodeToString([]byte(seed))
+	for len(h) < hexLenV1 {
+		h += "0"
+	}
+	return "magnet:?xt=urn:btih:" + h[:hexLenV1]
+}
+
+// itemWithHash builds a single TorrentItem for src whose magnet carries the
+// infohash derived from seed.
+func itemWithHash(src Source, seed string) TorrentItem {
+	return TorrentItem{
+		Title:  "stub-" + string(src) + "-" + seed,
+		Magnet: magnetWith(seed),
+		Size:   "1 GB",
+		Source: src,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Variant fan-out: each variant runs the registry once
+// ---------------------------------------------------------------------------
+
+func TestFetchForAnime_VariantFanOut_RunsEachSourcePerVariant(t *testing.T) {
+	t.Parallel()
+
+	var gc, ac, nc atomic.Int32
+	// Each source returns a unique infohash per call so nothing dedups —
+	// we only want to count fan-out invocations and total rows here.
+	var seq atomic.Int32
+	uniqueFn := func(src Source, counter *atomic.Int32) fetchFn {
+		return func(_ context.Context, _ string) ([]TorrentItem, error) {
+			counter.Add(1)
+			n := seq.Add(1)
+			return []TorrentItem{itemWithHash(src, string(rune('a'+byte(n%26)))+string(rune('a'+byte(n/26))))}, nil
+		}
+	}
+
+	a := newTestAggregator(t,
+		WithGardenFn(uniqueFn(SourceGarden, &gc)),
+		WithAcgFn(uniqueFn(SourceAcg, &ac)),
+		WithNyaaFn(uniqueFn(SourceNyaa, &nc)),
+	)
+
+	out, err := a.FetchForAnime(context.Background(), []string{"Naruto", "ナルト"}, nil)
+	require.NoError(t, err)
+
+	// 3 stubbed sources × 2 variants = 6 invocations, 6 rows (all unique).
+	assert.Equal(t, int32(2), gc.Load(), "garden runs once per variant")
+	assert.Equal(t, int32(2), ac.Load(), "acg runs once per variant")
+	assert.Equal(t, int32(2), nc.Load(), "nyaa runs once per variant")
+	assert.Len(t, out, 6, "all six unique rows survive (no dedup)")
+}
+
+// ---------------------------------------------------------------------------
+// Cross-variant dedup: same infohash under two variants → one row
+// ---------------------------------------------------------------------------
+
+func TestFetchForAnime_DedupsAcrossVariants(t *testing.T) {
+	t.Parallel()
+
+	// garden returns the SAME infohash regardless of the variant it is
+	// queried with, so the two variant fan-outs surface a duplicate that
+	// must collapse to a single row.
+	shared := itemWithHash(SourceGarden, "dupe")
+	a := newTestAggregator(t,
+		WithGardenFn(func(_ context.Context, _ string) ([]TorrentItem, error) {
+			return []TorrentItem{shared}, nil
+		}),
+		WithAcgFn(staticFn(nil, nil)),
+		WithNyaaFn(staticFn(nil, nil)),
+	)
+
+	out, err := a.FetchForAnime(context.Background(), []string{"title-a", "title-b"}, nil)
+	require.NoError(t, err)
+	require.Len(t, out, 1, "the same infohash under two variants dedups to one row")
+	assert.Equal(t, parseInfohash(shared.Magnet), out[0].Infohash, "survivor carries the normalised infohash")
+}
+
+// ---------------------------------------------------------------------------
+// AniDB aid feed: non-nil anidbID folds in AnimeTosho's ?aid= feed
+// ---------------------------------------------------------------------------
+
+func TestFetchForAnime_FoldsInAniDBFeed(t *testing.T) {
+	t.Parallel()
+
+	var sawAid atomic.Bool
+	// httptest server returns one aid-feed row carrying seeders so we can
+	// also confirm the row survives the ranker.  It only answers when the
+	// request actually carried ?aid=<id>.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("aid") == "17389" {
+			sawAid.Store(true)
+			_, _ = w.Write([]byte(`[{"title":"[SubsPlease] Show (1080p) [AID].mkv","magnet_uri":"magnet:?xt=urn:btih:a1dfeed000000000000000000000000000000000","info_hash":"a1dfeed000000000000000000000000000000000","seeders":42,"total_size":1500000000,"timestamp":1735689600,"anidb_aid":17389}]`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	a := newTestAggregator(t,
+		// Registry sources stubbed empty so the only rows come from the aid feed.
+		WithGardenFn(staticFn(nil, nil)),
+		WithAcgFn(staticFn(nil, nil)),
+		WithNyaaFn(staticFn(nil, nil)),
+		// Inject the rewrite client so FetchAnimeToshoByAniDB hits our server.
+		WithHTTPClient(newRewriteClient(srv.URL)),
+	)
+
+	aid := int32(17389)
+	out, err := a.FetchForAnime(context.Background(), []string{"some-title"}, &aid)
+	require.NoError(t, err)
+	require.True(t, sawAid.Load(), "the aid feed must be requested with ?aid=<id>")
+	require.Len(t, out, 1, "the aid-feed row is merged into the result")
+	assert.Equal(t, SourceTosho, out[0].Source)
+	require.NotNil(t, out[0].Seeders)
+	assert.Equal(t, 42, *out[0].Seeders, "aid-feed seeder count survives")
+}
+
+// The keyword fan-out and the aid feed overlap in practice (AnimeTosho
+// surfaces the same torrent both ways); the overlap must dedup by infohash.
+func TestFetchForAnime_AniDBFeedOverlapDedups(t *testing.T) {
+	t.Parallel()
+
+	const hash = "0123456789abcdef0123456789abcdef01234567"
+	magnet := "magnet:?xt=urn:btih:" + hash
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("aid") != "" {
+			// aid feed: same infohash, but WITHOUT seeders.
+			_, _ = w.Write([]byte(`[{"title":"aid copy","magnet_uri":"` + magnet + `","info_hash":"` + hash + `","total_size":1000000000,"timestamp":1735689600}]`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	seeders := 99
+	// garden surfaces the SAME infohash via the keyword fan-out, but WITH a
+	// seeder count — dedup must keep the richer (seeder-bearing) copy.
+	a := newTestAggregator(t,
+		WithGardenFn(func(_ context.Context, _ string) ([]TorrentItem, error) {
+			return []TorrentItem{{Title: "garden copy", Magnet: magnet, Source: SourceGarden, Seeders: &seeders}}, nil
+		}),
+		WithAcgFn(staticFn(nil, nil)),
+		WithNyaaFn(staticFn(nil, nil)),
+		WithHTTPClient(newRewriteClient(srv.URL)),
+	)
+
+	aid := int32(555)
+	out, err := a.FetchForAnime(context.Background(), []string{"dup-title"}, &aid)
+	require.NoError(t, err)
+	require.Len(t, out, 1, "keyword hit + aid-feed hit for the same torrent dedups to one row")
+	require.NotNil(t, out[0].Seeders, "the seeder-bearing copy wins the dedup")
+	assert.Equal(t, 99, *out[0].Seeders)
+}
+
+// ---------------------------------------------------------------------------
+// Shared cache across variants (sorted-join key)
+// ---------------------------------------------------------------------------
+
+func TestFetchForAnime_CacheSharedAcrossVariantOrder(t *testing.T) {
+	t.Parallel()
+
+	var gc atomic.Int32
+	a := newTestAggregator(t,
+		WithGardenFn(staticFn([]TorrentItem{itemWithHash(SourceGarden, "cafe")}, &gc)),
+		WithAcgFn(staticFn(nil, nil)),
+		WithNyaaFn(staticFn(nil, nil)),
+	)
+
+	first, err := a.FetchForAnime(context.Background(), []string{"Alpha", "Beta"}, nil)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	require.Equal(t, int32(2), gc.Load(), "two variants → garden ran twice on the miss")
+
+	a.cache.Wait()
+
+	// Same variant SET, reversed order + different casing → same cache key.
+	second, err := a.FetchForAnime(context.Background(), []string{"beta", "ALPHA"}, nil)
+	require.NoError(t, err)
+	require.Len(t, second, 1, "cache hit returns the same shape")
+	assert.Equal(t, int32(2), gc.Load(), "reordered/recased variant set must reuse the cached entry")
+}
+
+// A single-variant FetchForAnime and a one-keyword Fetch for the same string
+// must NOT collide — the anime key is namespaced away from the plain key.
+func TestFetchForAnime_DoesNotAliasFetchKey(t *testing.T) {
+	t.Parallel()
+
+	var gc atomic.Int32
+	a := newTestAggregator(t,
+		WithGardenFn(staticFn([]TorrentItem{itemWithHash(SourceGarden, "beef")}, &gc)),
+		WithAcgFn(staticFn(nil, nil)),
+		WithNyaaFn(staticFn(nil, nil)),
+	)
+
+	_, err := a.Fetch(context.Background(), "naruto")
+	require.NoError(t, err)
+	require.Equal(t, int32(1), gc.Load())
+	a.cache.Wait()
+
+	// Same string via the anime path — must MISS (distinct namespace), so
+	// garden runs again rather than serving Fetch's cached entry.
+	_, err = a.FetchForAnime(context.Background(), []string{"naruto"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), gc.Load(), "anime-keyed lookup must not alias the plain Fetch key")
+}
+
+// ---------------------------------------------------------------------------
+// Degrade paths
+// ---------------------------------------------------------------------------
+
+func TestFetchForAnime_NoVariantsNoAid_ShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	var gc, ac, nc atomic.Int32
+	a := newTestAggregator(t,
+		WithGardenFn(staticFn([]TorrentItem{stubItem(SourceGarden)}, &gc)),
+		WithAcgFn(staticFn([]TorrentItem{stubItem(SourceAcg)}, &ac)),
+		WithNyaaFn(staticFn([]TorrentItem{stubItem(SourceNyaa)}, &nc)),
+	)
+
+	// Only blank variants and no aid → nothing to search.
+	out, err := a.FetchForAnime(context.Background(), []string{"", "   ", "\t"}, nil)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+	assert.Equal(t, int32(0), gc.Load(), "no fan-out when there is nothing to search")
+	assert.Equal(t, int32(0), ac.Load())
+	assert.Equal(t, int32(0), nc.Load())
+}
+
+func TestFetchForAnime_NilAniDB_NoFeedRequested(t *testing.T) {
+	t.Parallel()
+
+	var hitServer atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hitServer.Store(true)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	a := newTestAggregator(t,
+		WithGardenFn(staticFn([]TorrentItem{itemWithHash(SourceGarden, "feed")}, nil)),
+		WithAcgFn(staticFn(nil, nil)),
+		WithNyaaFn(staticFn(nil, nil)),
+		WithHTTPClient(newRewriteClient(srv.URL)),
+	)
+
+	out, err := a.FetchForAnime(context.Background(), []string{"title"}, nil)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.False(t, hitServer.Load(), "nil anidbID must NOT issue an aid-feed request")
+}
+
+// ---------------------------------------------------------------------------
+// Empty result still takes the short TTL via the shared cacheResult path
+// ---------------------------------------------------------------------------
+
+func TestFetchForAnime_EmptyResult_ShortTTL_ReFetches(t *testing.T) {
+	t.Parallel()
+
+	var gc atomic.Int32
+	a := newTestAggregator(t,
+		WithGardenFn(staticFn(nil, &gc)),
+		WithAcgFn(staticFn(nil, nil)),
+		WithNyaaFn(staticFn(nil, nil)),
+		WithEmptyCacheTTL(50*time.Millisecond),
+	)
+
+	out, err := a.FetchForAnime(context.Background(), []string{"obscure"}, nil)
+	require.NoError(t, err)
+	require.Empty(t, out)
+	require.Equal(t, int32(1), gc.Load())
+
+	a.cache.Wait()
+
+	// Within the short window: cached empty, no re-fetch.
+	_, err = a.FetchForAnime(context.Background(), []string{"obscure"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), gc.Load(), "empty result cached within its short TTL")
+
+	// After expiry: re-fetch.
+	time.Sleep(150 * time.Millisecond)
+	_, err = a.FetchForAnime(context.Background(), []string{"obscure"}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), gc.Load(), "empty anime result must expire fast and re-fetch")
+}
+
+// ---------------------------------------------------------------------------
+// cleanVariants / animeCacheKey — direct unit coverage
+// ---------------------------------------------------------------------------
+
+func TestCleanVariants_TrimsAndDropsEmpties(t *testing.T) {
+	t.Parallel()
+
+	got := cleanVariants([]string{"  Naruto  ", "", "   ", "Bleach", "\tOne Piece\n"})
+	assert.Equal(t, []string{"Naruto", "Bleach", "One Piece"}, got)
+}
+
+func TestAnimeCacheKey_OrderAndCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	k1 := animeCacheKey([]string{"Alpha", "Beta"}, nil)
+	k2 := animeCacheKey([]string{"beta", "ALPHA"}, nil)
+	assert.Equal(t, k1, k2, "key is sorted + lowercased so order/case don't matter")
+
+	aid := int32(7)
+	withAid := animeCacheKey([]string{"Alpha", "Beta"}, &aid)
+	assert.NotEqual(t, k1, withAid, "adding an aid changes the key")
+}


### PR DESCRIPTION
> Final backend slice of the magnet live-path stack. Base = integration branch (all sources + dedup/seeders + AnimeTosho + throttle). Pairs with the frontend PR.

## What
`GET /api/anime/torrents?anilistId=N` — the server now resolves the four titles (romaji/native/english/chinese) + the AniDB id and fans out **every non-empty title variant (cap 4) across all 6 sources**, folds in the **AnimeTosho AniDB aid feed** when an AniDB id exists, then dedups by infohash and ranks by seeders. This unlocks the last two coverage multipliers (variant expansion ×2-4 + the aid feed). `?q=` keyword stays as the unchanged fallback.

## Changes
- **`aggregator.go`**: `FetchForAnime(variants []string, anidbID *int32)`; extracted `fanOut` helper (`Fetch` reuses it); `runToshoAniDB` shares `SourceTosho`'s timeout + throttle bucket; shared `finalise` (dedup→rank) + quality-aware cache (key = sorted variants `[+aid]`, `anime:`-namespaced so a 1-variant call never aliases a 1-keyword `Fetch`).
- **`db/queries/anime_cache.sql`** + regenerated `db/gen/*`: `GetTorrentQueryInputsByAnilistID` (4 titles + nullable `anidb_id` via LEFT JOIN bgm_id_map).
- **`handlers.go`**: `Torrents(agg, db)` + 1-method `TorrentsDB` use-site interface. `?anilistId` (bad id → 400, no row → 404, no anidb → degrades to variants-only) takes precedence; `?q=` unchanged; neither → 400.
- **`main.go`**: route passes the querier.

## Test plan
- [x] `go test -race ./internal/torrents/... ./internal/anime/...` green (11 `FetchForAnime` + 6 handler `?anilistId` cases; existing assertions unchanged)
- [x] `go vet ./...` + `go build ./...` + `sqlc generate` idempotent + gofmt clean

Variant concurrency: flat errgroup (≤4 variants × 6 sources + aid = bounded); the per-source token-bucket throttle is the outbound backstop, no extra semaphore (YAGNI).