### PR TITLE
docs: record the known gaps in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,243 +1,104 @@
-# AnimeGo 待办
+# TODO
 
-> **状态(2026-06-01):全栈 Go 重构 + 老栈退役已完成上线**(v3.0.0,见 CHANGELOG)。下方 Part 1 的 P0–P11 重构阶段全部完成,保留作历史记录。**分支模型(2026-06-01 简化):`main` = 唯一 canonical 分支**(生产 + 开发基线);`feat/go-backend` 已退役删除,新功能走从 main 切的短命 topic 分支 → PR → squash-merge → 从 main 部署。
+已知但尚未处理的事项。按"不处理会怎样"排序，不按工作量。
 
-## 🔭 退役后 follow-ups(新)
-
-- [ ] **老 bug 在新架构复查**:退役前 main 上 2 个 fix 改的是已删老文件,但 bug 本身可能在新代码复现 —— ① 季节查询参数大小写归一(老 `server` 修过;查 go-api seasonal handler 是否归一,否则 lowercase `?season=fall` 会 cache miss + AniList 400);② 剧集解析正则词边界(老 `client` 修过 `EP?\s*(\d+)` 缺 `\b` 导致 prose 误匹配;查 next-app 解析是否有同坑)。
-- [ ] **SlamDunk(anilist 170)id-map 可疑**:backfill 后绑到 bgm 3731「灌篮高手 剧场版」(score 7.30);若 170 实为 TV 则是上游 Fribb 映射错 —— 人工核 + 必要时 admin 表手动纠。
-- [ ] **dandanplay 全量 report + heal**:429 退避已上线,可跑带 ddp 的全量 `--report`(出 QUARANTINE)+ `--heal` 补中文 —— 抢在 dandanplay 2026-06-25 配额上线前。
-- [ ] **匹配来源列数据稀疏**:`bgm_match_source` 仅最近重富化的 ~3366 行有值,7185 行(migration 0011 前的老绑)为空,随 periodic sweep 重富化逐步填。
-- [ ] **`/welcome` 1.18s 偏慢**(其余路由 <0.12s):复测确认是冷启动还是稳定慢。
-- [ ] **Lighthouse 质量项**(2026-06-01 把这些从 error 降成 warn 让 CI 过,值得真修):LCP 图提 `fetchpriority="high"` 且不懒加载(`lcp-lazy-loaded`/`prioritize-lcp-image`)· 上 WebP/AVIF(`uses-optimized-images`/`modern-image-formats`)· 对比度(`color-contrast`)· 移动端触控目标(`target-size`)· 控制台报错(`errors-in-console`)· bf-cache 不可用排查。CI 跑 mobile 对 live prod。
-- [ ] **e2e sandbox 套件陈旧(workflow 已删,specs/config 仍在)**:`.github/workflows/e2e-sandbox.yml` 已于 2026-06-01 删除 —— 它启已退役的 Mongo/Express 栈,每个 PR 失败一次刷失败邮件。残留待清(无害,不跑就行):`e2e/globalSetup.ts` 的 Mongo seed、`e2e/specs/sandbox/**`(auth/library/player/admin 写路径)、playwright `chromium-sandbox` project、`docker-compose.ci.yml` 里的 `mongodb`/`app` 死服务。想恢复写路径 E2E 才需真修 = 去 Mongo seed(只留 Postgres)+ CI 起一次性测试 PG(扔掉的测试密码,**非 prod**)+ 新建 opt-in workflow。只读 chromium-prod 在 CI 已绿(globalSetup 默认 no-op)。
-- [ ] **soft-404 详情页真 404**:`/anime/{坏id}`(及 `/seasonal/*`、`/welcome`)因 `loading.tsx` 流式渲染,`notFound()` 返 HTTP **200 非 404**(`not-found.tsx` 那句"root not-found 设 404"是 comment rot)。Next 自动注入 `noindex` 已护住索引(2026-06-01 实测),实际危害近零 → **LOW**。真修两条路:① `global-not-found.js`(Next 16 experimental,但文档显示它是给"压根不匹配任何路由"的 URL,对"匹配路由内 streaming notFound"大概率**无效**,需部署后 curl 验);② 删 `/anime/[id]/loading.tsx`(保证真 404,但丢冷 id 骨架屏)。**eng-review pass-2(2026-06-01)决定 feat/detail-seo-fixes PR 不修,defer。**
-- [ ] **登录用户首页吃边缘缓存(去 CF `/` 的 session/refreshToken bypass + 加一致性守卫测试)** ← 2026-06-05 /plan-eng-review「登录用户提速」D1,用户 defer。islanding 后(PR #45)首页 HTML 已**人人一样**(服务端零用户数据,page.tsx + layout 核过),所以登录用户也能安全吃 CF 缓存,TTFB **0.73s→0.12s**。**但去 bypass = 撤掉那道天然安全网** —— 未来谁在首页服务端再塞"按用户"的读取,缓存会把一个人的数据发给所有人(跨用户泄漏,blast radius 高)。**所以必须配 CI 守卫测试**:断言带 / 不带 `session` cookie 的 `/` SSR HTML 逐字一致(或不含任何用户态标记),任何回归立即红。改动 = CF 规则删两条 cookie bypass + 新增守卫测试。同理可推广到 `/anime/*`(也已 island、也对登录用户 bypass)。
-- [ ] **首页图片减重(~10MB 封面 = "下载慢"根源)** ← 2026-06-05 /plan-eng-review「还有没有别的办法」,用户 defer(先不动)。实测:首页 114 张唯一封面 × ~87KB(`/large/`)≈ ~10MB,是登录用户"下载慢"的真因(**AniList CDN 本身健康**:走 CF-SYD、0.2-0.4s/张,纯粹是量;JS 284KB 次要、immutable 首访后缓存)。三条路:**A `/large/→/medium/`**(URL 路径段替换,87→29KB / **-66%**,5min,零部署风险,但视网膜略糊)· **B next/image 自托管 AVIF**(缩尺寸+转 AVIF+按 DPR 自动 srcset,87→~20-30KB / **-70%+ 且画质不损甚至更准**;sharp 0.34.5 已装、standalone 可行)· **C 减图片数**(产品决策)。**B 的两个事故级坑必须防**:① **standalone 不打包 sharp**([vercel/next.js #59460](https://github.com/vercel/next.js/discussions/59460))—— 我们 `next-app/Dockerfile` runner(`node:22-alpine`)**没装 sharp** → 一开优化封面**全裂**;防 = runner 阶段显式装 sharp(musl)或从 builder `COPY node_modules/sharp`。② **CF 不按 `Vary: Accept` 缓存** —— optimizer 按浏览器 `Accept` 出 AVIF/WebP/JPEG,CF 默认不认 Vary → 把 AVIF 喂给不支持的浏览器=**裂图**,或干脆不缓存=**源站 optimizer 被打爆**;防 = CF Cache Rule 给 `/_next/image*` 把 `Accept` 加进 cache key + 转发 Accept 头。次要坑:`.next/cache/images` 容器临时(挂 named volume 保险)、`images.minimumCacheTTL` 设大、`remotePatterns` 死锁 `s4.anilist.co`、`dangerouslyAllowSVG` 保持关。**上线必须 canary**(单 id 验证封面真出 AVIF + 不裂 + CF HIT)再全量。关联上方 Lighthouse 项的 `modern-image-formats`。资料:[Next 自托管指南](https://nextjs.org/docs/app/guides/self-hosting) · [standalone+sharp Docker](https://flinect.com/blog/nextjs-standalone-docker-sharp-installation) · [CF 缓存 self-hosted Next](https://focusreactive.com/configure-cdn-caching-for-self-hosted-next-js-websites/)。
+发现于 2026-08-09（v3.9.1 上线后）。
 
 ---
 
----
+## 1. `animegoanime@animegoclub.com` 收不到信 —— 需要人工操作
 
-## Part 1 — 重构 Workflow 进度
+**状态**：域名 `animegoclub.com` **没有 MX 记录**，该地址不存在，寄过去的邮件全部退回。
 
-### 🟡 P0: Go 骨架 + Postgres + Backup + dev script (0/6,二轮 review 2C 加 dev.sh)
+```
+dig +short MX animegoclub.com     # 空
+dig +short TXT animegoclub.com    # 只有 google-site-verification
+```
 
-起 `feat/go-backend` 分支 + Go + Postgres + R2 backup + 本机 dev 一键起。**20-35 hr**
+**为什么排第一**：这个地址已经随 v3.9.0 上线，写在三个法律页上——`/privacy`、`/terms`、`/copyright`。其中**版权页那个是 DMCA 下架通知的收件地址**。提供了一个收不到的联系方式，比不提供更糟。
 
-- [ ] 起分支 + `go-api/` 项目结构(chi + pgx + sqlc + river)
-- [ ] docker-compose 加 postgres:16-alpine
-- [ ] Cloudflare R2 bucket + rclone + nightly pg_dump cron
-- [ ] backup → restore 演练通过 + R2 30-day retention cron 实跑
-- [ ] **scripts/dev.sh 一键起 6 进程**(postgres + mongo + go-api + ws-server + Next + .env.example check)
-- [ ] 验收:`:8080/health` OK + postgres healthy + R2 backup 当天有文件 + scripts/dev.sh 工作
+**做法**（Cloudflare Email Routing，免费，DNS 已在 CF 上）：
 
----
+1. CF 控制台 → `animegoclub.com` → 左侧 **Email** → Email Routing → Get started
+2. 让它**自动添加** 3 条 MX + 1 条 SPF TXT（不要手工加，避免与后续冲突）
+3. Destination addresses → 添加常用邮箱 → 去那个邮箱点确认链接（**这一步只能人工**，CF 要验证收件方同意）
+4. Routing rules → Custom address → `animegoanime` → 转发到该邮箱
 
-### 🔴 P1: Migration Tool (0/6,二轮 review 6A + tests gap) ← critical
+**验证**：
 
-Go 单二进制 `cmd/migrate-mongo`,一次性 Mongo → Postgres。**40-60 hr**
+```bash
+dig +short MX animegoclub.com          # 应出现 route1/2/3.mx.cloudflare.net
+dig +short TXT animegoclub.com | grep spf
+```
 
-- [ ] 14 张 Postgres 表 + 索引 + **search_vec generated column STORED + GIN**(3P)+ **全 CASCADE FK**(1C) + pg_trgm extension
-- [ ] pg_cron 安装 + danmaku TTL 任务 + **pg_cron 实际 fire test**(P1 test gap)
-- [ ] 7 个 collection-specific transform 函数 + testcontainers 测试
-- [ ] **field-level parity test:10 个 UI-critical field × 1000 sample 严格 equal**(6A)
-- [ ] **idempotency:同 mongo dump 重跑 PG 不重 row**(P1 test gap)
-- [ ] **dry-run on prod mongodump 副本通过**,row count 差异 < 0.1%
+**两个坑**：
 
----
+- CF Email Routing **只能收不能发**。要以这个地址回信，需在 Gmail 配「Send mail as」走 Gmail SMTP。
+- **SPF 只能有一条**。若同时用 CF 收信 + Gmail 发信，必须合并成一条，两条是硬失败、比没有更糟：
+  ```
+  v=spf1 include:_spf.mx.cloudflare.net include:_spf.google.com ~all
+  ```
 
-### 🔴 P2: Go API 重写 (0/8 sub-milestones)
-
-48 endpoint + 311 测试。**112-185 hr + P2.7 测试 60-80 hr + P2.8 ws-server 10-15 hr**
-
-拆 8 个 sub-milestone,每个独立 PR ship:
-
-- [ ] **P2.1** `/api/anime/*` 9 endpoint + 富化 queue (river) + 2-tier cache 主从决策(35-55 hr)
-- [ ] **P2.2** `/api/auth/*` 7 endpoint + JWT + bcrypt + Gmail SMTP + **dual-accept header+cookie 7天**(18-28 hr)
-- [ ] **P2.3** `/api/admin/*` 14 endpoint + adminAuth + 富化 queue 控制(15-22 hr)
-- [ ] **P2.4** `/api/subscriptions/*` + `/api/users/*` + `/api/feed`(12-18 hr)
-- [ ] **P2.5** `/api/comments/*` + `/api/danmaku/*`(HTTP only)(8-12 hr)
-- [ ] **P2.6** `/api/dandanplay/*` + 3-phase match(**二轮 review 6C +12hr → 24-37 hr**)
-- [ ] **P2.7** testify + testcontainers-go 等价重写 311 测试(60-80 hr)
-- [ ] **P2.8** **ws-server 拆出独立服务**(10-15 hr,二轮 review 3A NEW)← LRU rate-limit + JWT 共享 + PG INSERT ON CONFLICT
-
-⚡ 顺路完成的旧 TODO:待办四(`is_public`)在 P2.2、enqueueEnrichment bgmId 在 P2.1、磁力 cache 持久化在 P2.1。
+**顺带**：现在 app 发密码重置信是从 gmail.com 直发的（`GMAIL_USER`），而 **79.6% 的用户邮箱是 @qq.com**（638/802，2026-08-09 实测）。gmail→QQ 送达率大概率过不了一半，且裸 `net/smtp` 看不到退信——**很可能已经有一批用户点了「忘记密码」但从没收到过信**。把发信域名一起做了（SPF+DKIM+DMARC，发件人改 `noreply@animegoclub.com`）会一次解决三件事：密码重置真能送达、版权投诉能收到、以及每周更新提醒邮件的前置条件。
 
 ---
 
-### 🟢 P3: Next.js 16 骨架 + Bun (0/3,二轮 review 1A 改版本)
+## 2. CI 不跑 `next build`
 
-Next 16 + Bun + rewrites 通老 Express + baseline 测量。**15-25 hr**
+**状态**：检查项只有 test + lint。**一个引用不存在模块的分支可以五项全绿走到合并。**
 
-- [ ] 起 `next-app/` scaffold + bun + bun.lockb (Next.js 16,React 19 默认,Turbopack stable)
-- [ ] next.config.js rewrites 通老 Express:5001(P9 cutover 时改 go-api:8080)
-- [ ] **建 baseline:** v2.0.1 Lighthouse 三路径 + Express 错误率 7 天 + socket.io 断流率 + GSC 索引数 + **prod metrics req/s p50/p95/p99 + 峰值**(8A) + **vnstat 30-day outbound + VPS 带宽 plan**(TODO-1 / Pf4)
+2026-08-09 实际发生过：`feat/activation-funnel` 一度包含 `SeriesDetailSheet.tsx` 引用 `../_services/loadSeriesRows`，而该模块是未跟踪文件、没进分支。CI 全绿，是手动 `git ls-tree` 才发现的。
 
----
+**做法**：`unit-tests.yml` 加一个 job 跑 `bun run build`。约十几行。
 
-### 🟢 P4: Public Pages RSC (0/4)
-
-LandingPage / About / Privacy → RSC + sitemap + metadata。**17-27 hr**
-
-- [ ] LandingPage RSC 化(fetch Go /api/anime/trending + yearly-top)
-- [ ] sitemap.xml + 全局 metadata
-- [ ] U1 inline script 防 lang/danmaku FOUC + 3 个 loading.tsx skeleton
-- [ ] 验收:Lighthouse SEO ≥ 95 + LCP < 1.5s + view-source 看到 anime 数据
+**附带收益**：能顺便断言 `/anime/[id]` 仍是 `●`（SSG 预渲染）——那是 Cloudflare 边缘缓存的前提，而 SEO 是本站唯一的获客来源。这条一旦退化成 `ƒ`，没有任何现有检查会发现。
 
 ---
 
-### 🟢 P5: SEO 核心 ISR (0/4)
+## 3. 部署后旧标签页崩在详情页 → [issue #76](https://github.com/lawrenceli0228/animego/issues/76)
 
-`/anime/[id]` + `/seasonal/*` + `/search` ISR 化。**18-33 hr**
-
-- [ ] `/anime/[id]` ISR + JSON-LD TVSeries(8 query Go 拼数据)
-- [ ] `/seasonal/[season]/[year]` + `/search` ISR
-- [ ] U2 anime_cache.accent_color 字段 + migration 回填 + AnimeCard 改读 props
-- [ ] 验收:SSR HTML 包含 anime 数据 + Lighthouse SEO 100 + JSON-LD Rich Results 通过
+细节见 issue。优先级低（有错误边界兜底，不白屏），但「重试」按钮在这种情况下无效，是骗人的。
 
 ---
 
-### 🔴 P6: Library + Player + libass 平移 (0/6) ← 最容易翻车
+## 4. 埋点：`user_activity_daily`
 
-全 client-side。Dexie / IndexedDB / FSA / artplayer / jassub 全部 dynamic({ssr:false})。**45-85 hr**
+**状态**：没有任何办法度量留存。`users` 表无 `last_login`、无事件表，只能靠 `refresh_rotated_at` 这个副作用推断（它在注册/登录/登出时被置 NULL，语义不可靠）。
 
-- [ ] `/library` + `/player` 'use client'
-- [ ] artplayer / dandanplay-vi / jassub libass-wasm dynamic import
-- [ ] react-router-dom → next/navigation 全替换(72 文件)
-- [ ] reauth E2E(补充 v2.0.1 已有的 6 个 wiring 单元测试)
-- [ ] U0 + U3:'use client' 边界审计 + 2 loading.tsx skeleton
-- [ ] 验收:50+ 文件夹无 hydration mismatch + jassub 字幕跟 v2.0.1 一致
+**为什么现在记**：v3.9.0/3.9.1 刚上线一批以提升留存为目标的改动，而**没有任何办法判断它们是否有效**。
 
----
+**关键性质**：激活率、注册量、流量都**可回溯**（`subscriptions.created_at` / `users.created_at` 一直在记）；**只有留存不可回溯**——今天不开始记，这段 cohort 就永远算不出来。
 
-### 🟢 P7: Admin RSC + middleware (0/3)
+**做法**：一张两列主键的表 + 一个 go-api 中间件，约 80 行。设计见 `docs/designs/growth-activation-plan-zh.html` 的 Tier 0。
 
-middleware role check + admin 页面 RSC。**15-25 hr**
+```sql
+CREATE TABLE user_activity_daily (
+    user_id       uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    day           date NOT NULL,
+    first_seen_at timestamptz NOT NULL DEFAULT now(),
+    last_seen_at  timestamptz NOT NULL DEFAULT now(),
+    hits          integer     NOT NULL DEFAULT 1,
+    PRIMARY KEY (user_id, day)
+);
+```
 
-- [ ] middleware admin 鉴权(runtime: nodejs)
-- [ ] admin 页面 RSC + 富化 queue 控制 UI(river client)
-- [ ] 验收:E2E admin 角色越权测试
+量级：DAU 约 10-15 → 约 400 行/月。十年不到 100 万行。
 
-⚡ 顺路完成:待办十七(admin 富化速率保护)。
-
----
-
-### 🟡 P8: 部署架构 (0/7,二轮 review 5A+5C+test gap 改)
-
-3 个 Dockerfile(app/Bun + go-api/distroless + ws-server/Node;**5C 删 Dockerfile.node**)+ nginx + Cloudflare + Sentry。**30-50 hr**
-
-- [ ] go-api Dockerfile multi-stage distroless
-- [ ] Next.js app Dockerfile (Bun + Next.js 16)
-- [ ] docker-compose 6 容器(app + go-api + ws-server + postgres + mongo + nginx)+ rollback profile
-- [ ] nginx 路由分发 + COOP/COEP/CORP + WASM CSP + local-fonts Permissions-Policy
-- [ ] **5 nginx header 联动 Playwright 测试:libass + cross-origin font + console.error 清零**(test gap)
-- [ ] Cloudflare cache rules + GitHub Actions CI (setup-go + setup-bun) + **build-express workflow 推 :rollback-T0 tag**(5A)
-- [ ] 验收:VPS staging 3 容器跑通 + Sentry 收到 staging error 流 + sentry alert 验证
-
-⚡ 顺路完成:待办十六(Sentry)。
+**同一天顺手**（各 5 分钟）：开启 Cloudflare Web Analytics——实测 beacon **当前不在页面上**（CSP 已放行，是遗留空壳），而它是「注册转化率」唯一缺的那个分母。
 
 ---
 
-### 🔴 P8.5: Shadow Traffic 1 周 + 演练 (0/6,二轮 review 1T+2T+Pf4 加 2 项) ← critical gate
+## 5. 自建弹幕：建议砍掉
 
-cutover 前 7 天,nginx mirror 复制 prod 流量到 Go,验证 P99。**15-25 hr**
+**状态**：`danmakus` 表 3 条数据，而它养着一个 7×24 常驻容器（ws-server）+ 约 1600 LOC + 2 张表 + nginx 路由。
 
-- [ ] nginx mirror directive + X-Shadow-Traffic header 识别
-- [ ] Go shadow mode:走完所有逻辑但不返回响应,记 metrics
-- [ ] Prometheus + Grafana(docker-compose 加 2 service)+ 告警阈值
-- [ ] **Pf4 mirror throttle:** 若 baseline outbound × 2 > VPS cap,降到 50% sample
-- [ ] **Day-6 cutover dress rehearsal:** staging 完整 T+0 序列(ws-server stop → Express stop → migration → switch)
-- [ ] **Day-7 rollback drill:** ssh + nginx switch 计时 <5min
-- [ ] **critical gate:** 7 天后错误率 < 1% + P99 < baseline×1.5 + 0 Go panic + 2 演练通过 → 进 P9
+**为什么不是"冷启动失败"而是"从来没有入口"**（四条独立证据）：
 
----
+- `next-app/package.json` **无 `socket.io-client` 依赖**
+- `next-app/src` **零处调用** `/api/danmaku`（连读都没接）
+- `VideoPlayer.tsx` 显式 `emitter: false`
+- `danmakus` 表**无播放时间戳字段** —— 结构上不可能覆盖到视频上；它是"按集的 2 小时聊天室"，和播放器里那个弹幕只是重名
 
-### 🔴 P9: Big-Bang Cutover (0/6,二轮 review 5A+5T) ← production critical
+播放器现有的弹幕来自 dandanplay（一集常几千条），那才是真正的卖点，**保留**。
 
-凌晨 3-5am UTC+8 维护窗口,nginx 一次切流量到 go-api。**10-20 hr**
-
-- [ ] T-7 day:全站 banner 公告维护 + 关闭注册 24h 前
-- [ ] **T-1 day:GH Actions trigger build-express + 推 :rollback-T0 tag 到 registry**(5A)
-- [ ] **T+0 维护窗口序列(修正):** stop ws-server → stop Express → 跑 migration → field+row 校验 → nginx 改 upstream(5T)
-- [ ] T+1h:Grafana + Sentry 验证 + 真实用户 smoke test
-- [ ] T+24h:错误率 < 1% + 0 critical bug → cutover 成功
-- [ ] T+30day:停 mongo 容器 + mongodump → R2(灾难恢复,不是 rollback)
-
-**Critical gate:** T+24h 错误率 > 1% 或 critical bug → nginx 一行回 Express,Postgres 写入数据丢失(详见 plan § 4)
-
----
-
-### 🟢 P10: Lighthouse CI + Sentry + Playwright E2E + 性能拍板 (0/7,二轮 review TODO-3+TODO-4+Pf1+Pf5 加 3 项)
-
-5 关键 E2E + Lighthouse CI + Sentry + pg_stat_statements。**15-30 hr**
-
-- [ ] 5 个 Playwright E2E(注册→播放、详情→订阅、reauth、admin 越权、弹幕实时)
-- [ ] Lighthouse CI on every PR(LCP regression > 10% block)
-- [ ] Sentry production DSN 接入 go-api + app
-- [ ] **Sentry alert wiring fire test:注 fake error → 验证 email/Slack 30s 内收到**(TODO-3)
-- [ ] **Playwright 视觉回归:pixel-diff 0.1% threshold + PR 评论 "visual: ok" 触发 CI re-snap**(TODO-4)
-- [ ] **P5 dual-mode 详情页 P10 拍板:基于 P8.5 数据决定 8-query 或 json_agg 默认**(Pf1)+ **pgx pool size 25-50**(Pf5)
-- [ ] 1328 client 测试适配 next/navigation(原 plan 写 1342,实际 1328)
-
----
-
-## Part 2 — 未完成产品 TODO(部分迁移期消化)
-
-| 待办 | 标题 | 优先级 | Effort | Migration impact |
-|------|------|------|------|------|
-| 四 | `users.is_public` 字段 | P3 | S | ⚡ P2.2 顺路 |
-| 五 | WebSocket Redis Pub/Sub | P3 | M | 不在 v2 plan 范围(ws-server 长期 follow-up) |
-| 十六 | Sentry 错误监控 | P2 | S | ⚡ P8 顺路(go-api + app 双 SDK) |
-| 十七 | Admin 重新富化速率保护 | P2 | S | ⚡ P2.3 + P7 顺路(river queue 控制) |
-| - | `enqueueEnrichment` 支持 bgmId 键 | P3 | S | ⚡ P2.1 顺路(river 任务支持 bgmId) |
-| - | 磁力 cache 持久化(Postgres 表)| P2 | S | ⚡ P2.1 顺路 |
-
-详细见 [docs/migration/MIGRATION_PLAN.md § 3.6](docs/migration/MIGRATION_PLAN.md)。
-
----
-
-### 迁后 TODO(P0-P10 全部完成后)
-
-- [ ] 开 `strict: true` 清扫 `any`(20-40 hr)
-- [ ] Lighthouse CI on every PR,LCP regression block merge
-- [ ] Go server-side schema 与 client TS 端到端类型(codegen via OpenAPI)
-- [ ] React 19 升级(等 Next 官方 stable + artplayer 兼容)
-- [ ] ws-server → Go(等 socket.io v4 Go 库成熟,可能永不迁)
-- [ ] Postgres → managed(Supabase / Neon)如果 VPS 不够用了
-- [ ] 待办五:socket.io-redis adapter(多 ws-server 实例时)
-
----
-
-## Part 3 — 已归档(完成项)
-
-### v0.1 - v0.2(社区化前期)
-
-- [x] **待办一:** 季度番剧翻页数据为空(2026-03-08)
-- [x] **待办二:** 限流未根本解决(2026-03-08)
-- [x] **待办三:** 补写核心测试(v0.1.0-v0.1.4)
-- [x] **待办八:** 建立 DESIGN.md 设计系统文档(2026-03-27)
-- [x] **待办九:** 全局 Toast 通知系统(2026-03-28)
-- [x] **待办十:** 弹幕输入框断线状态视觉处理(2026-03-28)
-- [x] **待办十一:** 用户追番列表分页(2026-03-28)
-- [x] **待办十二:** follow / profile / danmaku 控制器测试(v0.2.0)
-- [x] **待办十三:** `useFollow` 关注/取关失败 Toast 反馈
-- [x] **待办十四:** `GET /api/feed` 分页支持
-
-### v1.x(SEO + 富化)
-
-- [x] **待办十五:** 启动时全量扫描未富化番剧(`sweepUnenriched`)
-- [x] **待办十八:** 部署后 Google Search Console 操作(2026-04-17)
-
-### v2.0(本地媒体库)
-
-- [x] 本地影音库 P1-P5(2026-05-09 v2.0.0)
-- [x] **2026-05-10 patch:** UnavailableSeriesSection 加 section-level「重新授权」按钮
-
-### v2.0.1(libass-wasm 字幕渲染)
-
-- [x] **libass-wasm 集成**(2026-05-11,PR #9,commit `bcb0a51`)— MKV 内嵌 ASS 字幕渲染 + zlib 解压 + CJK 字体 fallback + COOP/COEP/CORP
-
----
-
-_最后更新:2026-05-12 19:00(/plan-eng-review **二轮 deep re-run** 后,19 个新 finding,17 resolved + 2 unresolved-accepted。NEW P2.8 ws-server split phase,Next.js 14→16,schema 全 CASCADE + search_vec generated column,P8.5 加 day-6 dress rehearsal + day-7 rollback drill,P9 序列加 stop ws-server)_
+**注意**：这是删代码，不可逆，且会动 `docker-compose.yml` / nginx 配置。做之前单独确认。


### PR DESCRIPTION
把当前已知、尚未处理的事项落到 `TODO.md`，按「不处理会怎样」排序而不是按工作量。

1. **`animegoanime@animegoclub.com` 收不到信** —— 域名无 MX 记录。这个地址已随 v3.9.0 上线，写在三个法律页上，其中版权页那个是 DMCA 下架通知的收件地址。需要人工在 Cloudflare 面板操作（目的地址验证只能人工点确认链接）。
2. **CI 不跑 `next build`** —— 引用不存在模块的分支可以五项全绿走到合并，2026-08-09 实际发生过。
3. 部署后旧标签页崩在详情页 → #76
4. **埋点 `user_activity_daily`** —— 留存是唯一不可回溯的指标，而刚上线的一批改动正以提升留存为目标。
5. 自建弹幕建议砍掉 —— 4 条证据表明它不是冷启动失败，是从来没有过入口。

纯文档，无代码改动。