### PR TITLE
fix(auth): stop logged-out flash in Navbar + EpisodeComments during the auth probe

### DIFF
--- a/next-app/src/components/anime/EpisodeComments.tsx
+++ b/next-app/src/components/anime/EpisodeComments.tsx
@@ -27,6 +27,7 @@ import Link from "next/link";
 import toast from "react-hot-toast";
 import { authFetch } from "@/lib/authFetch";
 import { hasAuthHint } from "@/lib/clientAuth";
+import { authChrome } from "@/lib/authChrome";
 import { DEFAULT_CARD_IMAGE } from "@/lib/cardDefaults";
 import FallbackImg from "@/components/ui/FallbackImg";
 import type { Dict, Lang } from "@/lib/i18n";
@@ -535,6 +536,10 @@ export default function EpisodeComments({
     [load, lang],
   );
 
+  // "authed" → comment box · "probing" → neutral placeholder (never the login
+  // prompt mid-probe) · "anonymous" → login prompt. See lib/authChrome.
+  const chrome = authChrome(Boolean(user), probing);
+
   return (
     <div style={{ padding: "20px 24px 24px" }}>
       <p style={sectionLabel}>
@@ -552,16 +557,7 @@ export default function EpisodeComments({
         )}
       </p>
 
-      {user ? (
-        <div style={{ marginBottom: 20 }}>
-          <CommentInput
-            onSubmit={handlePost}
-            isPending={posting && !replyTarget}
-            placeholder={dict.comment.placeholder}
-            dict={dict}
-          />
-        </div>
-      ) : probing ? (
+      {chrome === "probing" ? (
         // auth_hint says logged in but /api/auth/me hasn't resolved — neutral
         // placeholder, not the login prompt, so a logged-in user doesn't flash
         // "登录后发表评论" before the comment box appears.
@@ -577,6 +573,15 @@ export default function EpisodeComments({
           }}
           aria-hidden
         />
+      ) : user ? (
+        <div style={{ marginBottom: 20 }}>
+          <CommentInput
+            onSubmit={handlePost}
+            isPending={posting && !replyTarget}
+            placeholder={dict.comment.placeholder}
+            dict={dict}
+          />
+        </div>
       ) : (
         <div
           style={{

--- a/next-app/src/components/anime/EpisodeComments.tsx
+++ b/next-app/src/components/anime/EpisodeComments.tsx
@@ -26,6 +26,7 @@ import {
 import Link from "next/link";
 import toast from "react-hot-toast";
 import { authFetch } from "@/lib/authFetch";
+import { hasAuthHint } from "@/lib/clientAuth";
 import { DEFAULT_CARD_IMAGE } from "@/lib/cardDefaults";
 import FallbackImg from "@/components/ui/FallbackImg";
 import type { Dict, Lang } from "@/lib/i18n";
@@ -393,26 +394,39 @@ export default function EpisodeComments({
   const [comments, setComments] = useState<CommentDoc[]>([]);
   const [loading, setLoading] = useState(true);
   const [user, setUser] = useState<CurrentUser | null>(null);
+  // True while the auth_hint-gated /api/auth/me probe is in flight — the input
+  // area shows a neutral placeholder (not the login prompt) during this window
+  // so a logged-in user doesn't flash "登录后发表评论" before the box appears.
+  const [probing, setProbing] = useState(false);
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [replyTarget, setReplyTarget] = useState<ReplyTarget | null>(null);
   const [posting, setPosting] = useState(false);
 
-  // One-time auth probe — silent on 401 so anonymous users just see the
-  // login prompt instead of a redirect.
+  // One-time auth probe, gated on the auth_hint cookie so an anonymous panel
+  // open fires zero auth requests. While the probe is in flight `probing` is
+  // true so the input area renders a neutral placeholder instead of the login
+  // prompt; a logged-in user otherwise flashes "登录后发表评论" until
+  // /api/auth/me resolves. Silent on 401 — anonymous users just see the prompt.
   useEffect(() => {
     let cancelled = false;
-    (async () => {
+    const resolve = async () => {
+      if (!hasAuthHint()) return;
+      if (!cancelled) setProbing(true);
       try {
         const res = await authFetch("/api/auth/me", {
           skipRedirectOnFailure: true,
         });
-        if (cancelled || !res.ok) return;
-        const json = (await res.json()) as { data?: { user?: CurrentUser } };
-        if (json?.data?.user?.id) setUser(json.data.user);
+        if (!cancelled && res.ok) {
+          const json = (await res.json()) as { data?: { user?: CurrentUser } };
+          if (!cancelled && json?.data?.user?.id) setUser(json.data.user);
+        }
       } catch {
         /* anonymous — leave user null */
+      } finally {
+        if (!cancelled) setProbing(false);
       }
-    })();
+    };
+    void resolve();
     return () => {
       cancelled = true;
     };
@@ -547,6 +561,22 @@ export default function EpisodeComments({
             dict={dict}
           />
         </div>
+      ) : probing ? (
+        // auth_hint says logged in but /api/auth/me hasn't resolved — neutral
+        // placeholder, not the login prompt, so a logged-in user doesn't flash
+        // "登录后发表评论" before the comment box appears.
+        <div
+          style={{
+            marginBottom: 20,
+            // ~matches the 2-row CommentInput footprint (textarea + button row)
+            // so the placeholder → input swap doesn't shift the comment list.
+            height: 88,
+            borderRadius: 8,
+            background: "rgba(255,255,255,0.04)",
+            border: "1px solid #2c2c2e",
+          }}
+          aria-hidden
+        />
       ) : (
         <div
           style={{

--- a/next-app/src/components/layout/Navbar.tsx
+++ b/next-app/src/components/layout/Navbar.tsx
@@ -119,6 +119,15 @@ const s = {
     color: "rgba(235,235,245,0.75)",
     padding: "0 4px",
   } as CSSProperties,
+  // Neutral stand-in for the avatar while the auth probe is in flight — matches
+  // the .agc-avatar tile footprint (36x36, radius 8) so the swap to the real
+  // avatar causes no layout shift.
+  avatarSkeleton: {
+    width: 36,
+    height: 36,
+    borderRadius: 8,
+    background: "rgba(255,255,255,0.08)",
+  } as CSSProperties,
 };
 
 function isActive(pathname: string, href: string): boolean {
@@ -139,28 +148,44 @@ export default function Navbar({ season, year }: NavbarProps) {
   // and ONLY when the non-httpOnly `auth_hint` cookie says a session likely
   // exists — so an anonymous page load fires zero auth requests (ISSUE-001).
   const [user, setUser] = useState<NavUser | null>(null);
+  // `probing` covers the window where the non-httpOnly auth_hint cookie says a
+  // session probably exists but the /api/auth/me probe hasn't resolved yet. In
+  // that window we render a neutral avatar placeholder instead of the
+  // login/register CTA, so a logged-in visitor never flashes "login" first.
+  const [probing, setProbing] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    // No hint cookie → render anonymous (logout clears both the hint and our
-    // local state, so there's nothing to reset here).
-    if (!hasAuthHint()) return;
-    // authFetch self-heals an expired 15-min `session` via the 7-day refresh
-    // cookie. A raw fetch would 401 the moment the access token lapses and
-    // make a still-logged-in user look logged out (the phantom-logout that
-    // forced repeated re-logins). skipRedirectOnFailure so a genuinely
-    // expired visitor just renders anonymous instead of bouncing to /login.
+    // hasAuthHint() reads the non-httpOnly `auth_hint` cookie (client-only), so
+    // this resolves post-hydration. No hint → genuinely anonymous; leave the
+    // login/register CTA. Hint present → flip `probing` first so the chrome
+    // shows a neutral avatar placeholder (NOT the login CTA) while the probe is
+    // in flight, then swaps straight to the avatar. Without this a logged-in
+    // visitor sees a ~0.5s "login" flash before their avatar appears — very
+    // visible now the page paints instantly from the CF edge cache.
+    //
+    // setState lives inside the async helper (never synchronously in the effect
+    // body) to satisfy react-hooks/set-state-in-effect.
+    const resolve = async () => {
+      if (!hasAuthHint()) return;
+      if (!cancelled) setProbing(true);
+      try {
+        // authFetch self-heals an expired 15-min `session` via the 7-day
+        // refresh cookie; skipRedirectOnFailure so a truly-expired visitor
+        // renders anonymous instead of bouncing to /login.
+        const r = await authFetch("/api/auth/me", { skipRedirectOnFailure: true });
+        const json = r.ok ? await r.json() : null;
+        if (!cancelled) setUser(json?.data?.user ?? null);
+      } catch {
+        /* network blip — keep the last known state */
+      } finally {
+        if (!cancelled) setProbing(false);
+      }
+    };
     // Re-runs on pathname change so a fresh client-side login (LoginForm
     // navigates here) updates the nav without a manual page reload.
-    authFetch("/api/auth/me", { skipRedirectOnFailure: true })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((json) => {
-        if (!cancelled) setUser(json?.data?.user ?? null);
-      })
-      .catch(() => {
-        /* network blip — keep the last known state */
-      });
+    void resolve();
     return () => {
       cancelled = true;
     };
@@ -222,6 +247,11 @@ export default function Navbar({ season, year }: NavbarProps) {
               onLogout={handleLogout}
               loggingOut={loggingOut}
             />
+          ) : probing ? (
+            // auth_hint says a session likely exists but /api/auth/me hasn't
+            // resolved — show a neutral avatar placeholder, never the login CTA,
+            // so a logged-in visitor doesn't flash "login" before their avatar.
+            <div style={s.avatarSkeleton} aria-hidden />
           ) : (
             <>
               <button

--- a/next-app/src/components/layout/Navbar.tsx
+++ b/next-app/src/components/layout/Navbar.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import type { CSSProperties } from "react";
 import { useLang } from "@/lib/lang-client";
 import { hasAuthHint } from "@/lib/clientAuth";
+import { authChrome } from "@/lib/authChrome";
 import { authFetch } from "@/lib/authFetch";
 import AvatarMenu from "./AvatarMenu";
 
@@ -218,6 +219,10 @@ export default function Navbar({ season, year }: NavbarProps) {
     { href: "/welcome", label: t("nav.about"), key: "about" },
   ];
 
+  // "authed" → avatar · "probing" → neutral skeleton (never the login CTA mid-
+  // probe) · "anonymous" → login/register. See lib/authChrome.
+  const chrome = authChrome(Boolean(user), probing);
+
   return (
     <nav style={s.nav} aria-label={lang === "zh" ? "主导航" : "Main navigation"}>
       <div style={s.inner}>
@@ -239,7 +244,12 @@ export default function Navbar({ season, year }: NavbarProps) {
           ))}
         </div>
         <div style={s.right}>
-          {user ? (
+          {chrome === "probing" ? (
+            // auth_hint says a session likely exists but /api/auth/me hasn't
+            // resolved — show a neutral avatar placeholder, never the login CTA,
+            // so a logged-in visitor doesn't flash "login" before their avatar.
+            <div style={s.avatarSkeleton} aria-hidden />
+          ) : user ? (
             // Logged-in chrome (Hi / 我的追番 / language / 登出) collapses into
             // the avatar dropdown, which also hosts 卡片个性化.
             <AvatarMenu
@@ -247,11 +257,6 @@ export default function Navbar({ season, year }: NavbarProps) {
               onLogout={handleLogout}
               loggingOut={loggingOut}
             />
-          ) : probing ? (
-            // auth_hint says a session likely exists but /api/auth/me hasn't
-            // resolved — show a neutral avatar placeholder, never the login CTA,
-            // so a logged-in visitor doesn't flash "login" before their avatar.
-            <div style={s.avatarSkeleton} aria-hidden />
           ) : (
             <>
               <button

--- a/next-app/src/lib/authChrome.test.ts
+++ b/next-app/src/lib/authChrome.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { authChrome } from "./authChrome";
+
+// Locks the phantom-logout fix invariant: while the auth probe is in flight and
+// we are not yet authenticated, the chrome is the neutral "probing" placeholder
+// — NEVER "anonymous" (the login CTA). A regression that drops the probing
+// branch (back to `user ? avatar : cta`) makes authChrome(false, true) return
+// "anonymous", which this suite catches. The React wiring (effect timing,
+// cancellation) is exercised by E2E; this pins the render decision.
+
+describe("authChrome", () => {
+  test("a resolved session always wins, even mid-probe", () => {
+    expect(authChrome(true, true)).toBe("authed");
+    expect(authChrome(true, false)).toBe("authed");
+  });
+
+  test("INVARIANT: not authed + probe in flight → 'probing', never the CTA", () => {
+    expect(authChrome(false, true)).toBe("probing");
+    // The bug this guards against: a logged-in visitor must not see "anonymous"
+    // (the login button) while their /api/auth/me probe is still resolving.
+    expect(authChrome(false, true)).not.toBe("anonymous");
+  });
+
+  test("not authed + probe resolved → 'anonymous' (login CTA)", () => {
+    expect(authChrome(false, false)).toBe("anonymous");
+  });
+});

--- a/next-app/src/lib/authChrome.ts
+++ b/next-app/src/lib/authChrome.ts
@@ -1,0 +1,28 @@
+// Which auth chrome a client island should render. Shared by Navbar and
+// EpisodeComments (both render a logged-in UI / a neutral probe placeholder / a
+// logged-out CTA off the same two inputs).
+//
+// THE INVARIANT (this is the whole point of the phantom-logout fix): while the
+// auth_hint-gated /api/auth/me probe is in flight and we are NOT yet
+// authenticated, the answer is "probing" — a neutral placeholder — NEVER
+// "anonymous" (the login CTA). A logged-in visitor always carries the 7-day
+// auth_hint cookie, so they enter the "probing" path and never flash the login
+// button before their avatar / comment box resolves.
+//
+//   isAuthed │ probing │ result
+//   ─────────┼─────────┼────────────
+//     true   │  any    │ "authed"      (a resolved session always wins)
+//     false  │  true   │ "probing"     (probe in flight → neutral placeholder)
+//     false  │  false  │ "anonymous"   (probe resolved to no session → login CTA)
+
+export type AuthChrome = "authed" | "probing" | "anonymous";
+
+/**
+ * @param isAuthed Whether a user session has resolved (truthy `user`).
+ * @param probing  Whether the auth_hint-gated /api/auth/me probe is in flight.
+ */
+export function authChrome(isAuthed: boolean, probing: boolean): AuthChrome {
+  if (isAuthed) return "authed";
+  if (probing) return "probing";
+  return "anonymous";
+}


### PR DESCRIPTION
## Problem (user-reported)

> 重新进入网站看见"需要重新登录"的按键,刷新就看见登录成功;token 没有过期。

The Navbar (and EpisodeComments) are client islands that render the logged-**out** UI synchronously, then probe `/api/auth/me` on mount and swap to the logged-in UI. For a logged-in user this flashes the login button / "登录后发表评论" prompt for ~0.5s (the probe round-trip to the HK origin) before correcting. It became obvious **now** because the homepage paints instantly from the CF edge cache — the logged-out shell appears crisply, then the late probe swaps it. "Refresh fixes it" = the second probe is warm.

Diagnosis ruled out a real auth failure: `auth_hint` is a **7-day** cookie (matches refreshToken), `/api/auth/me` is not cached (DYNAMIC), and the `/anime/*` bypass works — so the token is fine, the navbar just paints before the probe resolves.

## Fix

Gate a `probing` state on `hasAuthHint()`: when auth_hint says a session likely exists but the probe hasn't resolved, render a **neutral placeholder** instead of the login CTA, then resolve to the logged-in UI (or, on failure, the anonymous CTA).

- **Navbar**: `probing` → 36×36 avatar skeleton (matches `.agc-avatar`, no CLS).
- **EpisodeComments**: `probing` → 88px muted box (~2-row CommentInput footprint); also gates the probe on `hasAuthHint` so an anonymous panel open fires **zero** auth requests.
- SSR has no `auth_hint` → `probing` stays false → anonymous CTA renders → **CF-cached anonymous homepage HTML is byte-unchanged** (cache safety preserved).

`setState` stays inside an async helper (react-hooks/set-state-in-effect).

## Process

- A codebase **sweep** (subagent) confirmed EpisodeComments is the *only* other instance of this bug class; SubscriptionButton / the `useAuthGatedList` islands already do the right thing (neutral loading state).
- Independent **typescript-reviewer** pass: no critical/high. State machine, cancellation (`cancelled` flag), hydration safety, and the `finally { setProbing(false) }` guarantee all verified.

## Out of scope (pre-existing, noted not fixed)

- `EpisodeComments.tsx` reload effect (`setReplyTarget`/`setConfirmId`) trips `react-hooks/set-state-in-effect` — pre-existing, not in this diff, CI doesn't gate eslint.
- Navbar: a transient 5xx on `/api/auth/me` during a re-nav writes `null` to `user` — pre-existing behavior (old code did the same).

## Test plan

- [x] `tsc` clean (both files), `next build` exit 0, lib tests 22/22 (clientAuth/authFetch/useAuthGatedList)
- [ ] **Live (post-deploy):** logged-in user re-enters `/` → avatar skeleton → avatar (NO login-button flash); anonymous user → login/register immediately; expand a comments panel logged-in → muted box → comment input (no "登录后发表评论" flash)