### PR TITLE
feat(legal): homepage title slim-down + footer legal pages

### DIFF
--- a/next-app/src/app/copyright/page.tsx
+++ b/next-app/src/app/copyright/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from "next";
+import LegalDoc, { legalStyles as x } from "@/components/legal/LegalDoc";
+import { getLang } from "@/lib/i18n";
+
+export const revalidate = 3600;
+
+const CONTACT = "copyright@animegoclub.com";
+const UPDATED = "2026年6月5日";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await getLang();
+  const title = lang === "zh" ? "版权与侵权处理" : "Copyright & Takedown";
+  const description =
+    lang === "zh"
+      ? "AnimeGoClub 版权声明与侵权通知（takedown）流程：本站不托管影音文件，权利人如何提交移除请求。"
+      : "AnimeGoClub copyright notice and takedown process. We host no media files; how rights holders submit removal requests.";
+  return {
+    title,
+    description,
+    alternates: { canonical: "/copyright", languages: { "zh-CN": "/copyright" } },
+    openGraph: { title, description, url: "/copyright", type: "website" },
+  };
+}
+
+export default function CopyrightPage() {
+  return (
+    <LegalDoc title="版权与侵权处理" updated={`最后更新：${UPDATED}`}>
+      <p style={x.p}>我们尊重知识产权，并致力于配合权利人妥善处理侵权问题。</p>
+
+      <h2 style={x.h2}>一、关于本站内容</h2>
+      <ul style={x.ul}>
+        <li style={x.li}>
+          <strong style={x.strong}>本站不存储、不托管任何影音文件。</strong>
+        </li>
+        <li style={x.li}>
+          番剧元数据（标题、封面、简介、评分、声优等）来自 AniList、Bangumi 等公开来源。
+        </li>
+        <li style={x.li}>
+          站内出现的部分外部链接（如磁力链接）指向由第三方公开来源或用户提供的资源；
+          本站仅作信息索引，不控制、不上传、亦不保证其内容。
+        </li>
+      </ul>
+
+      <h2 style={x.h2}>二、侵权通知（Takedown）</h2>
+      <p style={x.p}>
+        若你是版权人或其授权代理，且善意认为本站上的某项信息侵犯了你的权利，
+        请发送邮件至 <a style={x.a} href={`mailto:${CONTACT}`}>{CONTACT}</a>，并提供以下信息：
+      </p>
+      <ul style={x.ul}>
+        <li style={x.li}>权利人或授权代理的姓名、联系方式及授权证明；</li>
+        <li style={x.li}>受版权保护作品的说明（足以识别）；</li>
+        <li style={x.li}>被指信息在本站的<strong style={x.strong}>具体位置（完整 URL）</strong>；</li>
+        <li style={x.li}>你善意相信该使用未获权利人、其代理或法律授权的声明；</li>
+        <li style={x.li}>通知内容真实、且你有权代表相关权利人行事的声明。</li>
+      </ul>
+      <p style={x.p}>
+        我们将在收到完整、有效通知后的<strong style={x.strong}>合理时间内（通常 5 个工作日内）</strong>
+        进行核查，并移除或禁用相应信息。
+      </p>
+
+      <h2 style={x.h2}>三、重复侵权</h2>
+      <p style={x.p}>对于多次被认定侵权的账号或来源，我们将在适当情况下终止其使用。</p>
+
+      <h2 style={x.h2}>四、联系</h2>
+      <p style={x.p}>
+        版权与侵权相关事宜，请联系 <a style={x.a} href={`mailto:${CONTACT}`}>{CONTACT}</a>。
+        本声明受中华人民共和国香港特别行政区法律管辖。
+      </p>
+    </LegalDoc>
+  );
+}

