### PR TITLE
fix(anime): stop detail-page 500s under SEO crawl load

### DIFF
--- a/go-api/internal/anilist/client.go
+++ b/go-api/internal/anilist/client.go
@@ -34,6 +34,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -65,6 +66,17 @@ const defaultRetryAfter = 60 * time.Second
 // survive AniList's worst observed latency without hanging callers
 // forever.  Override with WithHTTPClient(...) to tune.
 const httpTimeout = 10 * time.Second
+
+// breakerCooldown is how long the circuit stays open after AniList rate-
+// limits us (a 429 that exhausts the retry budget).  While open, do()
+// short-circuits to ErrRateLimited WITHOUT making the HTTP call — so a
+// caller (e.g. the detail handler under an SEO crawl) degrades to stale
+// data in microseconds instead of burning the full retry budget (up to
+// refetchTimeout, ~15s) on every request during an AniList rate-limit
+// storm.  It also stops us hammering AniList while it's asking us to back
+// off.  After the cooldown the next call probes upstream again (a 429
+// re-trips it).  Set to 0 via WithBreakerCooldown to disable (tests).
+const breakerCooldown = 30 * time.Second
 
 // ErrRateLimited is returned after maxRetries exhausted on HTTP 429.
 // Express raises an Error with status=429 and a Chinese message; the
@@ -112,6 +124,14 @@ type Client struct {
 	// without real elapsed time.  The function must respect the passed
 	// duration semantically — production code uses time.Sleep equivalent.
 	sleep func(context.Context, time.Duration) error
+
+	// Circuit breaker (see breakerCooldown). breakerCooldown==0 disables
+	// it. openUntil is the instant the circuit closes again; now() is a
+	// hook so tests can advance time without sleeping. mu guards both.
+	breakerCooldown time.Duration
+	now             func() time.Time
+	mu              sync.Mutex
+	openUntil       time.Time
 }
 
 // Option mutates a Client during construction.  See NewClient.
