### PR TITLE
feat(library): pipeline hardening + player tab-return rescan (PR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 - **关键修复:reuse 导入现在会刷新 `series.updatedAt`** — `persistFileRefsOnly` 只写 episodes/fileRefs,而 useLibrary 的 liveQuery 只监听 series 表 → 老番出新集从来不会浮进 NewAdditionsRow(注释写了设计意图但代码路径缺失)。补 `seriesRepo.touchSeries()` 在 reuse 分支回写,新集现在会自动浮到「新加入」行。
 - **UI** — 静默扫描以 mini pill 呈现(不弹全屏导入抽屉);完成后 toast「发现 N 个新剧集」;溢出菜单新增「重新扫描文件夹」(手势路径,denied root 先走授权,并清空失败跳过集强制重试);UnavailableSeriesSection 下新增持久授权引导(授权弹窗选「每次访问时都允许」或安装 PWA,重启浏览器后免点击)。
 - **测试** — 新增 29 个单测:rescanService 分支全覆盖(9)、控制器守卫链/排序/隔离/抢占(16)、importPipeline reuse 分支 IRON 回归 + touchSeries(4,经真实 runImport + fake Dexie 表面);e2e seeded 用例加「自动扫描不得弹全屏 scrim」断言,现有两条 spec 一行未改。`bun test` 280/280;生产构建编译 + TS 检查通过。
-- 已知边界:FSA 为 Chromium-only(与现状一致);重启后能否静默扫描取决于用户授权选项(引导文案即为此);player 页扫描、管线加固(缓存裸 verdict 崩溃修复 + 全已知簇守卫)与 FileSystemObserver 实时监听排在 PR-2 / PR-3。
+- **(PR-2)管线加固** — 修掉一个存量崩溃:matchCache 里缓存的裸 `{kind:'new'}`(无 animeId,即"本地标题导入 + dandan 未命中"的产物)被复用时没有 seriesRecord 可持久化,`upsertCluster` 校验直接抛错、整簇计失败——每次重导入本地标题系列都触发;现按缓存未命中处理、重新匹配。新增**重导入守卫**:簇内每个文件都已有归属(同内容哈希 → 同 fileRef id → 各自挂在同一系列的剧集上)时不再铸新系列、翻转为 reuse——堵住"缓存过期 + dandan 不可达 → 重复卡片"和移动/改名场景;文件跨两个系列、或命中 ambiguous 行时守卫保守跳过。派生 reuse 无 animeId 不写缓存(避免再造裸条目)。5 个新单测。
+- **(PR-2)player 页 tab-return 扫描** — `useAutoRescan` 增加 `enabled` / `triggers` / `shouldDefer` 选项(shouldDefer 进控制器守卫链,可单测);PlayerShell 在 library 模式挂 hook:仅 visibilitychange 触发(挂载扫描是 /library 的职责)、`playbackPhase === "playing"` 时让位(哈希 worker 不与解码抢 CPU)、扫到新集后调 `seriesDetail.refresh()`(它是一次性加载非 liveQuery)让 EpisodeNav 立即出现新集——"看完第 6 集,下完第 7 集切回播放页点下一集"的续看场景就此闭环。
+- 已知边界:FSA 为 Chromium-only(与现状一致);重启后能否静默扫描取决于用户授权选项(引导文案即为此);FileSystemObserver 实时监听排在 PR-3。
 
 ---
 

--- a/next-app/src/app/library/_hooks/useAutoRescan.js
+++ b/next-app/src/app/library/_hooks/useAutoRescan.js
@@ -34,7 +34,16 @@ import {
  *   refreshHandles: () => Promise<void>,
  *   onBeforeSilentRun: () => void,
  *   onScanComplete: (result: any) => void,
+ *   enabled?: boolean,
+ *   triggers?: { mount?: boolean, visibility?: boolean },
+ *   shouldDefer?: () => boolean,
  * }} params