--- a/next-app/src/app/privacy/page.tsx
+++ b/next-app/src/app/privacy/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from "next";
+import LegalDoc, { legalStyles as x } from "@/components/legal/LegalDoc";
+import { getLang } from "@/lib/i18n";
+
+// Static legal page — hourly revalidate so copy edits land without a deploy.
+export const revalidate = 3600;
+
+const CONTACT = "copyright@animegoclub.com";
+const UPDATED = "2026年6月5日";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await getLang();
+  const title = lang === "zh" ? "隐私政策" : "Privacy Policy";
+  const description =
+    lang === "zh"
+      ? "AnimeGoClub 隐私政策：我们收集哪些数据、如何使用、Cookie、第三方处理者与你的权利。"
+      : "AnimeGoClub Privacy Policy: what we collect, how we use it, cookies, processors and your rights.";
+  return {
+    title,
+    description,
+    alternates: { canonical: "/privacy", languages: { "zh-CN": "/privacy" } },
+    openGraph: { title, description, url: "/privacy", type: "website" },
+  };
+}
+
+export default function PrivacyPage() {
+  return (
+    <LegalDoc title="隐私政策" updated={`最后更新：${UPDATED}`}>
+      <p style={x.p}>
+        本政策说明 AnimeGoClub（“本站”）在你使用本站时收集、使用与保护个人信息的方式。
+        使用本站即表示你已阅读并理解本政策。
+      </p>
+
+      <h2 style={x.h2}>一、我们收集的信息</h2>
+      <ul style={x.ul}>
+        <li style={x.li}>
+          <strong style={x.strong}>账号信息</strong>：注册邮箱、用户名，以及经加密（哈希）存储的密码。
+        </li>
+        <li style={x.li}>
+          <strong style={x.strong}>使用数据</strong>：你的追番列表、观看进度、评分、收藏等与账号关联的数据。
+        </li>
+        <li style={x.li}>
+          <strong style={x.strong}>你发布的内容</strong>：评论、弹幕等由你主动提交的内容。
+        </li>
+        <li style={x.li}>
+          <strong style={x.strong}>个性化数据</strong>：头像、主页背景等资料设置。
+        </li>
+        <li style={x.li}>
+          <strong style={x.strong}>技术数据</strong>：登录会话、IP 地址、设备与浏览器信息、访问日志，用于安全与故障排查。
+        </li>
+      </ul>
+
+      <h2 style={x.h2}>二、Cookie 与本地存储</h2>
+      <p style={x.p}>
+        我们使用必要的 Cookie 维持登录状态：<strong style={x.strong}>session</strong> 与{" "}
+        <strong style={x.strong}>refreshToken</strong> 为仅服务器可读（httpOnly）的登录凭证；
+        <strong style={x.strong}>auth_hint</strong> 为非敏感标记，仅供前端判断是否已登录。
+        我们<strong style={x.strong}>不使用第三方广告追踪 Cookie</strong>。
+      </p>
+
+      <h2 style={x.h2}>三、我们如何使用信息</h2>
+      <ul style={x.ul}>
+        <li style={x.li}>提供并维持核心功能（登录、追番、评分、评论、弹幕、播放等）。</li>
+        <li style={x.li}>保障账号与服务安全、防止滥用。</li>
+        <li style={x.li}>改进产品体验与排查问题。</li>
+      </ul>
+      <p style={x.p}>我们不出售你的个人信息。</p>
+
+      <h2 style={x.h2}>四、第三方处理者与数据来源</h2>
+      <ul style={x.ul}>
+        <li style={x.li}>
+          <strong style={x.strong}>Cloudflare</strong>：作为 CDN 与安全防护，会处理访问流量与 IP。
+        </li>
+        <li style={x.li}>
+          <strong style={x.strong}>Sentry</strong>：用于错误监控，可能接收少量技术性错误数据。
+        </li>
+        <li style={x.li}>
+          番剧元数据（标题、封面、简介、评分、声优等）来自{" "}
+          <a style={x.a} href="https://anilist.co" target="_blank" rel="noreferrer">AniList</a>、{" "}
+          <a style={x.a} href="https://bgm.tv" target="_blank" rel="noreferrer">Bangumi</a> 等公开来源；
+          我们向其请求公开数据，<strong style={x.strong}>不向其发送你的个人信息</strong>。
+        </li>
+      </ul>
+
+      <h2 style={x.h2}>五、数据保留与安全</h2>
+      <p style={x.p}>
+        我们在你的账号存续期间保留相关数据，并采取合理的技术与管理措施加以保护。
+        但请注意，互联网传输与存储不存在绝对安全。
+      </p>
+
+      <h2 style={x.h2}>六、你的权利</h2>
+      <ul style={x.ul}>
+        <li style={x.li}>在“设置”中查看与更新你的资料。</li>
+        <li style={x.li}>
+          如需删除账号及相关数据，可通过 <a style={x.a} href={`mailto:${CONTACT}`}>{CONTACT}</a> 联系我们。
+        </li>
+      </ul>
+
+      <h2 style={x.h2}>七、未成年人</h2>
+      <p style={x.p}>本站不面向低龄未成年人提供服务；若你为未成年人，请在监护人指导下使用。</p>
+
+      <h2 style={x.h2}>八、政策变更</h2>
+      <p style={x.p}>我们可能不时更新本政策，重大变更将于本页公布并更新“最后更新”日期。</p>
+
+      <h2 style={x.h2}>九、联系我们</h2>
+      <p style={x.p}>
+        如对本政策有任何疑问，请联系 <a style={x.a} href={`mailto:${CONTACT}`}>{CONTACT}</a>。
+        本政策受中华人民共和国香港特别行政区法律管辖。
+      </p>
+    </LegalDoc>
+  );
+}

