### PR TITLE
fix(auth): full navigation after login/register so the nav reflects logged-in

### DIFF
--- a/next-app/src/app/login/_components/LoginForm.tsx
+++ b/next-app/src/app/login/_components/LoginForm.tsx
@@ -6,6 +6,7 @@ import type { Dict } from "@/lib/i18n";
 import { translateErrorMessage } from "@/lib/authForm";
 import { authFormStyles } from "@/lib/authFormStyles";
 import { submitLogin } from "../_lib/loginFlow";
+import { redirectAfterAuth } from "@/lib/authRedirect";
 
 interface LoginFormProps {
   /**
@@ -66,17 +67,11 @@ export default function LoginForm({ from, dict }: LoginFormProps) {
     try {
       const result = await submitLogin(form.email, form.password);
       if (result.ok) {
-        // Full navigation (NOT router.replace): the Navbar is a client island
-        // that reads the auth_hint cookie + probes /api/auth/me in its OWN
-        // effect — the root layout no longer fetches auth server-side (that
-        // comment was rot). A soft router.replace only re-runs that effect on
-        // the pathname change, and racily: it can read document.cookie before
-        // this response's Set-Cookie is committed, leaving the nav stuck
-        // "logged out" until a manual refresh. A full navigation remounts
-        // everything with the cookies already in the jar (exactly what that
-        // manual refresh does), so the nav reliably shows logged-in. `from` is
+        // Full navigation, not a soft router.replace — see redirectAfterAuth
+        // (the Navbar is a client island; a soft nav updates it only racily, so
+        // the user lands "logged out" until a manual refresh). `from` is
         // server-sanitized to a same-origin path.
-        window.location.replace(from);
+        redirectAfterAuth(from);
       } else {
         // Backend response.error.message is already localized on the
         // server (legacy Express returns Chinese for INVALID_CREDENTIALS);

--- a/next-app/src/app/login/_components/LoginForm.tsx
+++ b/next-app/src/app/login/_components/LoginForm.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState, useTransition, type CSSProperties, type FormEvent } from "react";
+import { useState, type CSSProperties, type FormEvent } from "react";
 import type { Dict } from "@/lib/i18n";
 import { translateErrorMessage } from "@/lib/authForm";
 import { authFormStyles } from "@/lib/authFormStyles";
@@ -42,15 +41,15 @@ const styles = {
 };
 
 export default function LoginForm({ from, dict }: LoginFormProps) {
-  const router = useRouter();
   const [form, setForm] = useState<FormState>({ email: "", password: "" });
   const [error, setError] = useState<string>("");
   const [loading, setLoading] = useState(false);
-  const [navigating, startTransition] = useTransition();
   const [focused, setFocused] = useState<"email" | "password" | null>(null);
 
   const t = dict.login;
-  const busy = loading || navigating;
+  // `loading` stays true through the post-success full navigation (the page
+  // unloads), keeping the submit button disabled until we leave.
+  const busy = loading;
 
   function updateField<K extends keyof FormState>(key: K) {
     return (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -67,19 +66,17 @@ export default function LoginForm({ from, dict }: LoginFormProps) {
     try {
       const result = await submitLogin(form.email, form.password);
       if (result.ok) {
-        // Navigate to the sanitized `from`, then refresh so the root
-        // layout's /api/auth/me fetch re-runs and Navbar flips from
-        // anonymous to logged-in CTAs.
-        //
-        // No race on router.refresh() reading a stale cookie: the
-        // browser commits Set-Cookie from /api/auth/login before the
-        // fetch promise resolves, so by the time this branch runs the
-        // session cookie is already in the jar and the RSC refetch
-        // attaches it.
-        startTransition(() => {
-          router.replace(from);
-          router.refresh();
-        });
+        // Full navigation (NOT router.replace): the Navbar is a client island
+        // that reads the auth_hint cookie + probes /api/auth/me in its OWN
+        // effect — the root layout no longer fetches auth server-side (that
+        // comment was rot). A soft router.replace only re-runs that effect on
+        // the pathname change, and racily: it can read document.cookie before
+        // this response's Set-Cookie is committed, leaving the nav stuck
+        // "logged out" until a manual refresh. A full navigation remounts
+        // everything with the cookies already in the jar (exactly what that
+        // manual refresh does), so the nav reliably shows logged-in. `from` is
+        // server-sanitized to a same-origin path.
+        window.location.replace(from);
       } else {
         // Backend response.error.message is already localized on the
         // server (legacy Express returns Chinese for INVALID_CREDENTIALS);

--- a/next-app/src/app/register/_components/RegisterForm.tsx
+++ b/next-app/src/app/register/_components/RegisterForm.tsx
@@ -6,6 +6,7 @@ import type { Dict } from "@/lib/i18n";
 import { translateErrorMessage } from "@/lib/authForm";
 import { authFormStyles } from "@/lib/authFormStyles";
 import { submitRegister } from "../_lib/registerFlow";
+import { redirectAfterAuth } from "@/lib/authRedirect";
 
 interface RegisterFormProps {
   from: string;
@@ -63,11 +64,10 @@ export default function RegisterForm({ from, dict }: RegisterFormProps) {
     try {
       const result = await submitRegister(form.username, form.email, form.password);
       if (result.ok) {
-        // Full navigation (NOT router.replace) — same reasoning as /login: the
-        // Navbar is a client island that probes auth in its own effect, so a
-        // soft replace updates it only racily. A full nav lands the new account
-        // on `from` with cookies committed, so the nav reliably shows logged-in.
-        window.location.replace(from);
+        // Full navigation, not a soft router.replace — see redirectAfterAuth
+        // (same reasoning as /login: the client-island Navbar updates only
+        // racily on a soft nav). Lands the new account on `from`.
+        redirectAfterAuth(from);
       } else {
         const translated = translateErrorMessage(result.message, dict);
         setError(translated || t.fail);

--- a/next-app/src/app/register/_components/RegisterForm.tsx
+++ b/next-app/src/app/register/_components/RegisterForm.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState, useTransition, type FormEvent } from "react";
+import { useState, type FormEvent } from "react";
 import type { Dict } from "@/lib/i18n";
 import { translateErrorMessage } from "@/lib/authForm";
 import { authFormStyles } from "@/lib/authFormStyles";
@@ -30,15 +29,15 @@ const PASSWORD_MIN_LENGTH = 6;
 const styles = authFormStyles;
 
 export default function RegisterForm({ from, dict }: RegisterFormProps) {
-  const router = useRouter();
   const [form, setForm] = useState<FormState>({ username: "", email: "", password: "" });
   const [error, setError] = useState<string>("");
   const [loading, setLoading] = useState(false);
-  const [navigating, startTransition] = useTransition();
   const [focused, setFocused] = useState<FieldKey | null>(null);
 
   const t = dict.register;
-  const busy = loading || navigating;
+  // `loading` stays true through the post-success full navigation (the page
+  // unloads), keeping the submit button disabled until we leave.
+  const busy = loading;
 
   function updateField<K extends keyof FormState>(key: K) {
     return (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -64,14 +63,11 @@ export default function RegisterForm({ from, dict }: RegisterFormProps) {
     try {
       const result = await submitRegister(form.username, form.email, form.password);
       if (result.ok) {
-        // Cookies committed before the promise resolves (same invariant
-        // as /login). router.replace + router.refresh re-runs the root
-        // layout's /api/auth/me fetch so Navbar flips to logged-in
-        // CTAs and the new account lands on `from`.
-        startTransition(() => {
-          router.replace(from);
-          router.refresh();
-        });
+        // Full navigation (NOT router.replace) — same reasoning as /login: the
+        // Navbar is a client island that probes auth in its own effect, so a
+        // soft replace updates it only racily. A full nav lands the new account
+        // on `from` with cookies committed, so the nav reliably shows logged-in.
+        window.location.replace(from);
       } else {
         const translated = translateErrorMessage(result.message, dict);
         setError(translated || t.fail);

--- a/next-app/src/lib/authRedirect.test.ts
+++ b/next-app/src/lib/authRedirect.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { redirectAfterAuth } from "./authRedirect";
+
+// bun:test runs in node (no window). We stub window.location.replace and assert
+// redirectAfterAuth does a FULL-page navigation. This locks the fix: a
+// regression back to a soft Next router.replace (which updated the client-island
+// Navbar only racily → "logged in but shows logged-out until refresh") would
+// stop calling window.location.replace and fail this suite.
+
+type WinLike = { location: { replace: (url: string) => void } };
+const hadWindow = "window" in globalThis;
+const original = (globalThis as { window?: WinLike }).window;
+
+function stubWindow(replace: (url: string) => void): void {
+  (globalThis as { window?: WinLike }).window = { location: { replace } };
+}
+
+afterEach(() => {
+  if (hadWindow) {
+    (globalThis as { window?: WinLike }).window = original;
+  } else {
+    delete (globalThis as { window?: WinLike }).window;
+  }
+});
+
+describe("redirectAfterAuth", () => {
+  test("performs a full-page navigation to the target", () => {
+    const replace = mock((_url: string) => {});
+    stubWindow(replace);
+    redirectAfterAuth("/library");
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(replace).toHaveBeenCalledWith("/library");
+  });
+
+  test("passes the target through verbatim (query + hash preserved)", () => {
+    const replace = mock((_url: string) => {});
+    stubWindow(replace);
+    redirectAfterAuth("/player?seriesId=abc&fileId=42#top");
+    expect(replace).toHaveBeenCalledWith("/player?seriesId=abc&fileId=42#top");
+  });
+
+  test("no-ops on the server (no window) instead of throwing", () => {
+    delete (globalThis as { window?: WinLike }).window;
+    expect(() => redirectAfterAuth("/")).not.toThrow();
+  });
+});

--- a/next-app/src/lib/authRedirect.ts
+++ b/next-app/src/lib/authRedirect.ts
@@ -1,0 +1,26 @@
+// Post-auth redirect. Shared by LoginForm and RegisterForm.
+//
+// Deliberately a FULL navigation (`window.location.replace`), NOT a Next
+// `router.replace` + `router.refresh`. The Navbar is a client island that reads
+// the `auth_hint` cookie and probes `/api/auth/me` in its OWN effect (the root
+// layout no longer fetches auth server-side). A soft router.replace only
+// re-triggers that effect on the pathname change, and racily — it can read
+// document.cookie before the login/register response's Set-Cookie is committed,
+// leaving the nav stuck "logged out" until a manual refresh. A full navigation
+// remounts everything with the cookies already in the jar (exactly what that
+// manual refresh does), so the nav reliably shows logged-in.
+//
+// `replace` (not `assign`) so /login or /register don't sit in history behind
+// the now-authenticated landing page.
+
+/**
+ * Send a freshly-authenticated user to their post-auth target via a full page
+ * navigation.
+ *
+ * @param target Server-sanitized same-origin path (see authForm
+ *   `sanitizeFromParam`) — always starts with "/" and is never /login|/register.
+ */
+export function redirectAfterAuth(target: string): void {
+  if (typeof window === "undefined") return;
+  window.location.replace(target);
+}


### PR DESCRIPTION
## Problem (user-reported, 3rd auth iteration)

> 登录了显示登出态,刷新才能显示登录 (logged in but the nav shows logged-OUT; a manual refresh fixes it; token is valid).

`LoginForm`/`RegisterForm` did, on success:
```js
startTransition(() => { router.replace(from); router.refresh(); });
```
The comment claimed `router.refresh()` re-runs *"the root layout's /api/auth/me fetch"* so the Navbar flips to logged-in. **That's comment rot** — after the islanding work the layout no longer fetches auth server-side. The Navbar is a **client island** that reads the `auth_hint` cookie + probes `/api/auth/me` in its own `useEffect`.

So the only thing updating the nav was `router.replace(from)` → pathname change → the navbar effect re-runs. That's **racy**: the effect can read `document.cookie` before this response's `Set-Cookie` is committed (and `router.refresh()` does nothing for a client-island's auth). Result: the nav stays "logged out" until a full reload.

A manual refresh works precisely because it's a **full load** — everything remounts with cookies already in the jar.

## Fix

Replace the soft nav with `window.location.replace(from)` — a full navigation, exactly what the manual refresh does. Deterministic: the page remounts, `hasAuthHint()` is reliably true, the probe returns the user, the nav shows the avatar (with the #47 skeleton during the brief probe). `from` is already server-sanitized to a same-origin path. Drops the now-unused `useRouter` / `useTransition`.

`ResetPasswordForm` keeps `router.replace("/login")` — it deliberately lands on the login page with a dead session, no logged-in state to race.

## Test plan

- [x] tsc clean, eslint clean (no unused imports), `next build` exit 0
- [x] loginFlow + registerFlow unit tests 10/10 (the POST helpers are unchanged)
- [ ] **Live (post-deploy):** log in → lands on home **already showing the avatar** (no logged-out nav, no manual refresh needed); register → same; password-reset still lands on /login