+ *
+ * `triggers` picks which DOM triggers this host wires ({mount, visibility},
+ * both default true — /library uses both, the player only visibility).
+ * `shouldDefer` is a host veto evaluated inside the controller's guard chain
+ * (e.g. "video is playing"); `enabled` gates the whole hook (e.g. player
+ * drop-mode has no library context to scan for).
  */
 export function useAutoRescan({
   db,
@@ -45,7 +54,12 @@ export function useAutoRescan({
   refreshHandles,
   onBeforeSilentRun,
   onScanComplete,
+  enabled = true,
+  triggers = {},
+  shouldDefer,
 }) {
+  const wantMount = triggers.mount !== false;
+  const wantVisibility = triggers.visibility !== false;
   const [scanning, setScanning] = useState(false);
   const [lastResult, setLastResult] = useState(null);
 
@@ -59,6 +73,7 @@ export function useAutoRescan({
     refreshHandles,
     onBeforeSilentRun,
     onScanComplete,
+    shouldDefer,
   };
 
   const controllerRef = useRef(null);
@@ -85,6 +100,7 @@ export function useAutoRescan({
         refreshHandles: () =>
           Promise.resolve(latest.current.refreshHandles?.()),
         now: () => Date.now(),
+        shouldDefer: () => Boolean(latest.current.shouldDefer?.()),
       });
     }
     return controllerRef.current;
@@ -109,20 +125,22 @@ export function useAutoRescan({
   // 'no-roots' outcome with zero state changes.
   const mountFiredRef = useRef(false);
   useEffect(() => {
+    if (!enabled || !wantMount) return;
     if (mountFiredRef.current) return;
     if (handlesStatus !== "ready" && handlesStatus !== "denied") return;
     mountFiredRef.current = true;
     void scan("mount");
-  }, [handlesStatus, scan]);
+  }, [enabled, wantMount, handlesStatus, scan]);
 
   // Visibility trigger: "downloaded in another window, tabbed back".
   useEffect(() => {
+    if (!enabled || !wantVisibility) return;
     const onVisibility = () => {
       if (document.visibilityState === "visible") void scan("visibility");
     };
     document.addEventListener("visibilitychange", onVisibility);
     return () => document.removeEventListener("visibilitychange", onVisibility);
-  }, [scan]);
+  }, [enabled, wantVisibility, scan]);
 
   /** Gesture-path rescan from the overflow menu; bypasses the throttle. */
   const manualRescan = useCallback(() => scan("manual"), [scan]);

--- a/next-app/src/app/library/_services/importPipeline.js
+++ b/next-app/src/app/library/_services/importPipeline.js
@@ -168,6 +168,15 @@ async function processCluster(p) {
     cachedVerdict = await cacheRepo.get(rep.hash16M);
   }
 
+  // A cached bare {kind:'new'} (no animeId — a local-title import whose
+  // dandan lookup found nothing) carries no seriesRecord. Adopting it as the
+  // verdict crashes buildPersistPayload → upsertCluster on series:undefined
+  // and the whole cluster counts as failed on every re-import. Treat it as a
+  // cache miss and re-match instead.
+  if (cachedVerdict?.kind === 'new' && cachedVerdict.animeId === undefined) {
+    cachedVerdict = null;
+  }
+
   /** @type {MatchVerdict} */
   let verdict;
 
@@ -279,6 +288,23 @@ async function processCluster(p) {
     }
   }
 
