### PR TITLE
feat(anime): card hover-lift + navbar underline animations

### DIFF
--- a/next-app/src/app/anime/[id]/page.tsx
+++ b/next-app/src/app/anime/[id]/page.tsx
@@ -686,6 +686,7 @@ function RelationsSection({
               key={`${rel.anilistId}-${rel.relationType}`}
               href={`/anime/${rel.anilistId}`}
               prefetch={false}
+              className="card-lift"
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -1067,6 +1068,7 @@ function RecommendationsSection({
               key={r.anilistId}
               href={`/anime/${r.anilistId}`}
               prefetch={false}
+              className="card-lift"
               style={{
                 flexShrink: 0,
                 width: 110,

--- a/next-app/src/app/globals.css
+++ b/next-app/src/app/globals.css
@@ -197,3 +197,41 @@ h4 {
 .art-video-player .art-control-heatmap {
   transform: translateZ(0);
 }
+
+/* ── Card hover lift (relation / recommendation cards on /anime/[id]) ──────
+   Compositor-only transform; reduced-motion safe. */
+@media (prefers-reduced-motion: no-preference) {
+  .card-lift {
+    transition: transform 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  .card-lift:hover {
+    transform: translateY(-4px);
+  }
+}
+
+/* ── Navbar link: underline wipes in on hover ─────────────────────────────
+   Active state keeps its existing pill (set inline); this only adds the
+   hover affordance. transform-only (scaleX), reduced-motion safe. */
+.nav-link {
+  position: relative;
+}
+.nav-link::after {
+  content: "";
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 5px;
+  height: 2px;
+  border-radius: 2px;
+  background: #0a84ff;
+  transform: scaleX(0);
+  transform-origin: left center;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .nav-link::after {
+    transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+}
+.nav-link:hover::after {
+  transform: scaleX(1);
+}

--- a/next-app/src/components/layout/Navbar.tsx
+++ b/next-app/src/components/layout/Navbar.tsx
@@ -205,6 +205,7 @@ export default function Navbar({ season, year }: NavbarProps) {
               key={l.key}
               href={l.href}
               prefetch={false}
+              className="nav-link"
               style={s.link(isActive(pathname, l.href))}
               aria-current={isActive(pathname, l.href) ? "page" : undefined}
             >


### PR DESCRIPTION
## What

Two small, robust hover animations on `/anime/[id]` + the navbar:

- **Card hover-lift** — relation (关联作品) and recommendation (看了这部还在看) cards lift 4px on hover.
- **Navbar underline** — nav links get a blue underline that wipes in (scaleX) on hover; the active link keeps its existing pill.

Both are **compositor-only** (`transform`), gated on `prefers-reduced-motion: no-preference`, and **pure CSS** — no JS, no hydration dependency.

## Dropped (intentionally)

A JS scroll-entrance reveal (fade-up as cards enter view) was prototyped (`Reveal` → `RevealGroup`) and removed:
- It depended on client hydration, which a Grammarly-injected `<body>` attribute mismatch broke in real browsers (cards stayed static).
- Its `transform` also collided with the hover-lift `transform` on the same element.

Can return later as a **pure-CSS scroll-driven** version (`animation-timeline: view()`) that needs no JS/hydration. Tracked as a follow-up.

## Test plan
- [x] `tsc --noEmit` clean; net diff is +42 lines across 3 files (no JS components)
- [x] headless: card baseline `none` → hover `translateY(-4px)`; nav `::after` scaleX 0 → 1
- [ ] Post-deploy: hover a card → lifts; hover a nav item → underline wipes in