--- a/next-app/src/app/sitemap.ts
+++ b/next-app/src/app/sitemap.ts
@@ -55,6 +55,24 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "monthly",
       priority: 0.4,
     },
+    {
+      url: `${SITE}/terms`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.2,
+    },
+    {
+      url: `${SITE}/privacy`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.2,
+    },
+    {
+      url: `${SITE}/copyright`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.2,
+    },
   ];
 
   let animeUrls: MetadataRoute.Sitemap = [];

--- a/next-app/src/app/terms/page.tsx
+++ b/next-app/src/app/terms/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import LegalDoc, { legalStyles as x } from "@/components/legal/LegalDoc";
+import { getLang } from "@/lib/i18n";
+
+export const revalidate = 3600;
+
+const CONTACT = "copyright@animegoclub.com";
+const UPDATED = "2026年6月5日";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const lang = await getLang();
+  const title = lang === "zh" ? "服务条款" : "Terms of Service";
+  const description =
+    lang === "zh"
+      ? "AnimeGoClub 服务条款：账号、用户内容、可接受使用、第三方内容与链接、免责与责任限制。"
+      : "AnimeGoClub Terms of Service: accounts, user content, acceptable use, third-party links, disclaimers.";
+  return {
+    title,
+    description,
+    alternates: { canonical: "/terms", languages: { "zh-CN": "/terms" } },
+    openGraph: { title, description, url: "/terms", type: "website" },
+  };
+}
+
+export default function TermsPage() {
+  return (
+    <LegalDoc title="服务条款" updated={`最后更新：${UPDATED}`}>
+      <p style={x.p}>
+        欢迎使用 AnimeGoClub（“本站”）。访问或使用本站，即表示你同意本服务条款。
+        若你不同意，请勿使用本站。
+      </p>
+
+      <h2 style={x.h2}>一、服务说明</h2>
+      <p style={x.p}>
+        本站是一个动漫资料、发现、追番管理与弹幕播放工具，提供番剧元数据浏览、
+        每季新番、评分、声优、评论、弹幕与个人追番管理等功能。
+      </p>
+
+      <h2 style={x.h2}>二、账号</h2>
+      <ul style={x.ul}>
+        <li style={x.li}>你需提供真实、准确的注册信息，并对账号下的所有活动负责。</li>
+        <li style={x.li}>请妥善保管你的登录凭证；如发现未经授权的使用，请及时联系我们。</li>
+      </ul>
+
+      <h2 style={x.h2}>三、用户内容</h2>
+      <ul style={x.ul}>
+        <li style={x.li}>
+          你对自己发布的内容（评论、弹幕等）负责，并保留其权利；
+          你授予本站为提供服务而展示该内容的非独占许可。
+        </li>
+        <li style={x.li}>
+          禁止发布违法、侵权、辱骂、垃圾或其他不当内容；我们有权在不另行通知的情况下移除。
+        </li>
+      </ul>
+
+      <h2 style={x.h2}>四、可接受使用</h2>
+      <p style={x.p}>
+        你同意不滥用本站，包括但不限于：自动化抓取、攻击或干扰服务、规避访问限制、
+        以及任何违反适用法律的行为。
+      </p>
+
+      <h2 style={x.h2}>五、第三方内容与链接</h2>
+      <ul style={x.ul}>
+        <li style={x.li}>
+          <strong style={x.strong}>本站不存储、不托管任何影音文件。</strong>
+        </li>
+        <li style={x.li}>
+          番剧元数据来自 AniList、Bangumi 等公开来源；站内出现的部分外部链接由第三方公开来源或用户提供，本站仅作信息索引。
+        </li>
+        <li style={x.li}>
+          我们不控制亦不对第三方内容的合法性、准确性或可用性负责。版权相关事宜见{" "}
+          <Link style={x.a} href="/copyright">版权与侵权处理</Link>。
+        </li>
+      </ul>
+
+      <h2 style={x.h2}>六、知识产权</h2>
+      <p style={x.p}>
+        本站的界面设计、代码与原创内容的知识产权归本站所有，未经许可不得复制或商业使用。
+      </p>
+
+      <h2 style={x.h2}>七、免责声明</h2>
+      <p style={x.p}>
+        本站按“现状”与“现有”提供，不作任何明示或默示的担保（包括适销性、特定用途适用性等）。
+        你使用本站的风险由你自行承担。
+      </p>
+
+      <h2 style={x.h2}>八、责任限制</h2>
+      <p style={x.p}>
+        在适用法律允许的最大范围内，本站不对因使用或无法使用本站而产生的任何间接、附带或后果性损失负责。
+      </p>
+
+      <h2 style={x.h2}>九、终止</h2>
+      <p style={x.p}>对违反本条款的账号，我们可在适当情况下暂停或终止其使用。</p>
+
+      <h2 style={x.h2}>十、条款变更</h2>
+      <p style={x.p}>我们可能不时更新本条款，变更将于本页公布并更新“最后更新”日期。</p>
+
+      <h2 style={x.h2}>十一、适用法律与联系</h2>
+      <p style={x.p}>
+        本条款受中华人民共和国香港特别行政区法律管辖。如有疑问请联系{" "}
+        <a style={x.a} href={`mailto:${CONTACT}`}>{CONTACT}</a>。
+      </p>
+    </LegalDoc>
+  );
+}

