### PR TITLE
test(anilist): de-flake breaker retry tests (keep-alive)

### DIFF
--- a/go-api/internal/anilist/client_test.go
+++ b/go-api/internal/anilist/client_test.go
@@ -44,6 +44,21 @@ func newNoopSleep() (func(context.Context, time.Duration) error, *[]time.Duratio
 	return hook, &recorded
 }
 
+// freshConnClient returns an *http.Client with keep-alives disabled, so the
+// 429 retry loop opens a new connection per attempt.  The retry tests fire
+// several sequential POSTs at the httptest server; reusing a keep-alive
+// connection races the server closing an idle conn, and net/http does NOT
+// auto-retry a non-idempotent POST on a stale connection — it surfaces the
+// error, which cuts the retry loop short and flakes the asserted attempt
+// count under CI load (observed: TestClient_Breaker_ClosesAfterCooldown got
+// 5 calls instead of 8).  A fresh connection per attempt removes the race.
+func freshConnClient() *http.Client {
+	return &http.Client{
+		Timeout:   httpTimeout,
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}
+}
+
 // testClient builds a Client pointed at the given fake URL.  The
 // limiter is replaced with an unrestricted one so individual tests
 // don't pay the 700ms tax — TestClient_Throttle_700ms is the only
@@ -317,7 +332,7 @@ func TestClient_429_GiveUpAfter3Retries(t *testing.T) {
 	defer srv.Close()
 
 	sleepHook, recorded := newNoopSleep()
-	c := NewClient(WithEndpoint(srv.URL), WithSleep(sleepHook))
+	c := NewClient(WithEndpoint(srv.URL), WithSleep(sleepHook), WithHTTPClient(freshConnClient()))
 	c.limiter = rate.NewLimiter(rate.Inf, 0)
 
 	_, err := c.Search(context.Background(), SearchVars{Page: 1, PerPage: 20})
@@ -346,7 +361,7 @@ func TestClient_Breaker_ShortCircuitsWhileOpen(t *testing.T) {
 	defer srv.Close()
 
 	sleepHook, _ := newNoopSleep()
-	c := NewClient(WithEndpoint(srv.URL), WithSleep(sleepHook))
+	c := NewClient(WithEndpoint(srv.URL), WithSleep(sleepHook), WithHTTPClient(freshConnClient()))
 	c.limiter = rate.NewLimiter(rate.Inf, 0)
 
 	// First call exhausts the retry budget (1 + 3 = 4 attempts) and trips
@@ -378,6 +393,7 @@ func TestClient_Breaker_ClosesAfterCooldown(t *testing.T) {
 		WithEndpoint(srv.URL),
 		WithSleep(sleepHook),
 		WithNow(func() time.Time { return now }),
+		WithHTTPClient(freshConnClient()),
 	)
 	c.limiter = rate.NewLimiter(rate.Inf, 0)
 


### PR DESCRIPTION
## Why

After #40 merged, the **Unit Tests** workflow on `main` went red (run `26963184639`): `TestClient_Breaker_ClosesAfterCooldown` failed with `expected: 8, actual: 5`. The same commit passed on the PR branch — classic flake.

## Root cause

The 429 retry loop fires several **sequential POSTs** at the httptest server. After a 429, the body is drained/closed and the keep-alive connection returns to the idle pool. Under CI load the server can close that idle conn just as the next attempt reuses it; `net/http` does **not** auto-retry a non-idempotent POST on a stale connection, so `http.Do` returns an error and the retry loop exits early (1 call instead of 4 → 5 instead of 8).

## Fix

Add `freshConnClient()` (`Transport.DisableKeepAlives: true`) and use it in the three retry-loop tests that assert an exact attempt count: both breaker tests + `TestClient_429_GiveUpAfter3Retries`. Each attempt now opens a fresh connection, removing the reuse race. **Test-only** — no product code touched.

## Validation

- `go test -race -count=300 -run 'TestClient_Breaker|GiveUp'` → ok (900 iterations)
- `go test -race ./internal/anilist/` → ok
- build + gofmt clean