### PR TITLE
feat(torrents): query torrents by anilistId + show seeders

### DIFF
--- a/next-app/src/app/anime/[id]/page.tsx
+++ b/next-app/src/app/anime/[id]/page.tsx
@@ -1329,6 +1329,7 @@ export default async function AnimeDetailPage({ params }: PageProps) {
               torrentsCopy: dict.torrent.copy,
               torrentsCopied: dict.torrent.copied,
               torrentsOpenMagnet: dict.torrent.openMagnet,
+              torrentsSeeders: dict.torrent.seeders,
               play: dict.detail.openPlayer,
               playAria: dict.detail.openPlayerAria,
             }}

--- a/next-app/src/components/anime/DetailActions.tsx
+++ b/next-app/src/components/anime/DetailActions.tsx
@@ -64,6 +64,7 @@ interface DetailActionsProps {
     torrentsCopy: string;
     torrentsCopied: string;
     torrentsOpenMagnet: string;
+    torrentsSeeders: string;
     // PlayButton
     play: string;
     playAria: string;
@@ -153,6 +154,7 @@ export default function DetailActions({
             copy: labels.torrentsCopy,
             copied: labels.torrentsCopied,
             openMagnet: labels.torrentsOpenMagnet,
+            seeders: labels.torrentsSeeders,
           }}
           onClose={() => setTorrentOpen(false)}
           lang={lang}

--- a/next-app/src/components/anime/TorrentModal.tsx
+++ b/next-app/src/components/anime/TorrentModal.tsx
@@ -13,26 +13,38 @@
 //   copy               — title attr on copy button, e.g. "复制"
 //   copied             — short ✓ confirmation, e.g. "已复制" / "Copied!"
 //   openMagnet         — title attr on open button, e.g. "打开"
+//   seeders            — short seed-count prefix, e.g. "做种" / "Seeds"
 //
-// All eleven keys exist in next-app/src/locales/{zh,en}.ts under `torrent`.
-// The DetailActions parent agent just needs to map them through.
+// All twelve keys exist in next-app/src/locales/{zh,en}.ts under `torrent`.
+// The DetailActions parent maps them through.
 // ─────────────────────────────────────────────────────────────────────
 //
-// Full v2 port of client/src/components/anime/TorrentModal.jsx (466 lines).
-// Matches legacy layout exactly: 3-column body (185px fansub list / center
-// scrollable rows / 128px cover thumbnail), title-variant pills, episode
-// pills, fansub filter, episode-relevance + resolution + date sort, copy /
-// open-magnet actions, ESC + backdrop close, body scroll-lock.
+// v2 port of client/src/components/anime/TorrentModal.jsx, now driven by
+// anilistId. Layout: 3-column body (185px fansub list / center scrollable
+// rows / 128px cover thumbnail), title-variant pills, episode pills,
+// fansub filter, copy / open-magnet actions, ESC + backdrop close, body
+// scroll-lock.
 //
-// Data source: GET /api/anime/torrents?q=<query>
-//   Server controller: server/controllers/anime.controller.js getTorrents.
+// Data source (primary): GET /api/anime/torrents?anilistId=<number>
+//   go-api resolves the AniList title variants + AnimeTosho aid feed,
+//   dedups by infohash, and returns the list ALREADY SORTED by seeders
+//   desc (unknown-seeder rows sink to the bottom). The front-end therefore
+//   does NOT re-rank the full list — it preserves server order and only
+//   buckets by fansub / filters by selected episode.
+//
+// Data source (manual fallback): GET /api/anime/torrents?q=<keyword>
+//   The search box + title-variant pills still issue keyword searches so a
+//   user can override the auto query (e.g. an alternate romanisation the
+//   variant expansion missed). Both modes return the same envelope.
+//
 //   Response envelope: { data: TorrentItem[] }  — apiGet unwraps `data`.
-//   Per-item shape (verified against fetchAnimeGarden / fetchAcgRip /
-//   fetchNyaa): { title, magnet, size, fansub, date, source, provider? }
+//   Per-item shape: { title, magnet, size, fansub, date, source, seeders,
+//   infohash, provider? }. `seeders` is omitted/`null` when the source
+//   can't report it; `infohash` is the server-side dedup key.
 //
-// Cache behavior: backend caches results 1h server-side per lowercased
-// query. We pass `cache: 'no-store'` so each modal-open / new search hits
-// the backend fresh — bandwidth is cheap (server-cached) and torrents
+// Cache behavior: backend caches results 1h server-side per request key.
+// We pass `cache: 'no-store'` so each modal-open / new query hits the
+// backend fresh — bandwidth is cheap (server-cached) and torrents
 // staleness matters more than CDN economics for this surface.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -40,8 +52,9 @@ import { apiGet, ApiError } from "@/lib/api";
 import FadeImage from "@/components/ui/FadeImage";
 import type { Lang } from "@/lib/i18n";
 
-// Module-level cache: keyed by lowercased query, 5min TTL — matches the
-// legacy TanStack Query `staleTime: 5 * 60 * 1000` in client/src/hooks/
+// Module-level cache: keyed by the request key (anilistId-derived for the
+// primary path, lowercased keyword for manual searches), 5min TTL — matches
+// the legacy TanStack Query `staleTime: 5 * 60 * 1000` in client/src/hooks/
 // useAnime.js so re-opening the modal (or switching title-variant pills
 // within the same modal) returns instantly instead of round-tripping to
 // the backend on every interaction. Backend already caches 1h server-
@@ -60,6 +73,19 @@ interface TorrentItem {
   fansub: string | null;
   date: string | null;
   source: "garden" | "nyaa" | "acg" | "dmhy" | string;
+  /**
+   * Peer seed count, or null/undefined when the source can't report it.
+   * go-api emits `seeders` with `omitempty`, so the key is absent (→
+   * undefined) for RSS scrapes and any garden row missing the field; a
+   * known 0 is a genuine zero-seed torrent. Both undefined and null are
+   * treated as "unknown" by the UI.
+   */
+  seeders: number | null;
+  /**
+   * Normalised BitTorrent infohash (server-side dedup key). Absent when the
+   * magnet carries no parseable hash, hence optional.
+   */
+  infohash?: string;
   provider?: string | null;
 }
 
@@ -85,6 +111,8 @@ interface TorrentLabels {
   copy: string;
   copied: string;
   openMagnet: string;
+  /** Short label prefixed to the seed count, e.g. "Seeds" / "做种". */
+  seeders: string;
 }
 
 interface TorrentModalProps {
@@ -136,14 +164,6 @@ function epRelevance(title: string, epPad: string): number {
     ` ${epPad}.`,
   ];
   return patterns.some((p) => title.includes(p)) ? 1 : 0;
-}
-
-function resScore(title: string): number {
-  if (/2160[Pp]|4K/i.test(title)) return 4;
-  if (/1080[Pp]/i.test(title)) return 3;
-  if (/720[Pp]/i.test(title)) return 2;
-  if (/480[Pp]/i.test(title)) return 1;
-  return 0;
 }
 
 // ─── GroupRow sub-component ─────────────────────────────────────────
@@ -226,6 +246,7 @@ interface TorrentRowProps {
   copyLabel: string;
   copiedLabel: string;
   openLabel: string;
+  seedersLabel: string;
   lang: Lang;
 }
 
@@ -254,6 +275,15 @@ function sourceTooltip(item: TorrentItem): string | undefined {
   return undefined;
 }
 
+// Health-coded seed colour: green for well-seeded, amber for thin, muted
+// for dead/zero. `seeders` is normalised to a number here (null/undefined
+// callers are handled by the row before this runs).
+function seederColor(seeders: number): string {
+  if (seeders >= 20) return "#34d399";
+  if (seeders > 0) return "#f5a623";
+  return "rgba(235,235,245,0.30)";
+}
+
 function TorrentRow({
   item,
   copied,
@@ -262,10 +292,14 @@ function TorrentRow({
   copyLabel,
   copiedLabel,
   openLabel,
+  seedersLabel,
   lang,
 }: TorrentRowProps) {
   const { resolution, tags } = parseTags(item.title);
   const [hovered, setHovered] = useState(false);
+  // null/undefined → unknown count; a known number (incl. 0) renders.
+  const seeders =
+    typeof item.seeders === "number" ? item.seeders : null;
 
   return (
     <div
@@ -310,6 +344,26 @@ function TorrentRow({
             gap: 5,
           }}
         >
+          {/* Seed count — list is server-ranked by seeders desc, so this
+              leads the meta row. Unknown (null) renders a muted dash. */}
+          <span
+            title={seedersLabel}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 3,
+              fontSize: 10,
+              fontWeight: 700,
+              fontVariantNumeric: "tabular-nums",
+              padding: "1px 6px",
+              borderRadius: 4,
+              background: "rgba(52,211,153,0.1)",
+              color: seeders === null ? "rgba(235,235,245,0.30)" : seederColor(seeders),
+            }}
+          >
+            <span aria-hidden="true">🌱</span>
+            {seeders === null ? "—" : seeders}
+          </span>
           {resolution && (
             <span
               style={{
@@ -446,8 +500,11 @@ export default function TorrentModal({
 }: TorrentModalProps) {
   const defaultQ = anime.titleRomaji || anime.titleEnglish || "";
 
+  // `query` is the search-box text. `manualQ` is the active manual override:
+  //   - null  → primary path, fetch by anilistId (server expands variants)
+  //   - "..." → fetch that keyword via ?q= (search box / title pill)
   const [query, setQuery] = useState(defaultQ);
-  const [searchQ, setSearchQ] = useState(defaultQ);
+  const [manualQ, setManualQ] = useState<string | null>(null);
   const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
   const [selectedGroup, setSelectedGroup] = useState<string>("ALL");
   const [selectedEp, setSelectedEp] = useState<number | null>(null);
@@ -456,23 +513,38 @@ export default function TorrentModal({
   const [isLoading, setIsLoading] = useState(false);
 
   // ─── Data fetch ─────────────────────────────────────────────────
-  // No react-query in next-app; manage state by hand. Cancel in-flight
-  // request when query changes mid-load so a fast double-search doesn't
+  // No react-query in next-app; manage state by hand. Cancel any in-flight
+  // request when the query changes mid-load so a fast double-search doesn't
   // race a slow first request to overwrite fresh results.
+  //
+  // Primary path queries by anilistId — go-api resolves the title variants,
+  // pulls the AnimeTosho aid feed, dedups, and returns the list already
+  // sorted by seeders desc. A manual override (search box / title pill)
+  // switches to keyword ?q=. Either way the response is TorrentItem[].
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
-    const term = searchQ.trim();
-    if (!term) {
+    const term = manualQ?.trim() ?? "";
+    const isManual = manualQ !== null;
+
+    // Manual search with an empty box → nothing to query.
+    if (isManual && !term) {
       setTorrents([]);
       setIsLoading(false);
       return;
     }
 
-    // Stale-while-revalidate: paint cached entry immediately (if fresh),
-    // skip the network round-trip entirely. Falls through to fetch when
-    // there's no cached entry or the entry is past TTL.
-    const cacheKey = term.toLowerCase();
+    const path = isManual
+      ? `/api/anime/torrents?q=${encodeURIComponent(term)}`
+      : `/api/anime/torrents?anilistId=${anime.anilistId}`;
+    // Cache key namespaces the two modes so an anilistId result and a
+    // keyword result never collide.
+    const cacheKey = isManual
+      ? `q:${term.toLowerCase()}`
+      : `id:${anime.anilistId}`;
+
+    // Stale-while-revalidate: paint a fresh cached entry immediately and
+    // skip the network round-trip. Falls through to fetch on miss / expiry.
     const cached = torrentCache.get(cacheKey);
     if (cached && Date.now() - cached.ts < TORRENT_CACHE_TTL_MS) {
       setTorrents(cached.items);
@@ -485,10 +557,7 @@ export default function TorrentModal({
     abortRef.current = controller;
 
     setIsLoading(true);
-    apiGet<TorrentItem[]>(
-      `/api/anime/torrents?q=${encodeURIComponent(term)}`,
-      { signal: controller.signal },
-    )
+    apiGet<TorrentItem[]>(path, { signal: controller.signal })
       .then((data) => {
         if (controller.signal.aborted) return;
         const items = Array.isArray(data) ? data : [];
@@ -498,19 +567,16 @@ export default function TorrentModal({
       })
       .catch((err: unknown) => {
         if (controller.signal.aborted) return;
-        // Abort errors swallow silently; surface anything else as empty
-        // list (the noResults copy already covers the user-facing case,
-        // and detail page logs ApiError through its own boundary).
-        if (err instanceof ApiError) {
-          setTorrents([]);
-        } else {
-          setTorrents([]);
-        }
+        // Abort errors swallow silently; surface anything else as an empty
+        // list (the noResults copy covers the user-facing case, and the
+        // detail page logs ApiError through its own boundary).
+        void (err instanceof ApiError);
+        setTorrents([]);
         setIsLoading(false);
       });
 
     return () => controller.abort();
-  }, [searchQ]);
+  }, [manualQ, anime.anilistId]);
 
   // ─── Escape + body scroll lock ──────────────────────────────────
   useEffect(() => {
@@ -561,8 +627,10 @@ export default function TorrentModal({
     anime.titleNative,
   ]);
 
+  // Manual keyword search (search box Enter / button, or a title pill).
+  // Switches the fetch off the anilistId path and onto ?q=<keyword>.
   const triggerSearch = useCallback((newQ: string) => {
-    setSearchQ(newQ);
+    setManualQ(newQ);
     setSelectedGroup("ALL");
   }, []);
 
@@ -594,35 +662,28 @@ export default function TorrentModal({
         ? torrents
         : (grouped[selectedGroup] ?? []);
 
-    // Episode filter with fallback: when a specific ep is selected and
-    // no titles contain its number, show the unfiltered group instead
-    // (legacy behavior — better than empty-state when fansubs use
-    // unconventional numbering).
-    let filtered = base;
+    // The server already returns the list ranked by seeders desc, so we do
+    // NOT re-rank. The only client-side reshaping is the optional episode
+    // filter: when a specific ep is selected, surface its rows first.
+    //
+    // Episode partition with fallback: keep rows whose title matches the
+    // selected episode ahead of the rest while preserving the server's
+    // seeder order within each partition (stable). If nothing matches the
+    // episode number (fansubs with unconventional numbering), fall back to
+    // the unfiltered, server-ranked list rather than showing an empty state.
+    let filteredTorrents = base;
     if (epPad) {
-      const epFiltered = base.filter(
-        (item) => epRelevance(item.title, epPad) > 0,
-      );
-      filtered = epFiltered.length > 0 ? epFiltered : base;
-    }
-
-    const sorted = [...filtered].sort((a, b) => {
-      if (epPad) {
-        const epDiff =
-          epRelevance(b.title, epPad) - epRelevance(a.title, epPad);
-        if (epDiff !== 0) return epDiff;
+      const matched = base.filter((item) => epRelevance(item.title, epPad) > 0);
+      if (matched.length > 0) {
+        const rest = base.filter((item) => epRelevance(item.title, epPad) === 0);
+        filteredTorrents = [...matched, ...rest];
       }
-      const resDiff = resScore(b.title) - resScore(a.title);
-      if (resDiff !== 0) return resDiff;
-      const da = a.date ? new Date(a.date).getTime() : 0;
-      const db = b.date ? new Date(b.date).getTime() : 0;
-      return db - da;
-    });
+    }
 
     return {
       groups: grouped,
       groupNames: sortedNames,
-      filteredTorrents: sorted,
+      filteredTorrents,
     };
   }, [torrents, selectedGroup, selectedEp]);
 
@@ -952,7 +1013,7 @@ export default function TorrentModal({
               >
                 {filteredTorrents.map((item, i) => (
                   <TorrentRow
-                    key={`${item.source}-${item.magnet.slice(0, 64)}-${i}`}
+                    key={`${item.infohash || item.magnet.slice(0, 64)}-${i}`}
                     item={item}
                     copied={copiedIdx === i}
                     onCopy={() => copyMagnet(item.magnet, i)}
@@ -960,6 +1021,7 @@ export default function TorrentModal({
                     copyLabel={labels.copy}
                     copiedLabel={labels.copied}
                     openLabel={labels.openMagnet}
+                    seedersLabel={labels.seeders}
                     lang={lang}
                   />
                 ))}


### PR DESCRIPTION
> Final frontend slice. Base = integration branch. Pairs with the handler PR — only touches next-app (zero overlap with the Go side).

## What
The magnet modal now queries `?anilistId=<id>` (server does variant expansion + AnimeTosho aid feed + dedup + seeder-sort) and renders seed health per row.

## Changes
- **`TorrentModal.tsx`**: primary fetch `?q=<title>` → **`?anilistId=${anime.anilistId}`**. Keyword path kept via a `manualQ` state (search box + title pills set it; cache key namespaced `id:<n>` vs `q:<kw>`). Since the list is now server-ranked by seeders desc, dropped the client resolution/date re-sort (and unused `resScore()`); the episode filter is now a **stable partition** (matches first, server order preserved) instead of a full re-sort. Same abort/SWR/cache structure.
- **Seeders UI**: `TorrentItem` gains `seeders: number | null` + `infohash?`. Each row leads with a health-coded seed chip (`🌱 <count>`, green ≥20 / amber >0 / muted 0; unknown → `🌱 —`), glyph `aria-hidden` with a localized "做种/Seeds" tooltip. Row key prefers `infohash`.
- `DetailActions.tsx` + `anime/[id]/page.tsx`: thread the existing `torrent.seeders` locale label through (key already existed in `locales/{zh,en}`).

## Test plan
- [x] `tsc --noEmit`: 3 changed files clean; **zero new errors** (the 31 pre-existing errors in unrelated test files proven identical with changes stashed).
- [x] `eslint`: **zero new problems** (11 vs 11 baseline, byte-identical — all pre-existing debt).
- No test file references this surface; no `test` npm script (CI-run).

⚠️ Note: the worktree hit pre-existing package.json/lock drift (`npm ci` fails) unrelated to these 3 files — flagging for a lockfile sync check, not introduced here.