### PR TITLE
perf(home): island per-user sections so the homepage is edge-cacheable

### DIFF
--- a/next-app/src/app/page.tsx
+++ b/next-app/src/app/page.tsx
@@ -21,21 +21,26 @@ import type {
 // Phase 8.0: HomePage replaces the LandingPage at /. The marketing
 // page moved to /welcome.
 //
-// dynamic = "force-dynamic" instead of revalidate = 60:
-// The homepage aggregates 6 different upstream fetches with different
-// freshness needs (schedule changes hourly as Mongo rotates the
-// window; trending tightens every minute; yearly-top barely changes).
-// A single page-level revalidate window forces every fetch through
-// the same ISR cache and effectively silences each fetcher's own
-// `cache` / `revalidate` option — that's how schedule ended up
-// showing day-old tab counts even after we switched it to "no-store"
-// (the page-level revalidate=60 overrode it). Force-dynamic keeps
-// the page SSR per request; each safe* fetcher then honors its own
-// revalidate / cache mode, so schedule stays live while trending /
-// yearly-top can still cache. Cost: ~one server render per page
-// hit. The actual cards still benefit from Cloudflare HTML cache
-// in prod, and the per-page render is cheap because the upstream
-// API responses are themselves cached on the Express side.
+// dynamic = "force-dynamic" — and it STAYS, deliberately:
+//
+//   1. go-api is unreachable at `next build` (GO_API_INTERNAL_URL is a runtime
+//      env, not a build arg), so ISR would prerender an EMPTY homepage and keep
+//      serving it for the whole revalidate window after every deploy. Detail
+//      pages dodge this via generateStaticParams → [] → ISR-on-demand; a
+//      paramless static route has no such escape hatch. force-dynamic keeps the
+//      page rendering REAL data on first request.
+//   2. The two per-user sections (ContinueWatching, ActivityFeed) are now
+//      CLIENT islands, so this dynamic HTML is byte-identical for every
+//      anonymous visitor — no per-user data, no cache-poisoning risk.
+//
+// Caching is therefore done at the EDGE, not via Next ISR: a Cloudflare Cache
+// Rule on `/` with Edge TTL "override origin" (60s) + stale-while-revalidate
+// caches the anonymous render despite the no-store header force-dynamic emits,
+// and bypasses on the session / refreshToken cookie so logged-in users always
+// hit the origin. Anonymous + crawler traffic (the load that drove the
+// detail-page 500 incident) is served from the CF edge; the origin renders
+// ~once per 60s per PoP. Per-fetcher freshness (schedule no-store, etc.) still
+// holds at the origin; CF just caps how often anonymous traffic reaches it.
 export const dynamic = "force-dynamic";
 
 type Season = "WINTER" | "SPRING" | "SUMMER" | "FALL";

--- a/next-app/src/components/anime/ContinueWatching.tsx
+++ b/next-app/src/components/anime/ContinueWatching.tsx
@@ -1,20 +1,20 @@
+"use client";
+
 import Link from "next/link";
-import { ApiError, apiGet } from "@/lib/api";
 import { pickTitle } from "@/lib/formatters";
 import FadeImage from "@/components/ui/FadeImage";
+import { useAuthGatedList } from "@/lib/useAuthGatedList";
 import type { Dict, Lang } from "@/lib/i18n";
 import type { WatchingItem } from "@/lib/types";
 
-// RSC ContinueWatching. Server-side tries
-// `/api/subscriptions?status=watching`. 401 → render the logged-out
-// CTA stub. Authed-with-zero-rows → hide the section entirely (matches
-// legacy ContinueWatching.jsx: `if (!user || !list?.length) return null`
-// becomes "show stub when no auth, hide when authed-but-empty" — a
-// homepage with the CTA still makes sense for new visitors).
-//
-// Cookie forwarding via lib/api.ts buildHeaders() — same path the
-// ActivityFeed sibling uses. Both rely on P8.1 cookie dual-track
-// (commit cc073f9).
+// Client island ContinueWatching. Was an async RSC that read cookies()
+// server-side — that personalized the homepage HTML and blocked edge caching
+// (a cached watch list would leak across anonymous visitors). Now it fetches
+// `/api/subscriptions?status=watching` on the client, gated on the `auth_hint`
+// cookie (see useAuthGatedList): anonymous loads fire zero auth requests and
+// render the CTA stub; authed loads show the grid (or hide the section when the
+// watching bucket is empty). The homepage shell around it stays anonymous and
+// CF-cacheable.
 
 interface ContinueWatchingProps {
   dict: Dict;
@@ -275,28 +275,37 @@ function WatchingGrid({
   );
 }
 
-export default async function ContinueWatching({
+// Initial / first-paint state — the neutral blurred grid that lands in the
+// edge-cached HTML (no overlay, no user data, same for everyone). The client
+// swaps it for the stub or the real grid after hydration.
+function LoadingSkeleton({ dict }: { dict: Dict }) {
+  return (
+    <section style={sectionStyle} aria-label={dict.home.watchingTitle}>
+      <div style={headerStyle}>
+        <p style={labelStyle}>{dict.home.continueLabel}</p>
+        <h2 style={titleStyle}>{dict.home.watchingTitle}</h2>
+      </div>
+      <div style={wrapStyle}>
+        <div style={stubGridStyle} aria-hidden="true">
+          {Array.from({ length: PLACEHOLDER_COUNT }).map((_, i) => (
+            <div key={i} style={placeholderCardStyle} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function ContinueWatching({
   dict,
   lang,
 }: ContinueWatchingProps) {
-  let items: WatchingItem[] = [];
-  let loggedOut = false;
-  try {
-    items = await apiGet<WatchingItem[]>(
-      "/api/subscriptions?status=watching",
-      { cache: "no-store" },
-    );
-  } catch (err) {
-    if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
-      loggedOut = true;
-    } else {
-      loggedOut = true;
-    }
-  }
+  const { status, items } = useAuthGatedList<WatchingItem>(
+    "/api/subscriptions?status=watching",
+  );
 
-  if (loggedOut) {
-    return <LoggedOutStub dict={dict} lang={lang} />;
-  }
+  if (status === "loading") return <LoadingSkeleton dict={dict} />;
+  if (status === "anonymous") return <LoggedOutStub dict={dict} lang={lang} />;
   // Authed but nothing in this bucket — hide the section entirely.
   // Matches legacy ContinueWatching.jsx: `if (!list?.length) return null`.
   if (items.length === 0) return null;

--- a/next-app/src/components/social/ActivityFeed.tsx
+++ b/next-app/src/components/social/ActivityFeed.tsx
@@ -1,19 +1,17 @@
+"use client";
+
 import Link from "next/link";
 import FadeImage from "@/components/ui/FadeImage";
-import { ApiError, apiGet } from "@/lib/api";
+import { useAuthGatedList } from "@/lib/useAuthGatedList";
 import type { Dict, Lang } from "@/lib/i18n";
-import type { FeedItem, FeedResponse } from "@/lib/types";
+import type { FeedItem } from "@/lib/types";
 
-// RSC activity feed. Server-side tries `/api/feed?page=1`; Express
-// returns 401 if the session cookie is missing/invalid, which we treat
-// as "render the logged-out CTA stub". A successful fetch with zero
-// items still renders the section header so the page reserves space
-// (better LCP than a sudden post-hydrate insertion).
-//
-// Cookie forwarding: lib/api.ts buildHeaders() pulls next/headers
-// cookies() in the RSC context and forwards as Cookie: ...; Express
-// auth middleware reads `req.cookies.session` and verifies the JWT.
-// This relies on the P8.1 cookie dual-track commit cc073f9.
+// Client island activity feed. Was an async RSC that read cookies()
+// server-side — that personalized the homepage HTML and blocked edge caching.
+// Now it fetches `/api/feed?page=1` on the client, gated on the `auth_hint`
+// cookie (see useAuthGatedList): anonymous loads render the CTA stub with zero
+// auth requests; authed loads render the feed (empty-state included). The
+// homepage shell around it stays anonymous and CF-cacheable.
 
 interface ActivityFeedProps {
   dict: Dict;
@@ -292,33 +290,38 @@ function FeedList({ items, dict, lang }: { items: FeedItem[]; dict: Dict; lang: 
   );
 }
 
-export default async function ActivityFeed({ dict, lang }: ActivityFeedProps) {
-  // The Express envelope here is unusual: the response body is
-  // `{data, hasMore, nextPage}` directly (not wrapped in another
-  // `{data: ...}` layer), so apiGet's `env.data` unwrap returns the
-  // items array directly — but the `hasMore` / `nextPage` fields are
-  // lost in the cast. v1 only shows page 1 (no infinite scroll yet),
-  // so dropping them is fine.
-  let items: FeedItem[] = [];
-  let loggedOut = false;
-  try {
-    const resp = await apiGet<FeedResponse>("/api/feed?page=1", { cache: "no-store" });
-    items = resp.data ?? [];
-  } catch (err) {
-    if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
-      loggedOut = true;
-    } else {
-      // Network blip / server 500 — render the stub so the page doesn't
-      // explode. Treating this as "logged out" is a UX compromise: a
-      // logged-in user with a flaky backend sees the login CTA instead
-      // of a spinner. Better than a hard 500 page; revisit when the
-      // observability lane reports real failure rates.
-      loggedOut = true;
-    }
-  }
+// Initial / first-paint state — the neutral blurred rows that land in the
+// edge-cached HTML (no overlay, no user data, same for everyone). The client
+// swaps it for the stub or the real feed after hydration.
+function LoadingSkeleton({ dict }: { dict: Dict }) {
+  return (
+    <section style={sectionStyle} aria-label={dict.social.feedTitle}>
+      <div style={headerStyle}>
+        <p style={labelStyle}>{dict.social.feedLabel}</p>
+        <h2 style={titleStyle}>{dict.social.feedTitle}</h2>
+      </div>
+      <div style={wrapStyle}>
+        <div style={stubListStyle} aria-hidden="true">
+          {Array.from({ length: PLACEHOLDER_ROWS }).map((_, i) => (
+            <div key={i} style={placeholderRowStyle}>
+              <div style={placeholderCoverStyle} />
+              <div style={placeholderTextWideStyle} />
+              <div style={placeholderTextNarrowStyle} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
 
-  if (loggedOut) {
-    return <LoggedOutStub dict={dict} lang={lang} />;
-  }
+export default function ActivityFeed({ dict, lang }: ActivityFeedProps) {
+  // `/api/feed` returns `{ data, hasMore, nextPage }` directly;
+  // useAuthGatedList unwraps `data` to FeedItem[]. v1 only shows page 1 (no
+  // infinite scroll yet), so the hasMore / nextPage fields are dropped.
+  const { status, items } = useAuthGatedList<FeedItem>("/api/feed?page=1");
+
+  if (status === "loading") return <LoadingSkeleton dict={dict} />;
+  if (status === "anonymous") return <LoggedOutStub dict={dict} lang={lang} />;
   return <FeedList items={items} dict={dict} lang={lang} />;
 }

--- a/next-app/src/lib/useAuthGatedList.test.ts
+++ b/next-app/src/lib/useAuthGatedList.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { unwrapList } from "./useAuthGatedList";
+
+// Pure-logic tests. The React hook's auth-gate wiring (auth_hint → authFetch →
+// status: loading | anonymous | ready) is exercised by the homepage E2E; here
+// we lock the envelope-unwrap contract — the regression-prone bit. The two
+// islands hit endpoints with DIFFERENT envelopes:
+//   /api/subscriptions → { data: WatchingItem[] }
+//   /api/feed          → { data: FeedItem[], hasMore, nextPage }
+// and a malformed body MUST degrade to [] (the island renders empty / hides,
+// never throws into the tree). This catches the exact class of bug where the
+// feed's extra fields, or a non-array `data`, would otherwise blow up render.
+
+describe("unwrapList", () => {
+  test("unwraps the {data: [...]} envelope (subscriptions shape)", () => {
+    expect(
+      unwrapList({ data: [{ anilistId: 1 }, { anilistId: 2 }] }),
+    ).toEqual([{ anilistId: 1 }, { anilistId: 2 }]);
+  });
+
+  test("unwraps {data, hasMore, nextPage} and drops the extras (feed shape)", () => {
+    const out = unwrapList({
+      data: [{ username: "a" }],
+      hasMore: true,
+      nextPage: 2,
+    });
+    expect(out).toEqual([{ username: "a" }]);
+  });
+
+  test("tolerates a bare array", () => {
+    expect(unwrapList([{ x: 1 }])).toEqual([{ x: 1 }]);
+  });
+
+  test("empty data array stays empty", () => {
+    expect(unwrapList({ data: [] })).toEqual([]);
+  });
+
+  test("data:null degrades to []", () => {
+    expect(unwrapList({ data: null })).toEqual([]);
+  });
+
+  test("non-array data degrades to [] (never throws into the tree)", () => {
+    expect(unwrapList({ data: "nope" })).toEqual([]);
+  });
+
+  test("null / undefined / primitive bodies degrade to []", () => {
+    expect(unwrapList(null)).toEqual([]);
+    expect(unwrapList(undefined)).toEqual([]);
+    expect(unwrapList("string")).toEqual([]);
+    expect(unwrapList(42)).toEqual([]);
+  });
+});

--- a/next-app/src/lib/useAuthGatedList.ts
+++ b/next-app/src/lib/useAuthGatedList.ts
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import { authFetch } from "@/lib/authFetch";
+import { hasAuthHint } from "@/lib/clientAuth";
+
+// Client-side auth-gated list fetch — the shared engine behind the homepage
+// "islands" (ContinueWatching, ActivityFeed). These sections render per-user
+// data, so they CANNOT be server-rendered into the homepage HTML: that HTML is
+// edge-cached by Cloudflare and shared across all anonymous visitors, and a
+// server-rendered watch list would leak one user's data to everyone (cache
+// poisoning). Moving the fetch to the client keeps the cached shell anonymous.
+//
+// Mirrors the gate Navbar / SubscriptionButton already use: read the non-secret
+// `auth_hint` cookie first so an anonymous load fires ZERO auth requests, then
+// authFetch (which self-heals an expired 15-min session via the refresh cookie).
+//
+// State machine (the consuming island maps each status to UI):
+//
+//   mount
+//     │
+//     ├─ initial render (server + first client paint) ──▶ "loading"
+//     │                                                    (neutral skeleton;
+//     │                                                     this is what lands
+//     │                                                     in the cached HTML)
+//     │
+//     └─ useEffect ─┬─ no auth_hint ──────────────────▶ "anonymous" (CTA stub)
+//                   │
+//                   └─ auth_hint present ─ authFetch ─┬─ ok  ─▶ "ready" + items
+//                                                     └─ 401 / error ─▶ "anonymous"
+//
+// "loading" is deterministic and user-independent on purpose: every visitor's
+// first paint is the same skeleton, so the prerendered/cached HTML never
+// differs by user. hasAuthHint() only resolves client-side (reads
+// document.cookie), so the swap to stub/data always happens post-hydration.
+
+export type AuthGatedStatus = "loading" | "anonymous" | "ready";
+
+export interface AuthGatedListResult<T> {
+  status: AuthGatedStatus;
+  items: T[];
+}
+
+/**
+ * Unwrap an API list response into its item array.
+ *
+ * Handles both envelope shapes the islands hit:
+ *   - `/api/subscriptions` → `{ data: WatchingItem[] }`
+ *   - `/api/feed`          → `{ data: FeedItem[], hasMore, nextPage }`
+ * and tolerates a bare array. Anything malformed (null, primitive, non-array
+ * `data`) degrades to `[]`, so a weird body renders an empty/hidden section
+ * instead of throwing into the React tree.
+ *
+ * Exported so the contract is unit-tested directly (the hook's React wiring is
+ * covered by the homepage E2E), mirroring useDandanComments' dandanToArtplayer.
+ */
+export function unwrapList(body: unknown): unknown[] {
+  const raw =
+    body && typeof body === "object" && "data" in body
+      ? (body as { data: unknown }).data
+      : body;
+  return Array.isArray(raw) ? raw : [];
+}
+
+/**
+ * Fetch a per-user list on the client, gated on the `auth_hint` cookie.
+ *
+ * Unwraps the standard `{ data: [...] }` envelope (and tolerates a bare array),
+ * so both `/api/subscriptions` and `/api/feed` (whose body is
+ * `{ data, hasMore, nextPage }`) yield their item array directly.
+ *
+ * Any failure — no hint, 401 after a refresh attempt, network blip, malformed
+ * body — collapses to `"anonymous"`, which the islands render as the logged-out
+ * CTA stub. That matches the prior server-side behavior (treat any error as
+ * "show the login stub") and never throws into the React tree.
+ *
+ * @param url Same-origin API path (e.g. `/api/feed?page=1`).
+ */
+export function useAuthGatedList<T>(url: string): AuthGatedListResult<T> {
+  const [result, setResult] = useState<AuthGatedListResult<T>>({
+    status: "loading",
+    items: [],
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    // Resolve the gate + fetch inside an async helper so no setState runs
+    // synchronously in the effect body (react-hooks/set-state-in-effect).
+    const resolve = async () => {
+      // No hint → anonymous, with zero network requests (an anonymous homepage
+      // load must not touch the auth-gated API at all).
+      if (!hasAuthHint()) {
+        if (!cancelled) setResult({ status: "anonymous", items: [] });
+        return;
+      }
+      try {
+        // skipRedirectOnFailure: a genuinely-expired visitor renders the stub
+        // in place, NOT bounced to /login from the homepage.
+        const res = await authFetch(url, { skipRedirectOnFailure: true });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body: unknown = await res.json();
+        if (cancelled) return;
+        setResult({ status: "ready", items: unwrapList(body) as T[] });
+      } catch {
+        if (!cancelled) setResult({ status: "anonymous", items: [] });
+      }
+    };
+
+    void resolve();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return result;
+}


### PR DESCRIPTION
## Problem

The homepage `/` was `cf-cache-status: DYNAMIC` — every visit did a full SSR round-trip to the HK origin. Cold TTFB ~1.6s, warm ~0.5s. Detail pages `/anime/*` were already CF `HIT` ~0.2s (from the earlier edge-cache work); the homepage never got the same treatment.

**Root cause:** three server-side `no-store` fetches forced the route dynamic, and two of them personalized the HTML — `ContinueWatching` + `ActivityFeed` read per-user data via `cookies()`, so the rendered HTML could not be shared/cached without leaking one user's watch list / feed to every anonymous visitor.

The stale `page.tsx` comment even claimed *"the cards still benefit from Cloudflare HTML cache in prod"* — measured false: `DYNAMIC`.

## Fix

- Move both per-user sections to **client islands**, mirroring the Navbar / detail-page `auth_hint` gate. They fetch on mount via `authFetch`; anonymous loads fire **zero** auth requests and render the CTA stub; authed loads hydrate their data. The homepage shell is now byte-identical for every anonymous visitor → safe to edge-cache.
- New shared `useAuthGatedList` hook (auth-gate + envelope-unwrap engine) so the two islands don't duplicate the fetch/gate logic. Unit-tested the unwrap contract.
- **`force-dynamic` stays on purpose:** go-api is unreachable at `next build` (`GO_API_INTERNAL_URL` is a runtime env, not a build arg), so ISR would bake an *empty* homepage and serve it for the whole revalidate window after each deploy. Detail pages dodge this via `generateStaticParams → []`; a paramless static route has no such escape. Caching moves to the **edge** instead.

## Manual step after merge (not in this PR)

Cloudflare Cache Rule on `/`:
- Match: `(http.host eq "animegoclub.com") and http.request.uri.path eq "/" and not any(http.request.headers["rsc"][*] == "1") and not http.cookie contains "session=" and not http.cookie contains "refreshToken="`
- Eligible for cache; **Edge TTL: Override origin → 60s** (force-dynamic emits no-store, so "respect origin" won't cache — must override); Browser TTL: respect origin.

## Test plan

- [x] `tsc --noEmit` clean on changed files
- [x] `eslint` clean
- [x] `next build` exit 0, `/` classified `ƒ Dynamic`, no RSC boundary errors
- [x] `bun test` 7/7 new hook tests + 15/15 adjacent (authFetch/clientAuth)
- [ ] **Live (post-deploy):** anonymous `/` HTML contains the skeleton and NO per-user data; logged-in user's ContinueWatching/ActivityFeed hydrate on mount; `cf-cache-status: HIT` for anonymous, bypass when `session` cookie present