--- a/next-app/src/components/layout/Footer.tsx
+++ b/next-app/src/components/layout/Footer.tsx
@@ -111,11 +111,12 @@ export default function Footer({ dict, season, year }: FooterProps) {
 
   const supportLinks: Array<{ label: string; to?: string }> = [
     { label: dict.footer.faq, to: "/faq" }, // P11: /faq now a real next-app page
+    { label: dict.footer.terms, to: "/terms" },
+    { label: dict.footer.privacy, to: "/privacy" },
+    { label: dict.footer.copyrightNotice, to: "/copyright" },
     { label: dict.footer.contact },
     { label: dict.footer.feedback },
     { label: dict.footer.api },
-    { label: dict.footer.terms },
-    { label: dict.footer.privacy },
   ];
 
   return (
@@ -176,7 +177,11 @@ export default function Footer({ dict, season, year }: FooterProps) {
             <ul style={s.linkList}>
               {supportLinks.map((l) => (
                 <li key={l.label}>
-                  <a href="#" style={s.link}>{l.label}</a>
+                  {l.to ? (
+                    <Link href={l.to} prefetch={false} style={s.link}>{l.label}</Link>
+                  ) : (
+                    <a href="#" style={s.link}>{l.label}</a>
+                  )}
                 </li>
               ))}
             </ul>

--- a/next-app/src/components/legal/LegalDoc.tsx
+++ b/next-app/src/components/legal/LegalDoc.tsx
@@ -1,0 +1,61 @@
+import type { CSSProperties, ReactNode } from "react";
+
+// Shared chrome + prose styling for the static legal pages (/privacy,
+// /terms, /copyright). Owns layout + typography only so the three
+// documents stay visually consistent; the legal copy lives in each page.
+
+const wrap: CSSProperties = {
+  maxWidth: 820,
+  margin: "0 auto",
+  padding: "56px 24px 96px",
+  color: "rgba(235,235,245,0.82)",
+  fontSize: 15,
+  lineHeight: 1.8,
+};
+const titleStyle: CSSProperties = {
+  fontFamily: "'Sora', sans-serif",
+  fontSize: 28,
+  fontWeight: 700,
+  color: "#fff",
+  marginBottom: 8,
+  lineHeight: 1.25,
+};
+const updatedStyle: CSSProperties = {
+  fontSize: 13,
+  color: "rgba(235,235,245,0.40)",
+  marginBottom: 36,
+};
+
+// Prose tokens reused by every legal page so headings/lists/links match.
+export const legalStyles = {
+  h2: {
+    fontFamily: "'Sora', sans-serif",
+    fontSize: 18,
+    fontWeight: 600,
+    color: "#fff",
+    margin: "36px 0 12px",
+  } as CSSProperties,
+  p: { margin: "0 0 14px" } as CSSProperties,
+  ul: { margin: "0 0 14px", paddingLeft: 22 } as CSSProperties,
+  li: { margin: "0 0 7px" } as CSSProperties,
+  a: { color: "#0a84ff", textDecoration: "none" } as CSSProperties,
+  strong: { color: "#fff", fontWeight: 600 } as CSSProperties,
+};
+
+export default function LegalDoc({
+  title,
+  updated,
+  children,
+}: {
+  title: string;
+  updated: string;
+  children: ReactNode;
+}) {
+  return (
+    <main style={wrap}>
+      <h1 style={titleStyle}>{title}</h1>
+      <p style={updatedStyle}>{updated}</p>
+      {children}
+    </main>
+  );
+}

--- a/next-app/src/locales/en.ts
+++ b/next-app/src/locales/en.ts
@@ -206,6 +206,7 @@ const en = {
     api: 'API',
     terms: 'Terms of Service',
     privacy: 'Privacy Policy',
+    copyrightNotice: 'Copyright & Takedown',
     dataCredits: 'Data provided by',
     copyright: '© {year} AnimeGoClub · Rundle Streetが暮れる。東京が灯る。',
   },

--- a/next-app/src/locales/zh.ts
+++ b/next-app/src/locales/zh.ts
@@ -13,7 +13,7 @@ const zh = {
     // Homepage SEO: brand + 番剧 front-loaded so the brand+category query
     // "animegoclub 番剧" matches the homepage, not a detail page. See
     // app/page.tsx generateMetadata + the visually-hidden <h1>.
-    homeTitle: 'AnimeGoClub · 番剧追番与动漫发现平台 · Rundle Streetが暮れる。東京が灯る。',
+    homeTitle: 'AnimeGoClub · Rundle Streetが暮れる。東京が灯る。',
     homeDescription:
       'AnimeGoClub 是番剧追番与动漫发现平台 —— 每季新番、评分、声优、弹幕评论与追番管理。',
     homeH1: 'AnimeGoClub —— 番剧追番与动漫发现平台',
@@ -258,6 +258,7 @@ const zh = {
     api: 'API',
     terms: '服务条款',
     privacy: '隐私政策',
+    copyrightNotice: '版权 · 侵权处理',
     dataCredits: '数据来自',
     copyright: '© {year} AnimeGoClub · Rundle Streetが暮れる。東京が灯る。',
   },


### PR DESCRIPTION
## What

- **Homepage `<title>` / `og:title`** trimmed to brand + slogan (`zh.ts` `homeTitle`): `AnimeGoClub · Rundle Streetが暮れる。東京が灯る。`. Chinese keywords stay carried by the homepage **meta description + h1**, so the page isn't keyword-naked (verified on prod).
- **New static legal pages**: `/privacy` (隐私政策), `/terms` (服务条款), `/copyright` (版权与侵权处理 + notice-and-takedown + contact). zh body, bilingual metadata, shared `LegalDoc` chrome.
- **Footer**: the Support column links were all dead `href="#"` (even FAQ) — wired `faq/terms/privacy/copyright` to real routes + added the `版权·侵权处理` / `Copyright & Takedown` label (zh/en).
- **sitemap**: lists the three legal pages.

## ⚠️ Before this is "real"
- **DRAFT legal copy — not legal advice.** Have a HK IP lawyer review (esp. the takedown wording + the disclaimer) before relying on it for the 5-year posture.
- **`copyright@animegoclub.com` must be made deliverable** (e.g. Cloudflare Email Routing → your inbox), otherwise the takedown contact bounces — worse than none.

## Test plan
- [x] `bun run build` → `/privacy` `/terms` `/copyright` prerendered static (in prerender-manifest)
- [x] `tsc --noEmit` clean (changed files), `eslint` clean, `bun test` 245/0
- [ ] Post-deploy: footer links resolve; pages render; sitemap lists them