@@ -157,15 +177,33 @@ func WithSleep(f func(context.Context, time.Duration) error) Option {
 // the AniList URL (tests) and WithHTTPClient to swap timeout / transport.
 func NewClient(opts ...Option) *Client {
 	c := &Client{
-		endpoint: DefaultEndpoint,
-		http:     &http.Client{Timeout: httpTimeout},
-		limiter:  rate.NewLimiter(rate.Every(minInterval), 1),
-		sleep:    defaultSleep,
+		endpoint:        DefaultEndpoint,
+		http:            &http.Client{Timeout: httpTimeout},
+		limiter:         rate.NewLimiter(rate.Every(minInterval), 1),
+		sleep:           defaultSleep,
+		breakerCooldown: breakerCooldown,
+		now:             time.Now,
 	}
 	for _, opt := range opts {
 		opt(c)
 	}
 	return c
+}
+
+// WithBreakerCooldown overrides the circuit-breaker cooldown.  Pass 0 to
+// disable the breaker entirely (tests that assert raw retry behaviour).
+func WithBreakerCooldown(d time.Duration) Option {
+	return func(c *Client) {
+		c.breakerCooldown = d
+	}
+}
+
+// WithNow replaces the breaker clock.  Test-only — lets a test open the
+// circuit and then jump past the cooldown without real elapsed time.
+func WithNow(f func() time.Time) Option {
+	return func(c *Client) {
+		c.now = f
+	}
 }
 
 // defaultSleep is the production retry-sleep implementation.  It honours
@@ -183,6 +221,31 @@ func defaultSleep(ctx context.Context, d time.Duration) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// breakerOpen reports whether the AniList circuit is currently open
+// (recently rate-limited).  While open, do() short-circuits to
+// ErrRateLimited without making the HTTP call.
+func (c *Client) breakerOpen() bool {
+	if c.breakerCooldown <= 0 {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now().Before(c.openUntil)
+}
+
+// tripBreaker opens the circuit for breakerCooldown after AniList rate-
+// limits us, so subsequent calls back off immediately instead of each
+// burning the full retry budget against an upstream that's saying "slow
+// down".
+func (c *Client) tripBreaker() {
+	if c.breakerCooldown <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.openUntil = c.now().Add(c.breakerCooldown)
 }
 
 // ---------------------------------------------------------------------------
@@ -279,6 +342,13 @@ func (c *Client) Schedule(ctx context.Context, v ScheduleVars) (*WeeklyScheduleR
 // the corresponding GraphQL response shape (see types.go for the four
 // concrete payload types).
 func (c *Client) do(ctx context.Context, query string, vars any, dest any) error {
+	// Circuit breaker: while AniList is rate-limiting us, fail fast so the
+	// caller degrades immediately (e.g. detail → stale data) instead of
+	// every request blocking on the retry budget. See breakerCooldown.
+	if c.breakerOpen() {
+		return ErrRateLimited
+	}
+
 	// Marshal the body once — variables may not change between retries,
 	// so we can reuse the same payload buffer.  Build via anonymous
 	// struct so the per-query *Vars omitempty tags decide which fields
@@ -323,6 +393,7 @@ func (c *Client) do(ctx context.Context, query string, vars any, dest any) error
 			_ = res.Body.Close()
 
 			if attempt >= maxRetries {
+				c.tripBreaker()
 				return ErrRateLimited
 			}
 			retryAfter := parseRetryAfter(res.Header.Get("Retry-After"))

--- a/go-api/internal/anilist/client_test.go
+++ b/go-api/internal/anilist/client_test.go
@@ -331,6 +331,72 @@ func TestClient_429_GiveUpAfter3Retries(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Circuit breaker
+// ---------------------------------------------------------------------------
+
+func TestClient_Breaker_ShortCircuitsWhileOpen(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	sleepHook, _ := newNoopSleep()
+	c := NewClient(WithEndpoint(srv.URL), WithSleep(sleepHook))
+	c.limiter = rate.NewLimiter(rate.Inf, 0)
+
+	// First call exhausts the retry budget (1 + 3 = 4 attempts) and trips
+	// the breaker.
+	_, err := c.Search(context.Background(), SearchVars{Page: 1, PerPage: 20})
+	require.ErrorIs(t, err, ErrRateLimited)
+	require.Equal(t, int32(4), callCount.Load())
+
+	// Second call: breaker is open → short-circuit with ZERO HTTP calls.
+	_, err = c.Detail(context.Background(), DetailVars{ID: 1})
+	require.ErrorIs(t, err, ErrRateLimited)
+	assert.Equal(t, int32(4), callCount.Load(), "open breaker must not touch AniList")
+}
+
+func TestClient_Breaker_ClosesAfterCooldown(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	now := time.Unix(1_000_000, 0)
+	sleepHook, _ := newNoopSleep()
+	c := NewClient(
+		WithEndpoint(srv.URL),
+		WithSleep(sleepHook),
+		WithNow(func() time.Time { return now }),
+	)
+	c.limiter = rate.NewLimiter(rate.Inf, 0)
+
+	// Trip the breaker.
+	_, _ = c.Search(context.Background(), SearchVars{Page: 1, PerPage: 20})
+	require.Equal(t, int32(4), callCount.Load())
+
+	// Still inside the cooldown window → short-circuit, no new HTTP attempts.
+	now = now.Add(breakerCooldown - time.Second)
+	_, _ = c.Detail(context.Background(), DetailVars{ID: 1})
+	require.Equal(t, int32(4), callCount.Load(), "within cooldown: no upstream call")
+
+	// Past the cooldown → probe upstream again (4 more attempts; it 429s anew).
+	now = now.Add(2 * time.Second)
+	_, _ = c.Detail(context.Background(), DetailVars{ID: 1})
+	assert.Equal(t, int32(8), callCount.Load(), "after cooldown: probes upstream again")
+}
+
+// ---------------------------------------------------------------------------
 // Non-2xx / GraphQL error wrapping
 // ---------------------------------------------------------------------------
 

--- a/go-api/internal/anime/detail.go
+++ b/go-api/internal/anime/detail.go
@@ -52,7 +52,8 @@ const detailCacheTTL = 1 * time.Hour
 // re-fetch frequency ~24x so a crawl mostly serves straight from the DB
 // row without touching AniList at all.  Freshness loss is negligible:
 // AniList metadata for an existing title rarely changes within a day, and
-// the scheduled cache-warm worker refreshes hot titles independently.
+// the scheduled seasonal cache-warm worker (internal/queue/warm_season.go)
+// refreshes current-season titles independently of this TTL.
 const staleCacheTTL = 24 * time.Hour
 
 // refetchTimeout bounds the AniList round-trip + upsert path.  Longer

--- a/go-api/internal/anime/detail.go
+++ b/go-api/internal/anime/detail.go
@@ -39,20 +39,21 @@ import (
 const detailCacheTTL = 1 * time.Hour
 
 // staleCacheTTL is the cached_at age threshold that flips a DB-read row
-// into "stale, re-fetch from AniList".  Express uses 24h (CACHE_TTL_MS);
-// we use 1h here for two reasons:
+// into "stale, re-fetch from AniList".  Set to 24h to match Express's
+// original CACHE_TTL_MS.
 //
-//   1. The ristretto cache already evicts after 1h (detailCacheTTL above),
-//      so a cache miss with cached_at < 1h is impossible — the row was
-//      either just written by the cache-warm worker or by a prior
-//      re-fetch.  Using 1h aligns the two windows.
-//   2. AniList side updates land in our DB hourly instead of daily, at
-//      the cost of more AniList calls.  AniList's 90 req/min budget has
-//      headroom, and the /:anilistId endpoint is low-volume.
-//
-// This is deliberately tighter than Express; document the divergence
-// here so the next reader doesn't "fix" it.
-const staleCacheTTL = 1 * time.Hour
+// History: this was briefly 1h (to align with the ristretto window), but
+// the /:anilistId endpoint is NOT low-volume — SEO crawlers (Bingbot,
+// Ahrefs, Googlebot, ...) walk the full catalog, thousands of distinct
+// pages per crawl.  At 1h, every crawled page older than an hour fired a
+// synchronous, blocking AniList re-fetch; a full-catalog sweep produced
+// thousands of live AniList calls, blew AniList's per-IP rate limit, and
+// turned cold (not-yet-cached) anime into user-facing 502→500s.  24h cuts
+// re-fetch frequency ~24x so a crawl mostly serves straight from the DB
+// row without touching AniList at all.  Freshness loss is negligible:
+// AniList metadata for an existing title rarely changes within a day, and
+// the scheduled cache-warm worker refreshes hot titles independently.
+const staleCacheTTL = 24 * time.Hour
 
 // refetchTimeout bounds the AniList round-trip + upsert path.  Longer
 // than queryTimeout (5s) because the AniList call alone can take up to

--- a/go-api/internal/anime/detail_test.go
+++ b/go-api/internal/anime/detail_test.go
@@ -969,10 +969,10 @@ func freshTimestamp() pgtype.Timestamptz {
 	return pgtype.Timestamptz{Time: time.Now().Add(-5 * time.Minute), Valid: true}
 }
 
-// staleTimestamp builds a stale cached_at — 2 hours ago, beyond the 1h
+// staleTimestamp builds a stale cached_at — 25 hours ago, beyond the 24h
 // staleCacheTTL threshold.
 func staleTimestamp() pgtype.Timestamptz {
-	return pgtype.Timestamptz{Time: time.Now().Add(-2 * time.Hour), Valid: true}
+	return pgtype.Timestamptz{Time: time.Now().Add(-25 * time.Hour), Valid: true}
 }
 
 // TestIsStale_FreshNotStale: all five checks pass → false.

--- a/go-api/internal/httpmw/api_ratelimit.go
+++ b/go-api/internal/httpmw/api_ratelimit.go
@@ -132,6 +132,12 @@ func (s *apiLimiterStore) Middleware() func(http.Handler) http.Handler {
 				next.ServeHTTP(w, r)
 				return
 			}
+			// Public catalog reads bypass the per-IP limiter — see
+			// isPublicReadExempt for the SSR-collapse rationale.
+			if isPublicReadExempt(r.Method, r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
 			ip := extractIP(r)
 			if !ip.IsValid() {
 				// Couldn't parse — fail open rather than 429 every
@@ -161,6 +167,41 @@ func shouldLimitPath(p string) bool {
 		return false
 	}
 	return strings.HasPrefix(p, "/api/")
+}
+
+// isPublicReadExempt reports whether a request is a public, cacheable
+// catalog read that must NOT be per-IP rate limited.
+//
+// Why this exists: /anime/[id] and the catalog list pages are server-
+// rendered with auth:false, so next-app fetches them from go-api WITHOUT
+// forwarding the visitor's X-Real-IP — reading request headers there would
+// force the page dynamic and defeat ISR / Cloudflare edge caching. Every
+// such SSR read therefore reaches go-api from the single next-app
+// container IP and collapses into one shared per-IP bucket. Under an SEO
+// crawl of the full catalog (Bingbot / Ahrefs / Googlebot walking
+// thousands of distinct pages) that one bucket is permanently drained, so
+// the 1 req/s limiter starts 429ing legitimate reads — which next-app's
+// loadDetail re-throws as a user-facing 500.
+//
+// These reads are GETs, idempotent, public, and already protected by the
+// 1h ristretto cache (and Cloudflare). The expensive external fan-outs
+// under /api/anime/ keep their inbound limit because they carry real
+// upstream cost and are NOT on the SSR/crawl path — they're browser-
+// initiated (X-Real-IP forwarded, so limited per real user):
+//   - /api/anime/search   → AniList GraphQL
+//   - /api/anime/torrents  → BT scraper fan-out
+func isPublicReadExempt(method, path string) bool {
+	if method != http.MethodGet {
+		return false
+	}
+	if !strings.HasPrefix(path, "/api/anime/") {
+		return false
+	}
+	if strings.HasPrefix(path, "/api/anime/search") ||
+		strings.HasPrefix(path, "/api/anime/torrents") {
+		return false
+	}
+	return true
 }
 
 // limiterFor returns the per-IP limiter, creating one on first sight.

--- a/go-api/internal/httpmw/api_ratelimit_test.go
+++ b/go-api/internal/httpmw/api_ratelimit_test.go
@@ -41,6 +41,47 @@ func TestShouldLimitPath(t *testing.T) {
 	}
 }
 
+// ─── isPublicReadExempt ──────────────────────────────────────────────────────
+
+func TestIsPublicReadExempt(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		exempt bool
+	}{
+		// Public catalog reads — collapse to next-app's IP under SSR, so exempt.
+		{"detail GET", http.MethodGet, "/api/anime/1", true},
+		{"watchers GET", http.MethodGet, "/api/anime/1/watchers", true},
+		{"trending GET", http.MethodGet, "/api/anime/trending", true},
+		{"seasonal GET", http.MethodGet, "/api/anime/seasonal", true},
+		// Expensive external fan-outs — keep inbound limit (own upstream cost).
+		{"search GET", http.MethodGet, "/api/anime/search", false},
+		{"torrents GET", http.MethodGet, "/api/anime/torrents", false},
+		// Non-GET on an anime path (no such route today, but the method gate
+		// must hold regardless).
+		{"detail POST", http.MethodPost, "/api/anime/1", false},
+		// Other API surfaces are never exempt.
+		{"subscriptions GET", http.MethodGet, "/api/subscriptions", false},
+		{"dandanplay GET", http.MethodGet, "/api/dandanplay/match", false},
+		{"auth login POST", http.MethodPost, "/api/auth/login", false},
+		{"non-api GET", http.MethodGet, "/anime/1", false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isPublicReadExempt(tc.method, tc.path)
+			if got != tc.exempt {
+				t.Errorf("isPublicReadExempt(%q, %q) = %v, want %v", tc.method, tc.path, got, tc.exempt)
+			}
+		})
+	}
+}
+
 // ─── extractIP ──────────────────────────────────────────────────────────────
 
 func TestExtractIP(t *testing.T) {
@@ -145,6 +186,60 @@ func TestAPIRateLimiter_HealthSkipped(t *testing.T) {
 	}
 }
 
+func TestAPIRateLimiter_PublicReadExempt(t *testing.T) {
+	t.Parallel()
+	// The bug this guards: a flood of catalog GET reads from ONE IP — the
+	// SSR-collapse case, where next-app fans an entire SEO crawl through a
+	// single container IP — must all pass. With a burst of 1 the per-IP
+	// limiter would 429 the 2nd request onward; the exemption keeps them 200.
+	s := NewAPIRateLimiterWithBurst(rate.Limit(0.001), 1)
+	defer s.Stop()
+
+	mw := s.Middleware()
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for i := 0; i < 10; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/api/anime/1", nil)
+		req.RemoteAddr = "172.18.0.5:4321" // next-app container IP
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("catalog read %d: got %d, want 200 (exempt)", i, rec.Code)
+		}
+	}
+}
+
+func TestAPIRateLimiter_ExpensiveAnimePathsStillLimited(t *testing.T) {
+	t.Parallel()
+	// The external fan-outs under /api/anime/ are NOT exempt: a flood from a
+	// single IP must hit 429 once the burst is spent.
+	for _, path := range []string{"/api/anime/torrents?q=x", "/api/anime/search?q=x"} {
+		s := NewAPIRateLimiterWithBurst(rate.Limit(0.001), 1)
+		mw := s.Middleware()
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		var got429 bool
+		for i := 0; i < 5; i++ {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.RemoteAddr = "1.2.3.4:1234"
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if rec.Code == http.StatusTooManyRequests {
+				got429 = true
+				break
+			}
+		}
+		s.Stop()
+		if !got429 {
+			t.Errorf("%s: expected a 429 once burst was spent, never got one", path)
+		}
+	}
+}
+
 func TestAPIRateLimiter_ApiHealthSkipped(t *testing.T) {
 	t.Parallel()
 	s := NewAPIRateLimiterWithBurst(rate.Limit(0.001), 1)
@@ -201,7 +296,9 @@ func TestAPIRateLimiter_Throttles(t *testing.T) {
 	const ip = "5.6.7.8:9999"
 	statuses := make([]int, 5)
 	for i := 0; i < 5; i++ {
-		req := httptest.NewRequest(http.MethodGet, "/api/anime/1", nil)
+		// dandanplay/match is a limited endpoint — public catalog GET reads
+		// (/api/anime/*) are now exempt, see TestAPIRateLimiter_PublicReadExempt.
+		req := httptest.NewRequest(http.MethodGet, "/api/dandanplay/match", nil)
 		req.RemoteAddr = ip
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)

--- a/next-app/src/app/anime/[id]/error.tsx
+++ b/next-app/src/app/anime/[id]/error.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+// Route-level error boundary for /anime/[id]. Replaces the bare
+// "Internal Server Error" the user used to see when loadDetail() threw on
+// a transient upstream failure (e.g. go-api returning 502 "AniList
+// upstream error" while AniList rate-limits us during an SEO crawl, or a
+// 429 from go-api's own inbound limiter).
+//
+// Unlike global-error.tsx (which replaces the whole document on a root
+// crash), this boundary only swaps the page segment — the Navbar and
+// layout chrome stay — so the user gets a coherent, retryable surface
+// instead of a blank 500. `reset()` re-runs the failed server render,
+// which usually succeeds on the second try once the upstream blip passes.
+
+import * as Sentry from "@sentry/nextjs";
+import Link from "next/link";
+import { useEffect } from "react";
+
+interface DetailErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+const card = {
+  maxWidth: 460,
+  margin: "0 auto",
+  padding: "56px 24px 80px",
+  textAlign: "center" as const,
+};
+
+const primaryBtn = {
+  padding: "10px 22px",
+  borderRadius: 10,
+  border: "none",
+  background: "#0a84ff",
+  color: "#fff",
+  fontSize: 14,
+  fontWeight: 700,
+  cursor: "pointer",
+};
+
+const secondaryBtn = {
+  padding: "10px 22px",
+  borderRadius: 10,
+  border: "1px solid rgba(84,84,88,0.65)",
+  background: "transparent",
+  color: "rgba(235,235,245,0.75)",
+  fontSize: 14,
+  fontWeight: 600,
+  textDecoration: "none",
+  display: "inline-flex",
+  alignItems: "center",
+};
+
+export default function DetailError({ error, reset }: DetailErrorProps) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <main className="container" style={card}>
+      <div style={{ fontSize: 40, marginBottom: 16 }} aria-hidden="true">
+        🌥️
+      </div>
+      <h1
+        style={{
+          fontFamily: "'Sora', sans-serif",
+          fontSize: 22,
+          color: "#ffffff",
+          marginBottom: 10,
+          lineHeight: 1.3,
+        }}
+      >
+        这一页暂时加载不出来
+      </h1>
+      <p
+        style={{
+          color: "rgba(235,235,245,0.60)",
+          fontSize: 14,
+          lineHeight: 1.7,
+          marginBottom: 28,
+        }}
+      >
+        可能是上游数据源一时繁忙。稍等片刻再试，通常很快就好。
+        <br />
+        <span style={{ color: "rgba(235,235,245,0.40)", fontSize: 13 }}>
+          Couldn&apos;t load this page right now — please try again.
+        </span>
+      </p>
+      <div
+        style={{
+          display: "flex",
+          gap: 12,
+          justifyContent: "center",
+          flexWrap: "wrap",
+        }}
+      >
+        <button type="button" onClick={() => reset()} style={primaryBtn}>
+          重试
+        </button>
+        <Link href="/" style={secondaryBtn}>
+          返回首页
+        </Link>
+      </div>
+      {error.digest && (
+        <p
+          style={{
+            marginTop: 24,
+            color: "rgba(235,235,245,0.25)",
+            fontSize: 11,
+            fontFamily: "'JetBrains Mono', monospace",
+          }}
+        >
+          {error.digest}
+        </p>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Problem

Users hit **500 / "Internal Server Error"** on `/anime/[id]` (e.g. id 1, 30, intermittently others). Diagnosed live on prod:

Full-catalog SEO crawlers (last window: **5083 detail hits / 3278 distinct ids** — bingbot 264, generic `bot` 4698, ahrefs 90, googlebot 24) were driving two compounding rate limits into user-facing 500s:

1. **Inbound per-IP limiter collapse.** `/anime/[id]` is SSR with `auth:false`, so next-app fetches go-api **without forwarding X-Real-IP** (reading request headers would force the page dynamic and kill ISR/edge caching). Every SSR read reaches go-api from the single next-app container IP (`172.18.0.5`), collapsing into one `1 req/s` bucket. Under crawl, that bucket is permanently drained → go-api **429**s legitimate reads → `loadDetail` re-throws → **500**. (Verified: direct internal `GET /api/anime/1` returned `429 TOO_MANY_REQUESTS` 4/4; `/api/anime/{id}/watchers` 429 in logs.)
2. **Synchronous AniList re-fetch on a 1h TTL.** Each crawled page older than 1h fired a blocking AniList refresh; a full sweep blew AniList's per-IP limit (178 rate-limit hits / 1000 log lines) → go-api **502 "AniList upstream error"** on cold ids → **500**.

## Fixes

- **Exempt public catalog GET reads** (`/api/anime/*`, except the expensive `search`/`torrents` fan-outs) from the inbound per-IP limiter. Writes/auth/external fan-outs stay limited. → in-DB anime (14,092 rows) now reach the handler and degrade to stale 200 instead of 429→500.
- **`staleCacheTTL` 1h → 24h** so a crawl serves straight from the DB row without touching AniList.
- **AniList circuit breaker**: after a rate-limit exhausts retries, short-circuit for 30s so the detail handler degrades to stale data in microseconds instead of burning the ~15s retry budget per request (and stops hammering AniList while it's asking us to back off).
- **`app/anime/[id]/error.tsx`**: residual upstream failures render a retryable card (Navbar/chrome intact) instead of a bare "Internal Server Error".

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -race ./internal/httpmw/ ./internal/anilist/` — incl. new `TestIsPublicReadExempt`, `TestAPIRateLimiter_PublicReadExempt`, `TestAPIRateLimiter_ExpensiveAnimePathsStillLimited`, `TestClient_Breaker_ShortCircuitsWhileOpen`, `TestClient_Breaker_ClosesAfterCooldown`
- [x] `go test ./internal/anime/` — `staleTimestamp` updated to 25h for the 24h threshold
- [x] next-app `bun test` 245/0; `error.tsx` typechecks + eslint clean
- [ ] Post-deploy: `GET /anime/1` and `/anime/30` return 200; `/api/anime/{id}/watchers` no longer 429; AniList rate-limit log volume drops