+  // Re-import guard: when EVERY file in the cluster is already homed in the
+  // library (same content ⇒ same content-hash fileRef id, each attached to an
+  // episode of ONE series), never mint a new series — flip to reuse of that
+  // series. Covers moved/renamed unchanged files and the "matchCache expired
+  // + dandan unreachable" tail, both of which previously duplicated the card.
+  if (verdict.kind === 'new' && p.db) {
+    const home = await deriveExistingHome(cluster, p.db);
+    if (home) {
+      verdict = {
+        kind: 'reuse',
+        seriesId: home.seriesId,
+        seasonId: home.seasonId,
+        animeId: home.animeId,
+      };
+    }
+  }
+
   // Persist based on verdict kind
   if (verdict.kind === 'reuse' || verdict.kind === 'new') {
     if (verdict.kind === 'new') {
@@ -310,8 +336,10 @@ async function processCluster(p) {
       await seriesRepo.touchSeries(verdict.seriesId);
       trackFolders(verdict.seriesId);
     }
-    // Cache the verdict
-    if (rep?.hash16M) {
+    // Cache the verdict. A reuse without an animeId (the re-import guard's
+    // derived home) would serialize to a bare {kind:'new'} entry — useless
+    // since the bare-cache normalization above treats it as a miss — so skip.
+    if (rep?.hash16M && !(verdict.kind === 'reuse' && verdict.animeId === undefined)) {
       const cachePayload = buildCachePayload(verdict);
       await cacheRepo.put(rep.hash16M, cachePayload);
     }
@@ -330,6 +358,38 @@ async function processCluster(p) {
     summary.failed++;
     emit({ kind: 'clusterDone', clusterKey, verdict: 'failed' });
   }
+}
+
+/**
+ * Resolve the existing "home" (seriesId/seasonId) for a cluster whose every
+ * file is already imported. Returns null — guard does not apply — when any
+ * file is unknown, any known fileRef is ambiguous (episodeId null), or the
+ * files span more than one series (never guess across series).
+ *
+ * animeId comes back undefined when the home was derived structurally rather
+ * than via a dandan match; callers must not cache such verdicts.
+ *
+ * @param {import('@/lib/library/types').MatchCluster} cluster
+ * @param {import('dexie').Dexie} db
+ * @returns {Promise<{seriesId: string, seasonId: string|null, animeId: undefined}|null>}
+ */
+async function deriveExistingHome(cluster, db) {
+  let seriesId = null;
+  let seasonId = null;
+  for (const item of cluster.items) {
+    const ref = await db.fileRefs.get(fileRefId(item));
+    if (!ref?.episodeId) return null;
+    const ep = await db.episodes.get(ref.episodeId);
+    if (!ep?.seriesId) return null;
+    if (seriesId === null) {
+      seriesId = ep.seriesId;
+      seasonId = ep.seasonId ?? null;
+    } else if (ep.seriesId !== seriesId) {
+      return null;
+    }
+  }
+  if (!seriesId) return null;
+  return { seriesId, seasonId, animeId: undefined };
 }
 
 /**

--- a/next-app/src/app/library/_services/rescanController.js
+++ b/next-app/src/app/library/_services/rescanController.js
@@ -51,6 +51,7 @@ export const YIELD_TIMEOUT_MS = 5_000;
  *   refreshHandles: () => Promise<void>,
  *   now: () => number,
  *   sleep?: (ms: number) => Promise<void>,
+ *   shouldDefer?: () => boolean,
  * }} deps
  */
 export function createRescanController(deps) {
@@ -187,6 +188,9 @@ export function createRescanController(deps) {
    */
   async function maybeScan({ trigger }) {
     if (!deps.isFsaSupported()) return { outcome: "unsupported", trigger };
+    // Host veto (optional dep): e.g. the player page defers while a video is
+    // actively playing so hash workers never compete with decode.
+    if (deps.shouldDefer?.()) return { outcome: "host-deferred", trigger };
     if (running) return { outcome: "busy", trigger };
     if (deps.getImportStatus() === "running") {
       return { outcome: "import-busy", trigger };

--- a/next-app/src/app/library/_services/rescanController.test.js
+++ b/next-app/src/app/library/_services/rescanController.test.js
@@ -109,6 +109,19 @@ describe("createRescanController guards", () => {
     expect(calls.complete).toHaveLength(0);
   });
 
+  test("host veto (shouldDefer) blocks the scan before any work", async () => {
+    let defer = true;
+    const { controller, calls } = harness({
+      shouldDefer: () => defer,
+      listRoots: async () => [root("lib1", 1)],
+    });
+    const vetoed = await controller.maybeScan({ trigger: "visibility" });
+    expect(vetoed.outcome).toBe("host-deferred");
+    expect(calls.listRoots).toBe(0);
+    defer = false;
+    expect((await controller.maybeScan({ trigger: "visibility" })).outcome).toBe("scanned");
+  });
+
   test("manual import in flight blocks the scan", async () => {
     const { controller, calls } = harness({ getImportStatus: () => "running" });
     const result = await controller.maybeScan({ trigger: "visibility" });

--- a/next-app/src/app/player/_components/PlayerShell.tsx
+++ b/next-app/src/app/player/_components/PlayerShell.tsx
@@ -59,6 +59,9 @@ import { flattenDropFiles } from "@/lib/dropFiles";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — JS module
 import { useFileHandles } from "@/app/library/_hooks/useFileHandles";
+import { useImport } from "@/app/library/_hooks/useImport";
+import { useAutoRescan } from "@/app/library/_hooks/useAutoRescan";
+import { createDandanClient } from "@/app/library/_services/dandanClient";
 import { useSeriesDetail } from "@/app/library/_hooks/useSeriesDetail";
 import { useVideoFiles } from "@/app/library/_hooks/useVideoFiles";
 
@@ -424,6 +427,34 @@ function PlayerShellInner() {
     resumeAt,
     setLastTime,
   } = playback;
+
+  // PR-2 watch-folder rescan on tab-return (library mode only). Mount scans
+  // are /library's job — here we only catch "downloaded the next episode
+  // while watching, tabbed back, expects it in the episode nav". Never while
+  // the video is actively playing (hash workers must not compete with
+  // decode); the deferred scan simply fires on the next tab-return.
+  const rescanDandan = useMemo(() => createDandanClient(), []);
+  const { run: rescanImport, status: rescanImportStatus } = useImport({
+    db,
+    dandan: rescanDandan,
+  });
+  useAutoRescan({
+    db,
+    handlesStatus: fileHandles.status,
+    importStatus: rescanImportStatus,
+    runImport: rescanImport,
+    processFiles,
+    refreshHandles: fileHandles.refresh,
+    enabled: Boolean(locationSeriesId),
+    triggers: { mount: false, visibility: true },
+    shouldDefer: () => playbackPhase === "playing",
+    onBeforeSilentRun: () => {},
+    // useSeriesDetail is a one-shot load (not liveQuery) — pull the fresh
+    // episode list so the new download appears in EpisodeNav immediately.
+    onScanComplete: (result: { newCount: number }) => {
+      if (result.newCount > 0) seriesDetail.refresh();
+    },
+  });
 
   const [pickerEp, setPickerEp] = useState<number | null>(null);
   const [isMobileView, setIsMobileView] = useState<boolean>(isMobile);

--- a/next-app/src/lib/library/__tests__/importPipeline.hardening.test.js
+++ b/next-app/src/lib/library/__tests__/importPipeline.hardening.test.js
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { runImport } from "@/app/library/_services/importPipeline.js";
+import { fileRefId } from "../recordFactory.js";
+
+// PR-2 pipeline hardening:
+//   1. A cached bare {kind:'new'} verdict (no animeId) used to crash
+//      upsertCluster (series:undefined) — every re-import of a local-title
+//      series counted its clusters as failed. It must now re-match.
+//   2. Re-import guard: a cluster whose every file is already homed on ONE
+//      series flips to reuse instead of minting a duplicate series card
+//      (covers moved/renamed files and "cache expired + dandan down").
+
+const NOW = Date.now();
+
+function item(overrides = {}) {
+  return {
+    fileId: "f|700|0",
+    file: { size: 700, lastModified: 0 },
+    fileName: "[Sub] Frieren - 07.mkv",
+    relativePath: "Frieren/[Sub] Frieren - 07.mkv",
+    episode: 7,
+    parsedKind: "main",
+    parsedTitle: "Frieren",
+    hash16M: "deadbeef",
+    subtitle: null,
+    ...overrides,
+  };
+}
+
+function fakeDb({
+  seasons = [],
+  episodes = [],
+  episodesById = {},
+  fileRefsById = {},
+  cacheEntries = {},
+} = {}) {
+  const writes = {
+    episodes: [],
+    fileRefs: [],
+    seriesPuts: [],
+    seriesUpdates: [],
+    cachePuts: [],
+  };
+  const db = {
+    seasons: { toArray: async () => seasons },
+    userOverride: { toArray: async () => [] },
+    episodes: {
+      where: () => ({ equals: () => ({ toArray: async () => episodes }) }),
+      get: async (id) => episodesById[id],
+      bulkPut: async (rows) => {
+        writes.episodes.push(...rows);
+      },
+    },
+    fileRefs: {
+      get: async (id) => fileRefsById[id],
+      bulkPut: async (rows) => {
+        writes.fileRefs.push(...rows);
+      },
+    },
+    series: {
+      put: async (row) => {
+        writes.seriesPuts.push(row);
+      },
+      update: async (id, patch) => {
+        writes.seriesUpdates.push({ id, patch });
+      },
+    },
+    matchCache: {
+      get: async (hash) => cacheEntries[hash],
+      put: async (row) => {
+        writes.cachePuts.push(row);
+      },
+      count: async () => 1,
+    },
+    transaction: async (_mode, _tables, fn) => fn(),
+  };
+  return { db, writes };
+}
+
+function nullDandan() {
+  const calls = [];
+  return {
+    calls,
+    match: async (...args) => {
+      calls.push(args);
+      return null;
+    },
+  };
+}
+
+describe("bare cached verdict fix", () => {
+  test("cached {kind:'new'} without animeId re-matches instead of crashing the cluster", async () => {
+    const { db, writes } = fakeDb({
+      cacheEntries: {
+        deadbeef: { hash16M: "deadbeef", verdict: { kind: "new" }, updatedAt: NOW },
+      },
+    });
+    const dandan = nullDandan();
+
+    const summary = await runImport(
+      { items: [item()], libraryId: "lib-1" },
+      { db, dandan },
+    );
+
+    // Pre-fix: failed=1 (upsertCluster threw on series:undefined).
+    expect(summary.failed).toBe(0);
+    expect(summary.matched).toBe(1);
+    // Re-match happened: local matcher ran and dandan was consulted again.
+    expect(dandan.calls).toHaveLength(1);
+    // Local-title series persisted.
+    expect(writes.seriesPuts).toHaveLength(1);
+  });
+});
+
+describe("re-import guard (all files already homed)", () => {
+  const theItem = item();
+  const refId = fileRefId(theItem);
+  const HOMED = {
+    fileRefsById: {
+      [refId]: { id: refId, episodeId: "ep-7", relPath: theItem.relativePath, size: 700 },
+    },
+    episodesById: {
+      "ep-7": {
+        id: "ep-7",
+        seriesId: "sr-1",
+        seasonId: "season-1",
+        number: 7,
+        primaryFileId: refId,
+        alternateFileIds: [],
+      },
+    },
+    episodes: [
+      {
+        id: "ep-7",
+        seriesId: "sr-1",
+        seasonId: "season-1",
+        number: 7,
+        primaryFileId: refId,
+        alternateFileIds: [],
+      },
+    ],
+  };
+
+  test("flips to reuse: no duplicate series, updatedAt bumped, nothing cached", async () => {
+    const { db, writes } = fakeDb(HOMED);
+
+    const summary = await runImport(
+      { items: [theItem], libraryId: "lib-1" },
+      { db, dandan: nullDandan() },
+    );
+
+    expect(summary.matched).toBe(1);
+    expect(summary.failed).toBe(0);
+    // The whole point: NO fresh series minted for an already-imported cluster.
+    expect(writes.seriesPuts).toHaveLength(0);
+    // Reuse persistence ran: touchSeries bump + fileRef re-write.
+    expect(writes.seriesUpdates).toHaveLength(1);
+    expect(writes.seriesUpdates[0].id).toBe("sr-1");
+    expect(writes.fileRefs.length).toBeGreaterThanOrEqual(1);
+    // Derived home has no animeId — caching it would recreate the bare-entry
+    // problem, so nothing is cached.
+    expect(writes.cachePuts).toHaveLength(0);
+  });
+
+  test("ambiguous-homed file (episodeId null) skips the guard — proceeds as new", async () => {
+    const { db, writes } = fakeDb({
+      fileRefsById: {
+        [refId]: { id: refId, episodeId: null, relPath: theItem.relativePath, size: 700 },
+      },
+    });
+
+    await runImport({ items: [theItem], libraryId: "lib-1" }, { db, dandan: nullDandan() });
+
+    expect(writes.seriesPuts).toHaveLength(1);
+  });
+
+  test("unknown file in the cluster skips the guard — proceeds as new", async () => {
+    const { db, writes } = fakeDb();
+    await runImport({ items: [theItem], libraryId: "lib-1" }, { db, dandan: nullDandan() });
+    expect(writes.seriesPuts).toHaveLength(1);
+  });
+
+  test("cluster spanning two series skips the guard — never guesses across series", async () => {
+    const a = item();
+    const b = item({
+      fileId: "g|800|0",
+      file: { size: 800, lastModified: 0 },
+      fileName: "[Sub] Frieren - 08.mkv",
+      relativePath: "Frieren/[Sub] Frieren - 08.mkv",
+      episode: 8,
+      hash16M: "cafebabe",
+    });
+    const refA = fileRefId(a);
+    const refB = fileRefId(b);
+    const { db, writes } = fakeDb({
+      fileRefsById: {
+        [refA]: { id: refA, episodeId: "ep-a" },
+        [refB]: { id: refB, episodeId: "ep-b" },
+      },
+      episodesById: {
+        "ep-a": { id: "ep-a", seriesId: "sr-1", seasonId: "s1", number: 7, primaryFileId: refA },
+        "ep-b": { id: "ep-b", seriesId: "sr-OTHER", seasonId: "s9", number: 8, primaryFileId: refB },
+      },
+    });
+
+    await runImport({ items: [a, b], libraryId: "lib-1" }, { db, dandan: nullDandan() });
+
+    expect(writes.seriesPuts).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of the watch-folder work — **stacked on #55** (base = `feat/library-auto-rescan`; after #55 squash-merges, rebase this onto `main` with `git rebase --onto main feat/library-auto-rescan`).

Two review-mandated pipeline fixes plus the player-side scan (review decisions D3 / step-7 corrections):

### 1. Bare cached verdict crash (pre-existing, load-bearing)

`buildCachePayload` caches `{kind:'new'}` **without** `animeId` for local-title imports (dandan found nothing) — exactly what every unmatched file produces. On re-entry that bare verdict was adopted as-is: no `seriesRecord` → `buildPersistPayload` passes `series: undefined` → `upsertCluster`'s `validatePayload` **throws** → the cluster counts failed. Every manual "+ add folder" re-import of a folder containing local-title series hit this. Bare entries are now normalized to a cache miss and re-matched.

### 2. Re-import guard (duplicate-card killer)

When every file in a `'new'`-verdict cluster is already homed (same content hash ⇒ same fileRef id, each attached to an episode of **one** series), the verdict flips to `reuse` of that series instead of minting a fresh ulid. Kills the "matchCache expired (7d) + dandan unreachable → duplicate series card" tail the review flagged, and covers moved/renamed unchanged files. Conservative by design: any unknown file, ambiguous-homed fileRef (`episodeId: null`), or cross-series spread skips the guard. Derived reuse carries no `animeId` and is deliberately **not** cached (a bare entry would recreate bug 1).

### 3. Player tab-return scan (closes the binge flow)

`useAutoRescan` grows `{enabled, triggers, shouldDefer}`; PlayerShell (library mode only) wires it with:
- **visibility trigger only** — mount scans are `/library`'s job
- **`shouldDefer: playbackPhase === "playing"`** — evaluated inside the controller's guard chain (unit-tested), so md5 hash workers never compete with video decode; the deferred scan fires on the next tab-return
- **`seriesDetail.refresh()` on `newCount > 0`** — it's a one-shot loader (not liveQuery); without this the imported episode stays invisible until manual reload

Flow closed: watched ep N with the player pinned → downloaded ep N+1 → tabbed back → it's in EpisodeNav.

## Test plan

- [x] 6 new unit tests: bare-verdict rematch (1, fails pre-fix), re-import guard flip/ambiguous/unknown/cross-series (4), controller `shouldDefer` veto (1)
- [x] Full suite `bun test`: **286 pass / 0 fail** (all PR-1 regressions incl. reuse/touchSeries still green)
- [x] Sandbox e2e re-run on this branch: **3/3 pass** — notably the OPFS auto-rescan positive spec still passes, proving the re-import guard doesn't break the local-title import path
- [x] `next build` compile + TypeScript phases pass (export phase fails locally on AniList upstream from a cold DB — environmental, same as #55)
- [ ] TODO: manual smoke — player pinned & playing → drop next episode into the watched folder → pause → tab away/back → episode appears in EpisodeNav without reload

---
> Replaces #56 — GitHub auto-closed it when its base branch (`feat/library-auto-rescan`) was deleted by the #55 squash-merge, and closed PRs cannot be retargeted/reopened. Identical commits, rebased onto main.
