### PR TITLE
docs(enrichment): retire the stale batch-size caveat now that attempt stamping landed

### DIFF
--- a/go-api/internal/queue/description_backfill.go
+++ b/go-api/internal/queue/description_backfill.go
@@ -96,11 +96,12 @@ import (
 // right shape for work that has no deadline and shares a rate limit with
 // requests a user is waiting on.
 //
-// Against the ~9,100 rows currently waiting, 300/hour reads like ~31 passes to
-// walk the catalogue once.  It is not: see KNOWN LIMITATION in the file
-// header.  Until the candidate query can exclude rows it has already tried,
-// this constant caps total coverage at p*B/(1-p) ≈ 450 rows no matter how long
-// the sweep runs, and raising it is not the fix.
+// Against the ~9,100 rows waiting at first deploy, 300/hour is ~31 passes to
+// walk the catalogue once, and that reading is now accurate: attempt stamping
+// (migration 0015, and "Why the sweep can finish" above) retires a row whatever
+// the outcome, so a pass advances a full 300 rather than only the ones that
+// converted.  ~31 hours also lands well inside descriptionBackfillRetryDays, so
+// the first walk finishes before any row is due for a re-check.
 const descriptionBackfillScanBatchSize int32 = 300
 
 // descriptionBackfillWorkTimeout bounds one subject fetch plus one UPDATE.


### PR DESCRIPTION
纯注释修正（11 行，零代码变更）：`descriptionBackfillScanBatchSize` 头上的段落还在描述 migration 0015 之前的已知缺陷（无尝试标记 → 反复捞同批行 → 覆盖上限 ~450 行）。0015 落地后每趟真实推进 300 行，~31 趟 ≈ 31 小时扫完 9,100 行积压，且在 30 天重试窗口内。把注释改成与现实一致，免得后来的读者围绕一个已不存在的限制做规划。