### PR TITLE
ci(bgmmap): move refresh workflow off Node 20 and document the PR gate

### DIFF
--- a/.github/workflows/refresh-bgm-map.yml
+++ b/.github/workflows/refresh-bgm-map.yml
@@ -26,6 +26,16 @@ concurrency:
   group: refresh-bgm-map
   cancel-in-progress: true
 
+# `pull-requests: write` alone is NOT enough to open the PR. The repo
+# setting Settings → Actions → General → "Allow GitHub Actions to create
+# and approve pull requests" gates it separately, and with it off this job
+# pushes the branch fine and then dies on the very last step with
+# "GitHub Actions is not permitted to create or approve pull requests."
+# That is exactly how this silently stopped producing PRs for a month —
+# the branch kept updating, so nothing looked broken from the branch list.
+# Verify with:
+#   gh api repos/OWNER/REPO/actions/permissions/workflow
+# and expect can_approve_pull_request_reviews: true.
 permissions:
   contents: write
   pull-requests: write
@@ -37,10 +47,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go-api/go.mod
 
@@ -49,7 +59,7 @@ jobs:
         run: go run ./cmd/bgmmap
 
       - name: Open PR if the map changed
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           # Only fires when the regenerated JSON differs from what's vendored.
           add-paths: go-api/internal/bgmidmap/anilist_bgm_map.json


### PR DESCRIPTION
## 背景

`chore/refresh-bgm-map` 分支在分支列表里一直显示"3 周前更新",但**从来没有对应的 PR**。翻仓库全部 56 个 PR 没有任何一个 head 是这个分支。

查 workflow 运行记录:**从 2026-07-13 起连续 4 次失败**(07-06 之前都是绿的),日志末尾:

```
##[error]GitHub Actions is not permitted to create or approve pull requests.
```

分支 push 成功、只有最后一步建 PR 挂掉,所以分支看起来一直在更新,**从分支列表完全看不出坏了** —— 静默了一个月,map 数据一直是旧的。

## 根因

`permissions: pull-requests: write` **不够**。仓库级设置 Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests" 单独控制建 PR 的能力,关着就是这个报错。

实测确认:

```
$ gh api repos/lawrenceli0228/animego/actions/permissions/workflow
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":false}
```

## 已做

**1. 打开了那个开关**(已生效,`default_workflow_permissions` 保持 `read` 不变,最小权限没动 —— workflow 自己的 job 级 `permissions:` 块提供它需要的):

```
{"default_workflow_permissions":"read","can_approve_pull_request_reviews":true}
```

**2. 手动触发验证** —— run [30916416249](https://github.com/lawrenceli0228/animego/actions/runs/30916416249) ✅ 成功,机器人自己开出了 #61(+81/-3,基于当前 main,MERGEABLE)。原来那个 3 周前的陈旧快照已被覆盖。

**3. 本 PR** —— 在 workflow 头部写清这个依赖 + 查询命令,下次看到红叉不用再从日志里重新推一遍。

**4. 顺带脱离 Node 20**(日志里的弃用警告):

| action | 前 | 后 | 说明 |
|---|---|---|---|
| actions/checkout | v4 | v5 | node24,和仓库其他 3 个 workflow 一致 |
| actions/setup-go | v5 | v6 | node24 |
| peter-evans/create-pull-request | v6 | **v8** | node24 |

> create-pull-request v8 相对 v7 **只是 Node 24 运行时升级**,无 input / 行为变更(见 v8.0.0 release notes),我们用到的 6 个 input(`add-paths` / `branch` / `commit-message` / `title` / `body` / `delete-branch`)全部保留。跑在 `ubuntu-latest`,不涉及 self-hosted runner 的版本要求。

## 遗留 / 需要你判断

- 仓库其他 workflow 还在用 `actions/setup-go@v5` 和 `actions/checkout@v4`,同样会吃 Node 20 弃用警告。本 PR 只动了这一个文件,要不要一起扫一遍你定。
- **安全考量**:"Allow Actions to create and approve pull requests" 打开后,理论上 workflow 可以 approve PR。目前仓库没有任何 auto-approve 的 workflow,且 fork 来的 PR 拿到的是只读 token。但你的磁力目录围栏依赖分支保护的 "Require review from Code Owners",这一点值得你确认一下是否可接受。要关掉的话:`gh api -X PUT repos/lawrenceli0228/animego/actions/permissions/workflow -f default_workflow_permissions=read -F can_approve_pull_request_reviews=false`(代价是这个 workflow 又会回到只推分支不开 PR)。
- 更深一层的问题是**没人看失败通知** —— 4 次红叉没触发任何动作。要不要给定时 workflow 加个失败通知,单独讨论。