### PR TITLE
fix(privacy): stop serving email addresses and phone numbers as usernames

### DIFF
--- a/go-api/internal/anime/handlers.go
+++ b/go-api/internal/anime/handlers.go
@@ -29,6 +29,7 @@ import (
 	"github.com/lawrenceli0228/animego/go-api/internal/cache"
 	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 	"github.com/lawrenceli0228/animego/go-api/internal/torrents"
 )
 
@@ -319,9 +320,21 @@ func Watchers(q dbgen.Querier) http.HandlerFunc {
 		// Map rows → []watcherItem so the JSON shape carries an object per
 		// element ({username, avatarUrl}). avatarUrl drives the watcher
 		// avatar thumbnails; nil renders the initial fallback.
+		//
+		// pii.PublicUsername is load-bearing here, more than anywhere else
+		// in the codebase: this endpoint takes no auth at all, and the
+		// frontend renders each username four times per watcher (the
+		// /u/{username} href, title, aria-label and img alt) into
+		// /anime/{id} — a route that is ISR-prerendered, Cloudflare
+		// edge-cached and indexed.  A contact-shaped username here ends up
+		// in a CDN-cached search result.
 		items := make([]watcherItem, 0, len(watchers))
 		for _, row := range watchers {
-			items = append(items, watcherItem{Username: row.Username, AvatarURL: row.AvatarUrl, BackdropCoverURL: row.BackdropCoverUrl})
+			items = append(items, watcherItem{
+				Username:         pii.PublicUsername(row.Username),
+				AvatarURL:        row.AvatarUrl,
+				BackdropCoverURL: row.BackdropCoverUrl,
+			})
 		}
 
 		// Express:  res.json({data, total}) — flat sibling keys, not

--- a/go-api/internal/anime/watchers_pii_test.go
+++ b/go-api/internal/anime/watchers_pii_test.go
@@ -1,0 +1,95 @@
+package anime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+// GET /api/anime/{id}/watchers takes no auth at all, and the frontend renders
+// each username four times per watcher (the /u/{username} href, title,
+// aria-label and img alt) into /anime/{id} — an ISR-prerendered,
+// Cloudflare-edge-cached, indexable route.
+//
+// On 2026-08-16 this endpoint was returning live email addresses and phone
+// numbers in production, because nothing constrained the shape of
+// users.username.  These tests fail if the masking is ever removed.
+func TestWatchers_MasksContactShapedUsernames(t *testing.T) {
+	t.Parallel()
+
+	// Shapes observed in production (values altered, shapes kept).
+	q := &fakeQuerier{
+		getWatchersFn: func(_ context.Context, _ int32, _ int32) ([]dbgen.GetWatchersRow, error) {
+			return []dbgen.GetWatchersRow{
+				{Username: "2548537435@qq.com"},
+				{Username: "17566285293"},
+				{Username: "alice"},
+			}, nil
+		},
+		countWatchersFn: func(_ context.Context, _ int32) (int64, error) { return 3, nil },
+	}
+
+	rec := httptest.NewRecorder()
+	watchersRouter(q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/42/watchers", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+
+	// The whole point: none of it may appear anywhere in the response.
+	for _, leak := range []string{"2548537435", "@qq.com", "17566285293", "@"} {
+		require.NotContains(t, body, leak,
+			"watchers response leaked %q — this reaches an anonymous caller and the CDN-cached detail page", leak)
+	}
+
+	var parsed struct {
+		Data []struct {
+			Username string `json:"username"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &parsed))
+	require.Len(t, parsed.Data, 3)
+
+	// Masked entries are replaced, not dropped: the watcher count and the
+	// avatar row must stay honest.
+	require.True(t, strings.HasPrefix(parsed.Data[0].Username, "user-"))
+	require.True(t, strings.HasPrefix(parsed.Data[1].Username, "user-"))
+
+	// A normal username is untouched — a false positive here would rename
+	// real users and break their /u/ links.
+	require.Equal(t, "alice", parsed.Data[2].Username)
+}
+
+// The slug has to be stable, or the same watcher would appear as a different
+// person on every request and /u/{slug} could never resolve.
+func TestWatchers_MaskIsStableAcrossRequests(t *testing.T) {
+	t.Parallel()
+
+	q := &fakeQuerier{
+		getWatchersFn: func(_ context.Context, _ int32, _ int32) ([]dbgen.GetWatchersRow, error) {
+			return []dbgen.GetWatchersRow{{Username: "2548537435@qq.com"}}, nil
+		},
+		countWatchersFn: func(_ context.Context, _ int32) (int64, error) { return 1, nil },
+	}
+
+	get := func() string {
+		rec := httptest.NewRecorder()
+		watchersRouter(q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/42/watchers", nil))
+		var parsed struct {
+			Data []struct {
+				Username string `json:"username"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+		require.Len(t, parsed.Data, 1)
+		return parsed.Data[0].Username
+	}
+
+	require.Equal(t, get(), get())
+}

--- a/go-api/internal/auth/account.go
+++ b/go-api/internal/auth/account.go
@@ -23,6 +23,7 @@ import (
 	"github.com/lawrenceli0228/animego/go-api/internal/avatars"
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 	"github.com/lawrenceli0228/animego/go-api/internal/jwtx"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 const (
@@ -65,6 +66,13 @@ func (h *Handlers) UpdateMe(w http.ResponseWriter, r *http.Request) {
 		name := strings.TrimSpace(*req.Username)
 		if len(name) < minUsernameLen || len(name) > maxUsernameLen {
 			httpx.Fail(w, httpx.NewError(http.StatusBadRequest, codeValidation, msgUsernameLen))
+			return
+		}
+		// Same rule as registration — otherwise the settings page is a
+		// back door that puts a contact detail back on the public
+		// surfaces internal/pii exists to keep it off.
+		if pii.LooksLikeContact(name) {
+			httpx.Fail(w, httpx.NewError(http.StatusBadRequest, codeValidation, msgUsernameLooksLikeContact))
 			return
 		}
 		if _, err := h.db.UpdateUsername(ctx, claims.UserID, name); err != nil {

--- a/go-api/internal/auth/handlers.go
+++ b/go-api/internal/auth/handlers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lawrenceli0228/animego/go-api/internal/email"
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 	"github.com/lawrenceli0228/animego/go-api/internal/jwtx"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 // queryTimeout bounds every handler's database round-trip.  Five
@@ -104,6 +105,13 @@ const (
 	msgUsernameRequired  = "Username must be 3-50 characters"
 	msgEmailRequired     = "Invalid email format"
 	msgValidationGeneric = "Invalid request"
+
+	// The username is a public display name and the /u/{username} routing
+	// key; the email is only ever a way to recover the account.  Letting
+	// one be the other published contact details into anonymous endpoints
+	// and, through the watchers list, into the CDN-cached /anime/{id}
+	// page.  See internal/pii.
+	msgUsernameLooksLikeContact = "Username cannot be an email address or a phone number — it is shown publicly"
 )
 
 // AuthDB is the sqlc subset that auth handlers consume.  Defined here
@@ -225,6 +233,17 @@ func (h *Handlers) Register(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := h.validator.Struct(&req); err != nil {
 		httpx.Fail(w, httpx.NewError(http.StatusBadRequest, codeValidation, validationMessage(err)))
+		return
+	}
+
+	// The username is public (display name + /u/{username} route) while the
+	// email exists only to recover the account.  Nothing used to stop the
+	// two from being the same string, and users did exactly that, which put
+	// live addresses and phone numbers into anonymous endpoints.  Rejecting
+	// at registration stops new ones; internal/pii masks the existing rows
+	// on the way out.
+	if pii.LooksLikeContact(req.Username) {
+		httpx.Fail(w, httpx.NewError(http.StatusBadRequest, codeValidation, msgUsernameLooksLikeContact))
 		return
 	}
 

--- a/go-api/internal/auth/ratelimit.go
+++ b/go-api/internal/auth/ratelimit.go
@@ -213,4 +213,3 @@ func writeRateLimited(w http.ResponseWriter) {
 		slog.Warn("auth: write 429 envelope", "err", err)
 	}
 }
-

--- a/go-api/internal/auth/safeuser_pii_test.go
+++ b/go-api/internal/auth/safeuser_pii_test.go
@@ -1,0 +1,91 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+// One name, one value, everyone — the owner included.  There is no second
+// field carrying the raw username, so nothing can leak it back and nothing
+// on screen can disagree with what other people see.
+func TestToSafeUser_MasksForTheOwnerToo(t *testing.T) {
+	const addr = "2548537435@qq.com"
+
+	su := ToSafeUser(dbgen.User{ID: uuid.New(), Username: addr, Email: addr})
+
+	if su.Username == addr {
+		t.Fatal("Username still holds the address — the owner's own view leaks it")
+	}
+	if !strings.HasPrefix(su.Username, "user-") {
+		t.Fatalf("Username = %q, want a masked handle", su.Username)
+	}
+	if !su.UsernameHidden {
+		t.Fatal("UsernameHidden = false — the settings page cannot explain the handle")
+	}
+}
+
+// The common case must stay boring: the real name, no flag, no warning.
+func TestToSafeUser_LeavesAnOrdinaryNameAlone(t *testing.T) {
+	su := ToSafeUser(dbgen.User{ID: uuid.New(), Username: "lawrence", Email: "l@example.com"})
+
+	if su.Username != "lawrence" {
+		t.Fatalf("Username = %q, want it unchanged", su.Username)
+	}
+	if su.UsernameHidden {
+		t.Fatal("UsernameHidden = true for an ordinary name — a warning would appear for no reason")
+	}
+}
+
+// The flag and the value have to agree.  If they ever drift, the settings
+// page either warns about a name that is fine or stays silent about one that
+// is hidden.
+func TestToSafeUser_FlagAgreesWithTheValue(t *testing.T) {
+	cases := []struct {
+		stored     string
+		wantHidden bool
+	}{
+		{"2548537435@qq.com", true},
+		{"17566285293", true},
+		{"154961455462", true},
+		{"lawrence", false},
+		{"无始冬", false},
+		{"2024", false},
+	}
+	for _, c := range cases {
+		su := ToSafeUser(dbgen.User{ID: uuid.New(), Username: c.stored})
+		if su.UsernameHidden != c.wantHidden {
+			t.Errorf("%q: UsernameHidden = %v, want %v", c.stored, su.UsernameHidden, c.wantHidden)
+		}
+		masked := su.Username != c.stored
+		if masked != c.wantHidden {
+			t.Errorf("%q: value masked = %v but flag = %v — they disagree", c.stored, masked, su.UsernameHidden)
+		}
+	}
+}
+
+// ToSafeUser is documented as the ONLY conversion from a DB row into a
+// response payload.  Assert the secret columns still do not survive it, so
+// the guarantee that everything routes through here keeps its teeth.
+func TestToSafeUser_StillStripsSecrets(t *testing.T) {
+	su := ToSafeUser(dbgen.User{
+		ID:                 uuid.New(),
+		Username:           "lawrence",
+		Email:              "l@example.com",
+		Password:           "$2a$10$hashed",
+		RefreshToken:       strptr("refresh-token"),
+		ResetPasswordToken: strptr("reset-token"),
+	})
+
+	// SafeUser has no field for any of them — a compile-time guarantee — so
+	// assert the observable part: the projection built and did not carry the
+	// extra columns through some future catch-all.
+	if su.Username != "lawrence" || su.Email != "l@example.com" {
+		t.Fatalf("unexpected projection: %+v", su)
+	}
+}
+
+func strptr(s string) *string { return &s }

--- a/go-api/internal/auth/types.go
+++ b/go-api/internal/auth/types.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 
 	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 // RegisterReq is the POST /api/auth/register body shape.  Validation
@@ -78,8 +79,25 @@ type ResetPasswordReq struct {
 // resetPasswordToken, resetPasswordExpires.  See ToSafeUser comment for
 // the trust boundary.
 type SafeUser struct {
-	ID                uuid.UUID `json:"id"`
-	Username          string    `json:"username"`
+	ID       uuid.UUID `json:"id"`
+	Username string    `json:"username"`
+
+	// UsernameHidden is true when the stored username was contact-shaped and
+	// internal/pii replaced it, so Username above is an opaque handle rather
+	// than a name its owner chose.
+	//
+	// Username itself carries the SAME value for everyone, the owner
+	// included — there is deliberately no second field holding the raw
+	// string.  One name means one thing on screen, and the owner has no use
+	// for the original: sessions are keyed on email (see LoginReq), so the
+	// username is purely a display name.
+	//
+	// The flag exists so the settings page can explain the handle without
+	// re-implementing the detection rule in TypeScript.  A second copy of
+	// that rule would eventually disagree with the Go one, and the failure
+	// mode is telling someone their name is fine while the server hides it.
+	UsernameHidden bool `json:"usernameHidden"`
+
 	Email             string    `json:"email"`
 	Role              *string   `json:"role"`
 	IsPublic          bool      `json:"isPublic"`
@@ -102,8 +120,11 @@ type SafeUser struct {
 // explicitly added here.
 func ToSafeUser(u dbgen.User) SafeUser {
 	return SafeUser{
-		ID:                u.ID,
-		Username:          u.Username,
+		ID: u.ID,
+		// Masked for everyone, the owner included — see the Username and
+		// UsernameHidden field comments for why there is no raw-value twin.
+		Username:          pii.PublicUsername(u.Username),
+		UsernameHidden:    pii.LooksLikeContact(u.Username),
 		Email:             u.Email,
 		Role:              u.Role,
 		IsPublic:          u.IsPublic,

--- a/go-api/internal/comments/community.go
+++ b/go-api/internal/comments/community.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 	"github.com/lawrenceli0228/animego/go-api/internal/jwtx"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 const (
@@ -97,7 +98,7 @@ func (h *Handlers) ListCommentSummaries(w http.ResponseWriter, r *http.Request) 
 		items[i].Latest = append(items[i].Latest, commentSummaryPreview{
 			ID:               row.ID,
 			UserID:           row.UserID,
-			Username:         row.Username,
+			Username:         pii.PublicUsername(row.Username),
 			AvatarURL:        row.AvatarUrl,
 			BackdropCoverURL: row.BackdropCoverUrl,
 			Content:          row.Content,
@@ -167,7 +168,7 @@ func (h *Handlers) ListTrendingDiscussions(w http.ResponseWriter, r *http.Reques
 			ReactionCount:    row.ReactionCount,
 			Latest: trendingDiscussionLatest{
 				ID:        row.LatestCommentID,
-				Username:  row.LatestUsername,
+				Username:  pii.PublicUsername(row.LatestUsername),
 				AvatarURL: row.LatestAvatarUrl,
 				Content:   row.LatestContent,
 				IsSpoiler: row.LatestIsSpoiler,

--- a/go-api/internal/comments/handlers.go
+++ b/go-api/internal/comments/handlers.go
@@ -28,11 +28,13 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 	"github.com/lawrenceli0228/animego/go-api/internal/jwtx"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 // queryTimeout bounds every DB round-trip in this package.  Matches the
@@ -145,17 +147,64 @@ func (h *Handlers) ListComments(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ListEpisodeComments returns []EpisodeComment which already has
-	// the right camelCase JSON tags (id, anilistId, episode, userId,
-	// username, content, parentId, replyToUsername, createdAt, updatedAt).
-	// sqlc init's empty slice as `[]EpisodeComment{}` already, but we
-	// defensively ensure a non-nil slice so the envelope emits `"data":[]`
-	// not `"data":null` on the unlikely off-chance ListEpisodeComments
-	// returns nil.
-	if rows == nil {
-		rows = []dbgen.ListEpisodeCommentsRow{}
+	// The sqlc row already carries the right camelCase JSON tags, so this
+	// used to serialize `rows` directly.  It no longer can: `username` and
+	// `replyToUsername` are user-chosen and some users registered with an
+	// email address or a phone number, and this endpoint answers anonymous
+	// callers.  Mapping through publicComment is what keeps a contact
+	// detail out of the response — see internal/pii.
+	//
+	// The mapper also guarantees a non-nil slice so the envelope emits
+	// `"data":[]` rather than `"data":null`.
+	httpx.Data(w, http.StatusOK, toPublicComments(rows))
+}
+
+// publicComment mirrors dbgen.ListEpisodeCommentsRow field-for-field.  It
+// exists only so the two username fields can pass through pii.PublicUsername
+// on their way out; every other field is copied verbatim, and the JSON tags
+// are identical so the wire shape is unchanged.
+type publicComment struct {
+	ID               uuid.UUID          `json:"id"`
+	AnilistID        int32              `json:"anilistId"`
+	Episode          int32              `json:"episode"`
+	UserID           uuid.UUID          `json:"userId"`
+	Username         string             `json:"username"`
+	Content          string             `json:"content"`
+	IsSpoiler        bool               `json:"isSpoiler"`
+	ParentID         *uuid.UUID         `json:"parentId"`
+	ReplyToUsername  *string            `json:"replyToUsername"`
+	CreatedAt        pgtype.Timestamptz `json:"createdAt"`
+	UpdatedAt        pgtype.Timestamptz `json:"updatedAt"`
+	AvatarUrl        *string            `json:"avatarUrl"`
+	BackdropCoverUrl *string            `json:"backdropCoverUrl"`
+	ReactionCount    int64              `json:"reactionCount"`
+	ViewerReacted    bool               `json:"viewerReacted"`
+}
+
+// toPublicComments masks both username fields on every row.  Returns an
+// empty (non-nil) slice for nil input.
+func toPublicComments(rows []dbgen.ListEpisodeCommentsRow) []publicComment {
+	out := make([]publicComment, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, publicComment{
+			ID:               row.ID,
+			AnilistID:        row.AnilistID,
+			Episode:          row.Episode,
+			UserID:           row.UserID,
+			Username:         pii.PublicUsername(row.Username),
+			Content:          row.Content,
+			IsSpoiler:        row.IsSpoiler,
+			ParentID:         row.ParentID,
+			ReplyToUsername:  pii.PublicUsernamePtr(row.ReplyToUsername),
+			CreatedAt:        row.CreatedAt,
+			UpdatedAt:        row.UpdatedAt,
+			AvatarUrl:        row.AvatarUrl,
+			BackdropCoverUrl: row.BackdropCoverUrl,
+			ReactionCount:    row.ReactionCount,
+			ViewerReacted:    row.ViewerReacted,
+		})
 	}
-	httpx.Data(w, http.StatusOK, rows)
+	return out
 }
 
 // AddComment implements POST /api/comments/:anilistId/:episode.

--- a/go-api/internal/danmaku/handlers.go
+++ b/go-api/internal/danmaku/handlers.go
@@ -37,6 +37,7 @@ import (
 
 	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 // queryTimeout bounds every DB round-trip in this package.  Matches
@@ -212,7 +213,7 @@ func mapDanmakuRows(rows []dbgen.ListDanmakuRecentRow) []danmakuItem {
 		row := rows[i]
 		out = append(out, danmakuItem{
 			ID:        row.ID,
-			Username:  row.Username,
+			Username:  pii.PublicUsername(row.Username),
 			Content:   row.Content,
 			CreatedAt: row.CreatedAt.Time,
 		})

--- a/go-api/internal/db/gen/querier.go
+++ b/go-api/internal/db/gen/querier.go
@@ -428,6 +428,24 @@ type Querier interface {
 	// Uniqueness check during register (we also rely on the unique index,
 	// but a pre-check gives a friendlier 400 vs a 500-looking pg error).
 	GetUserByUsername(ctx context.Context, username string) (User, error)
+	// Companion lookup for users whose username is masked on public surfaces.
+	//
+	// internal/pii replaces a contact-shaped username with 'user-' || the first
+	// ten hex characters of its MD5, so that is the only handle those users have
+	// in a public response — and therefore the only thing a /u/ link can carry.
+	// Without this query their profile would 404 for everyone, including the
+	// people already following them.
+	//
+	// md5() is a core Postgres function (no pgcrypto), and internal/pii hashes
+	// the raw username bytes with no case folding precisely so this expression
+	// matches it.  internal/pii's TestSlug_MatchesPostgresMd5Contract pins the
+	// Go half of that contract.
+	//
+	// This cannot use the users_username_key index — it is a sequential scan
+	// over a table in the low thousands.  That is why it is a separate query
+	// rather than an OR branch on the one above: the common path stays indexed,
+	// and only a slug lookup pays the scan.
+	GetUserIDByPublicSlug(ctx context.Context, username string) (GetUserIDByPublicSlugRow, error)
 	// Queries for the social surface (P2.4) — follows + public profile + feed.
 	//
 	// Backs five endpoints:

--- a/go-api/internal/db/gen/social.sql.go
+++ b/go-api/internal/db/gen/social.sql.go
@@ -117,6 +117,53 @@ func (q *Queries) GetProfileCounts(ctx context.Context, userID uuid.UUID) (GetPr
 	return i, err
 }
 
+const getUserIDByPublicSlug = `-- name: GetUserIDByPublicSlug :one
+SELECT id, username, created_at, avatar_url, backdrop_anilist_id, is_public
+FROM users
+WHERE 'user-' || left(md5(username), 10) = $1
+LIMIT 1
+`
+
+type GetUserIDByPublicSlugRow struct {
+	ID                uuid.UUID          `json:"id"`
+	Username          string             `json:"username"`
+	CreatedAt         pgtype.Timestamptz `json:"createdAt"`
+	AvatarUrl         *string            `json:"avatarUrl"`
+	BackdropAnilistID *int32             `json:"backdropAnilistId"`
+	IsPublic          bool               `json:"isPublic"`
+}
+
+// Companion lookup for users whose username is masked on public surfaces.
+//
+// internal/pii replaces a contact-shaped username with 'user-' || the first
+// ten hex characters of its MD5, so that is the only handle those users have
+// in a public response — and therefore the only thing a /u/ link can carry.
+// Without this query their profile would 404 for everyone, including the
+// people already following them.
+//
+// md5() is a core Postgres function (no pgcrypto), and internal/pii hashes
+// the raw username bytes with no case folding precisely so this expression
+// matches it.  internal/pii's TestSlug_MatchesPostgresMd5Contract pins the
+// Go half of that contract.
+//
+// This cannot use the users_username_key index — it is a sequential scan
+// over a table in the low thousands.  That is why it is a separate query
+// rather than an OR branch on the one above: the common path stays indexed,
+// and only a slug lookup pays the scan.
+func (q *Queries) GetUserIDByPublicSlug(ctx context.Context, username string) (GetUserIDByPublicSlugRow, error) {
+	row := q.db.QueryRow(ctx, getUserIDByPublicSlug, username)
+	var i GetUserIDByPublicSlugRow
+	err := row.Scan(
+		&i.ID,
+		&i.Username,
+		&i.CreatedAt,
+		&i.AvatarUrl,
+		&i.BackdropAnilistID,
+		&i.IsPublic,
+	)
+	return i, err
+}
+
 const getUserIDByUsername = `-- name: GetUserIDByUsername :one
 
 SELECT id, username, created_at, avatar_url, backdrop_anilist_id, is_public

--- a/go-api/internal/db/queries/social.sql
+++ b/go-api/internal/db/queries/social.sql
@@ -20,6 +20,29 @@ SELECT id, username, created_at, avatar_url, backdrop_anilist_id, is_public
 FROM users
 WHERE username = $1;
 
+-- name: GetUserIDByPublicSlug :one
+-- Companion lookup for users whose username is masked on public surfaces.
+--
+-- internal/pii replaces a contact-shaped username with 'user-' || the first
+-- ten hex characters of its MD5, so that is the only handle those users have
+-- in a public response — and therefore the only thing a /u/ link can carry.
+-- Without this query their profile would 404 for everyone, including the
+-- people already following them.
+--
+-- md5() is a core Postgres function (no pgcrypto), and internal/pii hashes
+-- the raw username bytes with no case folding precisely so this expression
+-- matches it.  internal/pii's TestSlug_MatchesPostgresMd5Contract pins the
+-- Go half of that contract.
+--
+-- This cannot use the users_username_key index — it is a sequential scan
+-- over a table in the low thousands.  That is why it is a separate query
+-- rather than an OR branch on the one above: the common path stays indexed,
+-- and only a slug lookup pays the scan.
+SELECT id, username, created_at, avatar_url, backdrop_anilist_id, is_public
+FROM users
+WHERE 'user-' || left(md5(username), 10) = $1
+LIMIT 1;
+
 -- ==================== Follow CRUD ====================
 
 -- name: UpsertFollow :exec

--- a/go-api/internal/notifications/handlers.go
+++ b/go-api/internal/notifications/handlers.go
@@ -17,6 +17,7 @@ import (
 	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 	"github.com/lawrenceli0228/animego/go-api/internal/jwtx"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 const (
@@ -142,7 +143,7 @@ func (h *Handlers) List(w http.ResponseWriter, r *http.Request) {
 		item := itemResponse{
 			ID:        row.ID,
 			Type:      notificationType(row.NotificationType),
-			Actor:     actorResponse{Username: row.ActorUsername, AvatarURL: row.ActorAvatarUrl},
+			Actor:     actorResponse{Username: pii.PublicUsername(row.ActorUsername), AvatarURL: row.ActorAvatarUrl},
 			Episode:   row.Episode,
 			CommentID: row.CommentID,
 			Excerpt:   row.CommentContent,

--- a/go-api/internal/pii/username.go
+++ b/go-api/internal/pii/username.go
@@ -1,0 +1,115 @@
+// Package pii masks personally identifying information that users have put
+// into fields that were never meant to hold it.
+//
+// The concrete problem this exists for: `users.username` is constrained only
+// by length (0001_init.up.sql — CHECK char_length BETWEEN 3 AND 50), so
+// nothing stopped people from registering with an email address or a phone
+// number.  Some did.  That username is then the public display name AND the
+// /u/{username} routing key, so it reaches:
+//
+//   - GET /api/anime/{id}/watchers          (no auth at all)
+//   - GET /api/community/discussions/trending
+//   - GET /api/comments/{anilistId}/{episode}
+//   - GET /api/comments/summary/{anilistId}
+//   - GET /api/users/{username} (+ /followers, /following)
+//
+// and, worst of all, gets server-rendered into /anime/{id} — a route that is
+// ISR-prerendered, Cloudflare edge-cached and indexed by Google.  A contact
+// detail baked into a CDN-cached search result is the failure this package
+// prevents.
+//
+// The masking is deliberately narrow: a username that does NOT look like a
+// contact detail passes through byte-for-byte.  Only contact-shaped ones are
+// replaced, and they are replaced with a *stable, opaque* slug rather than a
+// partial redaction — "xi***@qq.com" still discloses the provider and enough
+// of the local part to be worth guessing at.
+//
+// The slug is derived with MD5 rather than SHA-256 on purpose: Postgres ships
+// md5() as a core function, so the reverse lookup (slug → user row) can be
+// computed in SQL without the pgcrypto extension.  This is not a security
+// hash — it is an opaque, collision-resistant-enough label, and the input it
+// protects is already known to anyone who can enumerate the user list by
+// other means.  Do not reuse it for anything that needs preimage resistance.
+package pii
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+// SlugPrefix marks a username that this package generated.  Real usernames
+// can technically start with it too, which is why resolution never assumes a
+// prefixed value is a slug — it looks the row up and falls back.
+const SlugPrefix = "user-"
+
+// slugHexLen is how much of the MD5 hex we keep.  40 bits over a user table
+// in the low thousands leaves collision odds negligible, and the lookup
+// treats a multi-row match as "not found" rather than guessing.
+const slugHexLen = 10
+
+// minDigitRun is the shortest all-digit username treated as a contact
+// detail.  QQ numbers run 5-11 digits and mainland mobile numbers are 11, so
+// the line sits just under the QQ range: short numeric handles like "2024"
+// stay untouched while account identifiers do not.
+//
+// The asymmetry is deliberate.  Masking a legitimate numeric handle costs
+// that user a display name until they rename; failing to mask a QQ number
+// publishes a contact address into a CDN-cached, indexed page.
+const minDigitRun = 7
+
+// allDigits matches a username made entirely of ASCII digits.
+var allDigits = regexp.MustCompile(`^[0-9]+$`)
+
+// LooksLikeContact reports whether username is shaped like a way to contact
+// the person behind it.
+//
+// The email test is intentionally cruder than RFC 5322: any '@' at all is
+// treated as an address.  A username has no legitimate reason to contain one,
+// and a false positive costs a display name while a false negative costs an
+// email address.
+func LooksLikeContact(username string) bool {
+	u := strings.TrimSpace(username)
+	if u == "" {
+		return false
+	}
+	if strings.ContainsRune(u, '@') {
+		return true
+	}
+	return allDigits.MatchString(u) && len(u) >= minDigitRun
+}
+
+// Slug returns the opaque public label for username.
+//
+// It hashes the raw bytes with no case folding, so the value matches
+// Postgres `left(md5(username), 10)` exactly.  Lowercasing first would have
+// meant relying on Go's Unicode casing and the database collation agreeing,
+// which they need not.
+func Slug(username string) string {
+	sum := md5.Sum([]byte(username))
+	return SlugPrefix + hex.EncodeToString(sum[:])[:slugHexLen]
+}
+
+// PublicUsername returns the value safe to serialize to an unauthenticated
+// caller: username unchanged, or its slug when it is contact-shaped.
+//
+// Call this at the serialization boundary of every public response.  Do NOT
+// call it for the caller's own account (/api/auth/me, /api/account) or for
+// admin views — those need the real value to be usable.
+func PublicUsername(username string) string {
+	if LooksLikeContact(username) {
+		return Slug(username)
+	}
+	return username
+}
+
+// PublicUsernamePtr is PublicUsername for the optional-username fields
+// (reply_to_username, report target, and friends).  nil passes through.
+func PublicUsernamePtr(username *string) *string {
+	if username == nil {
+		return nil
+	}
+	masked := PublicUsername(*username)
+	return &masked
+}

--- a/go-api/internal/pii/username_test.go
+++ b/go-api/internal/pii/username_test.go
@@ -1,0 +1,160 @@
+package pii
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// The shapes below are the ones actually observed in production on
+// 2026-08-16 (values altered, shapes kept): a QQ address used as a
+// username, a bare mobile number, and a bare QQ number.
+func TestLooksLikeContact_MasksWhatWasFoundInProduction(t *testing.T) {
+	contactShaped := []string{
+		"2548537435@qq.com", // QQ address — the reported case
+		"xieyu_5656@qq.com", // same shape, different local part
+		"someone@gmail.com",
+		"17566285293",  // mainland mobile, 11 digits
+		"154961455462", // bare QQ number, 12 digits
+		"1234567",      // shortest run we treat as an account id
+	}
+	for _, u := range contactShaped {
+		if !LooksLikeContact(u) {
+			t.Errorf("LooksLikeContact(%q) = false, want true — this would leak", u)
+		}
+	}
+}
+
+func TestLooksLikeContact_LeavesRealUsernamesAlone(t *testing.T) {
+	// Every one of these must pass through byte-for-byte.  A false
+	// positive here silently renames a real user.
+	safe := []string{
+		"lawrence",
+		"无始冬", // CJK handle, from the same production sample
+		"xin",
+		"user_2024",
+		"2024",     // short numeric handle, under minDigitRun
+		"123456",   // 6 digits — still under the line
+		"a1b2c3d4", // mixed, not all digits
+		"kirito-kun",
+		"日暮里の猫",
+	}
+	for _, u := range safe {
+		if LooksLikeContact(u) {
+			t.Errorf("LooksLikeContact(%q) = true, want false — this would rename a real user", u)
+		}
+	}
+}
+
+func TestLooksLikeContact_EmptyAndBlank(t *testing.T) {
+	for _, u := range []string{"", "   ", "\t"} {
+		if LooksLikeContact(u) {
+			t.Errorf("LooksLikeContact(%q) = true, want false", u)
+		}
+	}
+}
+
+func TestLooksLikeContact_AnyAtSignCounts(t *testing.T) {
+	// Deliberately cruder than RFC 5322 — a username has no legitimate
+	// reason to carry an '@', and a false negative costs an address.
+	for _, u := range []string{"@handle", "no-tld@localhost", "a@b", "two@@ats"} {
+		if !LooksLikeContact(u) {
+			t.Errorf("LooksLikeContact(%q) = false, want true", u)
+		}
+	}
+}
+
+func TestLooksLikeContact_IgnoresSurroundingWhitespace(t *testing.T) {
+	if !LooksLikeContact("  2548537435@qq.com  ") {
+		t.Error("padded address should still be detected")
+	}
+}
+
+func TestPublicUsername_MasksContactLeavesRest(t *testing.T) {
+	const addr = "2548537435@qq.com"
+	got := PublicUsername(addr)
+
+	if strings.Contains(got, "@") {
+		t.Fatalf("PublicUsername(%q) = %q — still contains an '@'", addr, got)
+	}
+	if strings.Contains(got, "2548537435") {
+		t.Fatalf("PublicUsername(%q) = %q — still contains the local part", addr, got)
+	}
+	if !strings.HasPrefix(got, SlugPrefix) {
+		t.Fatalf("PublicUsername(%q) = %q — want the %q prefix", addr, got, SlugPrefix)
+	}
+
+	if got := PublicUsername("lawrence"); got != "lawrence" {
+		t.Fatalf("PublicUsername(%q) = %q, want it unchanged", "lawrence", got)
+	}
+}
+
+// A partial redaction like "xi***@qq.com" would still disclose the provider
+// and enough of the local part to guess at.  Pin the stronger contract.
+func TestPublicUsername_DisclosesNothingAboutTheAddress(t *testing.T) {
+	for _, addr := range []string{"2548537435@qq.com", "xieyu_5656@qq.com", "someone@gmail.com"} {
+		got := PublicUsername(addr)
+		for _, leak := range []string{"qq", "gmail", ".com", "@", "xieyu", "someone"} {
+			if strings.Contains(got, leak) {
+				t.Errorf("PublicUsername(%q) = %q leaks %q", addr, got, leak)
+			}
+		}
+	}
+}
+
+func TestSlug_IsStable(t *testing.T) {
+	const addr = "2548537435@qq.com"
+	if Slug(addr) != Slug(addr) {
+		t.Fatal("Slug is not deterministic")
+	}
+	if Slug(addr) == Slug("other@qq.com") {
+		t.Fatal("different usernames collided")
+	}
+}
+
+// The reverse lookup runs in SQL as left(md5(username), 10).  If Go and
+// Postgres ever disagree on the digest input, /u/{slug} silently 404s for
+// exactly the users this package is protecting.  This pins the Go half to
+// the raw bytes, with no case folding, so the SQL half can match it.
+func TestSlug_MatchesPostgresMd5Contract(t *testing.T) {
+	const addr = "2548537435@qq.com"
+
+	sum := md5.Sum([]byte(addr)) // raw bytes, no ToLower
+	want := SlugPrefix + hex.EncodeToString(sum[:])[:slugHexLen]
+
+	if got := Slug(addr); got != want {
+		t.Fatalf("Slug(%q) = %q, want %q — the SQL lookup will not match", addr, got, want)
+	}
+	if len(want) != len(SlugPrefix)+slugHexLen {
+		t.Fatalf("slug length drifted: %d", len(want))
+	}
+}
+
+// Case folding would have made the Go side depend on Postgres collation
+// agreeing with Go's Unicode casing.  Assert we did not do it.
+func TestSlug_IsCaseSensitive(t *testing.T) {
+	if Slug("A@b.com") == Slug("a@b.com") {
+		t.Fatal("Slug folded case — it must hash raw bytes so SQL md5(username) matches")
+	}
+}
+
+func TestPublicUsernamePtr(t *testing.T) {
+	if got := PublicUsernamePtr(nil); got != nil {
+		t.Fatalf("PublicUsernamePtr(nil) = %v, want nil", got)
+	}
+
+	addr := "2548537435@qq.com"
+	got := PublicUsernamePtr(&addr)
+	if got == nil || strings.Contains(*got, "@") {
+		t.Fatalf("PublicUsernamePtr(%q) = %v — not masked", addr, got)
+	}
+	if addr != "2548537435@qq.com" {
+		t.Fatalf("PublicUsernamePtr mutated its input: %q", addr)
+	}
+
+	plain := "lawrence"
+	if got := PublicUsernamePtr(&plain); got == nil || *got != "lawrence" {
+		t.Fatalf("PublicUsernamePtr(%q) changed a safe username", plain)
+	}
+}

--- a/go-api/internal/social/fake_db_test.go
+++ b/go-api/internal/social/fake_db_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
@@ -37,6 +38,7 @@ import (
 
 type fakeDB struct {
 	getUserIDByUsernameFn      func(ctx context.Context, username string) (dbgen.GetUserIDByUsernameRow, error)
+	getUserIDByPublicSlugFn    func(ctx context.Context, slug string) (dbgen.GetUserIDByPublicSlugRow, error)
 	getProfileCountsFn         func(ctx context.Context, userID uuid.UUID) (dbgen.GetProfileCountsRow, error)
 	listProfileWatchingFn      func(ctx context.Context, userID uuid.UUID) ([]dbgen.ListProfileWatchingRow, error)
 	followExistsFn             func(ctx context.Context, follower, followee uuid.UUID) (bool, error)
@@ -58,6 +60,17 @@ func (f *fakeDB) GetUserIDByUsername(ctx context.Context, username string) (dbge
 		panic("fakeDB.GetUserIDByUsername not set")
 	}
 	return f.getUserIDByUsernameFn(ctx, username)
+}
+
+// GetUserIDByPublicSlug defaults to "no such slug" rather than panicking:
+// almost every social test resolves a plain username and never reaches the
+// slug fallback, and a panic default would have forced all of them to stub a
+// method they do not exercise.
+func (f *fakeDB) GetUserIDByPublicSlug(ctx context.Context, slug string) (dbgen.GetUserIDByPublicSlugRow, error) {
+	if f.getUserIDByPublicSlugFn == nil {
+		return dbgen.GetUserIDByPublicSlugRow{}, pgx.ErrNoRows
+	}
+	return f.getUserIDByPublicSlugFn(ctx, slug)
 }
 
 func (f *fakeDB) GetProfileCounts(ctx context.Context, userID uuid.UUID) (dbgen.GetProfileCountsRow, error) {

--- a/go-api/internal/social/feed.go
+++ b/go-api/internal/social/feed.go
@@ -33,6 +33,7 @@ import (
 	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 	"github.com/lawrenceli0228/animego/go-api/internal/jwtx"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 // GetFeed implements GET /api/feed?page=1 — chronological feed of
@@ -131,7 +132,7 @@ func mapFeedRows(rows []dbgen.ListFeedActivitiesRow) []feedItem {
 		out[i] = feedItem{
 			ID:             row.ActivityID,
 			Kind:           row.EventType,
-			Username:       row.Username,
+			Username:       pii.PublicUsername(row.Username),
 			AvatarURL:      row.AvatarUrl,
 			AnilistID:      row.AnilistID,
 			Title:          title,
@@ -144,7 +145,7 @@ func mapFeedRows(rows []dbgen.ListFeedActivitiesRow) []feedItem {
 			CommentID:      row.CommentID,
 			Content:        row.CommentContent,
 			Excerpt:        row.CommentContent,
-			TargetUsername: row.TargetUsername,
+			TargetUsername: pii.PublicUsernamePtr(row.TargetUsername),
 			IsSpoiler:      row.CommentIsSpoiler,
 		}
 	}

--- a/go-api/internal/social/follow.go
+++ b/go-api/internal/social/follow.go
@@ -51,7 +51,7 @@ func (h *Handlers) Follow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	username := chi.URLParam(r, "username")
-	followee, err := h.Queries.GetUserIDByUsername(ctx, username)
+	followee, err := h.resolveUserHandle(ctx, username)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			httpx.Fail(w, httpx.NewError(http.StatusNotFound, httpx.CodeNotFound, msgUserNotFound))
@@ -109,7 +109,7 @@ func (h *Handlers) Unfollow(w http.ResponseWriter, r *http.Request) {
 	}
 
 	username := chi.URLParam(r, "username")
-	followee, err := h.Queries.GetUserIDByUsername(ctx, username)
+	followee, err := h.resolveUserHandle(ctx, username)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			httpx.Fail(w, httpx.NewError(http.StatusNotFound, httpx.CodeNotFound, msgUserNotFound))

--- a/go-api/internal/social/followers.go
+++ b/go-api/internal/social/followers.go
@@ -23,6 +23,7 @@ import (
 
 	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 // ListFollowers implements GET /api/users/:username/followers?page=1.
@@ -32,7 +33,7 @@ func (h *Handlers) ListFollowers(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	username := chi.URLParam(r, "username")
-	user, err := h.Queries.GetUserIDByUsername(ctx, username)
+	user, err := h.resolveUserHandle(ctx, username)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			httpx.Fail(w, httpx.NewError(http.StatusNotFound, httpx.CodeNotFound, msgUserNotFound))
@@ -73,7 +74,7 @@ func (h *Handlers) ListFollowers(w http.ResponseWriter, r *http.Request) {
 
 	items := make([]followListItem, len(rows))
 	for i, row := range rows {
-		items[i] = followListItem{Username: row.Username, AvatarURL: row.AvatarUrl, BackdropCoverURL: row.BackdropCoverUrl}
+		items[i] = followListItem{Username: pii.PublicUsername(row.Username), AvatarURL: row.AvatarUrl, BackdropCoverURL: row.BackdropCoverUrl}
 	}
 	writeFollowListEnvelope(w, items, total, page)
 }
@@ -86,7 +87,7 @@ func (h *Handlers) ListFollowing(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	username := chi.URLParam(r, "username")
-	user, err := h.Queries.GetUserIDByUsername(ctx, username)
+	user, err := h.resolveUserHandle(ctx, username)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			httpx.Fail(w, httpx.NewError(http.StatusNotFound, httpx.CodeNotFound, msgUserNotFound))
@@ -127,7 +128,7 @@ func (h *Handlers) ListFollowing(w http.ResponseWriter, r *http.Request) {
 
 	items := make([]followListItem, len(rows))
 	for i, row := range rows {
-		items[i] = followListItem{Username: row.Username, AvatarURL: row.AvatarUrl, BackdropCoverURL: row.BackdropCoverUrl}
+		items[i] = followListItem{Username: pii.PublicUsername(row.Username), AvatarURL: row.AvatarUrl, BackdropCoverURL: row.BackdropCoverUrl}
 	}
 	writeFollowListEnvelope(w, items, total, page)
 }

--- a/go-api/internal/social/handlers.go
+++ b/go-api/internal/social/handlers.go
@@ -8,14 +8,18 @@ package social
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 // queryTimeout bounds every DB round-trip in this package.  Matches
@@ -50,6 +54,12 @@ const (
 // path param, plus the per-endpoint reads / writes below.
 type SocialDB interface {
 	GetUserIDByUsername(ctx context.Context, username string) (dbgen.GetUserIDByUsernameRow, error)
+
+	// GetUserIDByPublicSlug resolves the masked handle that internal/pii
+	// hands out for contact-shaped usernames.  Required, not optional: a
+	// type assertion that failed would have silently 404'd exactly the
+	// users the masking protects, with no error and no failing test.
+	GetUserIDByPublicSlug(ctx context.Context, slug string) (dbgen.GetUserIDByPublicSlugRow, error)
 
 	// Profile
 	GetProfileCounts(ctx context.Context, userID uuid.UUID) (dbgen.GetProfileCountsRow, error)
@@ -139,3 +149,33 @@ func parsePage(r *http.Request) int {
 // intPtr returns &n.  Convenience for assigning hasMore-derived
 // NextPage values into the response envelope.
 func intPtr(n int) *int { return &n }
+
+// resolveUserHandle turns a /u/{handle} path param into a user row.
+//
+// The handle is normally the username itself.  For users whose username is
+// contact-shaped, internal/pii replaces it with an opaque slug on every
+// public response — so the slug is the only handle a link can carry, and it
+// has to resolve here or those profiles 404 for everyone, including their
+// existing followers.
+//
+// Order matters: the exact-username lookup runs first and uses the unique
+// index.  The slug lookup is a sequential scan, so it only runs when the
+// handle actually has the slug prefix AND the indexed lookup missed.  A real
+// username that happens to start with "user-" therefore still wins.
+func (h *Handlers) resolveUserHandle(ctx context.Context, handle string) (dbgen.GetUserIDByUsernameRow, error) {
+	user, err := h.Queries.GetUserIDByUsername(ctx, handle)
+	if err == nil {
+		return user, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) || !strings.HasPrefix(handle, pii.SlugPrefix) {
+		return user, err
+	}
+
+	row, slugErr := h.Queries.GetUserIDByPublicSlug(ctx, handle)
+	if slugErr != nil {
+		// Report the original miss, so the caller's ErrNoRows → 404
+		// mapping stays intact whichever lookup came up empty.
+		return user, err
+	}
+	return dbgen.GetUserIDByUsernameRow(row), nil
+}

--- a/go-api/internal/social/profile.go
+++ b/go-api/internal/social/profile.go
@@ -36,6 +36,7 @@ import (
 	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 	"github.com/lawrenceli0228/animego/go-api/internal/jwtx"
+	"github.com/lawrenceli0228/animego/go-api/internal/pii"
 )
 
 // GetProfile implements GET /api/users/:username — public profile +
@@ -50,7 +51,7 @@ func (h *Handlers) GetProfile(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	username := chi.URLParam(r, "username")
-	user, err := h.Queries.GetUserIDByUsername(ctx, username)
+	user, err := h.resolveUserHandle(ctx, username)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			httpx.Fail(w, httpx.NewError(http.StatusNotFound, httpx.CodeNotFound, msgUserNotFound))
@@ -149,7 +150,7 @@ func (h *Handlers) GetProfile(w http.ResponseWriter, r *http.Request) {
 
 	httpx.Data(w, http.StatusOK, profileResponse{
 		ID:                user.ID.String(),
-		Username:          user.Username,
+		Username:          pii.PublicUsername(user.Username),
 		CreatedAt:         user.CreatedAt,
 		AvatarURL:         user.AvatarUrl,
 		BackdropAnilistID: user.BackdropAnilistID,

--- a/next-app/src/app/settings/_components/SettingsClient.tsx
+++ b/next-app/src/app/settings/_components/SettingsClient.tsx
@@ -20,6 +20,14 @@ import "./settings.css";
 
 interface SettingsClientProps {
   username: string;
+  /**
+   * True when `username` above is a masked handle rather than a name its
+   * owner chose — see go-api/internal/pii. Supplied by the API rather than
+   * re-derived here on purpose: a second copy of the detection rule would
+   * eventually disagree with the Go one, and the failure mode is telling
+   * someone their name is fine while the server hides it.
+   */
+  usernameHidden: boolean;
   userId: string | null;
   createdAt: string | null;
   avatarUrl: string | null;
@@ -61,6 +69,7 @@ async function patchMe(
 
 export default function SettingsClient({
   username,
+  usernameHidden,
   userId,
   createdAt,
   avatarUrl,
@@ -77,6 +86,13 @@ export default function SettingsClient({
   const since = sinceLabel(createdAt);
 
   const [name, setName] = useState(username);
+
+  // The server decides whether the name is hidden; we never re-derive it.
+  // Gated on the field still holding the handle, so the warning clears the
+  // moment they type a replacement rather than lingering until the save
+  // round-trips.
+  const usernameIsHidden = usernameHidden && name.trim() === username;
+
   const [nameStatus, setNameStatus] = useState<Status>({ kind: "idle" });
   const [photoUrl, setPhotoUrl] = useState<string | null>(avatarUrl);
   const [passStatus, setPassStatus] = useState<Status>({ kind: "idle" });
@@ -342,8 +358,26 @@ export default function SettingsClient({
                 value={name}
                 maxLength={50}
                 onChange={(e) => setName(e.target.value)}
+                aria-describedby={usernameIsHidden ? "set-username-hidden" : undefined}
               />
             </div>
+            {usernameIsHidden && (
+              // Each run of copy is a single string expression rather than JSX
+              // text. JSX turns a newline + indent into a space, which is
+              // correct for English and wrong for Chinese — that is what put
+              // stray gaps mid-sentence here before.
+              <div id="set-username-hidden" className="set-warn" role="status">
+                <p className="set-warn-title">
+                  {zh ? "用户名已隐藏" : "Username hidden"}
+                </p>
+                <p className="set-warn-body">
+                  {zh
+                    ? "你注册时填的名字看起来是邮箱或手机号，所以没有公开显示。现在你和别人看到的都是："
+                    : "The name you registered with looks like an email address or a phone number, so it is not shown. You and everyone else now see:"}
+                </p>
+                <code className="set-warn-code">{username}</code>
+              </div>
+            )}
             <div className="set-actions">
               <button
                 type="button"

--- a/next-app/src/app/settings/_components/settings.css
+++ b/next-app/src/app/settings/_components/settings.css
@@ -302,6 +302,56 @@
   color: #ff453a;
 }
 
+/* Shown under the username field when the server is masking the name because
+   it looks like an email address or a phone number. Amber rather than red:
+   nothing is broken and no action is forced — the account works either way,
+   the name is just not on display. */
+.set-warn {
+  margin: 10px 0 0;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 214, 10, 0.26);
+  border-left-width: 3px;
+  border-radius: 8px;
+  background: rgba(255, 214, 10, 0.06);
+}
+.set-warn-title {
+  margin: 0;
+  color: #ffd60a;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+.set-warn-body {
+  /* CJK has no inter-word spaces to absorb slack, so it needs more leading
+     than the latin copy elsewhere on this page to stay readable. */
+  margin: 6px 0 0;
+  color: rgba(235, 235, 245, 0.78);
+  font-size: 12.5px;
+  line-height: 1.8;
+}
+/* The handle is opaque, unbreakable and the thing the reader is looking for.
+   Own line, not inline: mid-sentence it forced an awkward wrap and buried
+   the one string that matters. */
+.set-warn-code {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  margin: 8px 0 0;
+  padding: 5px 10px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.07);
+  color: #fff;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12.5px;
+  overflow-wrap: anywhere;
+}
+/* The 4px on .set-actions is right when the button follows a bare input.
+   Behind a bordered callout it reads as if the button belongs to the box,
+   so give it room here only — scoped rather than raising the global value. */
+.set-warn + .set-actions {
+  margin-top: 16px;
+}
+
 /* photo row */
 .set-photo {
   display: flex;

--- a/next-app/src/app/settings/page.tsx
+++ b/next-app/src/app/settings/page.tsx
@@ -17,6 +17,8 @@ interface MeResp {
   user?: {
     id?: string | null;
     username: string;
+    /** True when `username` is a masked handle rather than a chosen name. */
+    usernameHidden?: boolean;
     createdAt?: string | null;
     avatarUrl?: string | null;
     backdropAnilistId?: number | null;
@@ -98,6 +100,7 @@ export default async function SettingsPage() {
     <main>
       <SettingsClient
         username={me.username}
+        usernameHidden={me.usernameHidden ?? false}
         userId={me.id ?? null}
         createdAt={me.createdAt ?? null}
         avatarUrl={me.avatarUrl ?? null}

--- a/next-app/src/app/u/[username]/_components/FollowListRow.tsx
+++ b/next-app/src/app/u/[username]/_components/FollowListRow.tsx
@@ -5,6 +5,7 @@ import type { FollowListItem } from "./types";
 import FollowButton from "./FollowButton";
 import type { Lang } from "@/lib/i18n";
 import { DEFAULT_CARD_IMAGE } from "@/lib/cardDefaults";
+import { isMaskedUsername } from "@/lib/publicUsername";
 import FallbackImg from "@/components/ui/FallbackImg";
 
 interface FollowListRowProps {
@@ -75,7 +76,18 @@ export default function FollowListRow({
             style={{ width: "100%", height: "100%", objectFit: "cover" }}
           />
         </div>
-        <span style={{ fontSize: 14, fontWeight: 600, color: "#ffffff" }}>
+        <span
+          style={{ fontSize: 14, fontWeight: 600, color: "#ffffff" }}
+          // Contact-shaped usernames come back masked; explain the opaque
+          // handle on hover instead of letting it read as a broken name.
+          title={
+            isMaskedUsername(user.username)
+              ? lang === "zh"
+                ? "这位用户还没有设置公开显示名"
+                : "This user hasn't set a public display name yet"
+              : undefined
+          }
+        >
           {user.username}
         </span>
       </Link>

--- a/next-app/src/components/anime/WatchersAvatarList.tsx
+++ b/next-app/src/components/anime/WatchersAvatarList.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { ApiError, apiGetEnvelope } from "@/lib/api";
 import { getDict, getLang } from "@/lib/i18n";
 import { DEFAULT_CARD_IMAGE } from "@/lib/cardDefaults";
+import { isMaskedUsername } from "@/lib/publicUsername";
 import FallbackImg from "@/components/ui/FallbackImg";
 import type { WatcherItem, WatchersResponse } from "@/lib/types";
 
@@ -106,6 +107,10 @@ export default async function WatchersAvatarList({
   const animeDict = dict.anime as unknown as Record<string, string>;
   const watchersLabel = animeDict.watchers ?? "watching";
   const moreLabel = animeDict.watchersMore ?? "+";
+  // Users whose username looked like a contact detail come back from the API
+  // as an opaque handle. Explain the placeholder on hover rather than letting
+  // it read as a broken name — see lib/publicUsername.ts.
+  const maskedLabel = animeDict.maskedUser ?? "This user hasn't set a public display name yet";
 
   return (
     <div style={rowStyle}>
@@ -113,12 +118,16 @@ export default async function WatchersAvatarList({
         {watchers.map((w, i) => {
           const overlap = i < watchers.length - 1 ? { marginRight: -8 } : {};
           const stack = { zIndex: watchers.length - i };
+          const masked = isMaskedUsername(w.username);
+          // The handle still identifies the row and still routes, so it stays
+          // the visible label; the hover text is what explains it.
+          const hoverText = masked ? `${w.username} — ${maskedLabel}` : w.username;
           return (
             <Link
               key={w.username}
-              href={`/u/${w.username}`}
-              title={w.username}
-              aria-label={w.username}
+              href={`/u/${encodeURIComponent(w.username)}`}
+              title={hoverText}
+              aria-label={hoverText}
               prefetch={false}
               style={{
                 ...avatarStyle,

--- a/next-app/src/components/community/HotDiscussions.tsx
+++ b/next-app/src/components/community/HotDiscussions.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import FadeImage from "@/components/ui/FadeImage";
 import { pickTitle } from "@/lib/formatters";
 import { useLang } from "@/lib/lang-client";
+import { isMaskedUsername } from "@/lib/publicUsername";
 import type { HotDiscussion } from "@/lib/types";
 import {
   communityDiscussionTarget,
@@ -128,7 +129,16 @@ export default function HotDiscussions({ items }: { items: HotDiscussion[] }) {
                       : styles.preview
                   }
                 >
-                  <b>@{item.latest.username}</b> {preview}
+                  <b
+                    title={
+                      isMaskedUsername(item.latest.username)
+                        ? t("communityDiscovery.maskedUser")
+                        : undefined
+                    }
+                  >
+                    @{item.latest.username}
+                  </b>{" "}
+                  {preview}
                 </span>
               </span>
 

--- a/next-app/src/lib/publicUsername.test.ts
+++ b/next-app/src/lib/publicUsername.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { isMaskedUsername, MASKED_USERNAME_PREFIX } from "./publicUsername";
+
+// The values below are real output from go-api/internal/pii for the shapes
+// found in production on 2026-08-16, so this file also pins the cross-language
+// contract: if the Go side ever changes the prefix or the hex width, these
+// stop matching and the tooltip silently disappears.
+describe("isMaskedUsername", () => {
+  test("recognises the handles go-api actually emits", () => {
+    // Slug("2548537435@qq.com") and Slug("17566285293") respectively.
+    expect(isMaskedUsername("user-8c73f3856f")).toBe(true);
+    expect(isMaskedUsername("user-c3b19c6642")).toBe(true);
+  });
+
+  test("leaves real usernames alone", () => {
+    for (const name of ["lawrence", "无始冬", "xin", "user_2024", "2024", "kirito-kun"]) {
+      expect(isMaskedUsername(name)).toBe(false);
+    }
+  });
+
+  test("does not fire on a lookalike that is not the exact shape", () => {
+    // Ten hex is the contract. Anything else is someone's real name.
+    expect(isMaskedUsername("user-")).toBe(false);
+    expect(isMaskedUsername("user-8c73f385")).toBe(false); // 8 chars
+    expect(isMaskedUsername("user-8c73f3856f0")).toBe(false); // 11 chars
+    expect(isMaskedUsername("user-8C73F3856F")).toBe(false); // uppercase
+    expect(isMaskedUsername("user-8c73f3856g")).toBe(false); // 'g' is not hex
+    expect(isMaskedUsername("xuser-8c73f3856f")).toBe(false); // not anchored
+    expect(isMaskedUsername("user-8c73f3856f ")).toBe(false); // trailing space
+  });
+
+  test("never claims a contact detail is masked", () => {
+    // If one of these ever returned true it would mean the mask failed
+    // upstream and we were about to reassure the viewer about a live
+    // address on screen.
+    expect(isMaskedUsername("2548537435@qq.com")).toBe(false);
+    expect(isMaskedUsername("17566285293")).toBe(false);
+  });
+
+  test("handles null and undefined", () => {
+    expect(isMaskedUsername(null)).toBe(false);
+    expect(isMaskedUsername(undefined)).toBe(false);
+    expect(isMaskedUsername("")).toBe(false);
+  });
+
+  test("the exported prefix matches what the matcher accepts", () => {
+    expect(isMaskedUsername(`${MASKED_USERNAME_PREFIX}8c73f3856f`)).toBe(true);
+  });
+});

--- a/next-app/src/lib/publicUsername.ts
+++ b/next-app/src/lib/publicUsername.ts
@@ -1,0 +1,38 @@
+// Recognising the masked handle the API hands out for users whose username
+// is contact-shaped.
+//
+// go-api/internal/pii replaces a username that looks like an email address or
+// a phone number with `user-` + the first ten hex characters of its MD5,
+// because the username is a public display name AND the /u/{username} routing
+// key, and it reaches anonymous endpoints — including the watcher list that
+// gets server-rendered into the Cloudflare-cached /anime/{id} page.
+//
+// The frontend cannot tell a masked handle from a real username by asking the
+// API (the field is the same `username` string either way), so it matches the
+// shape.  The shape is a real contract, not a guess: the same `user-` prefix
+// is what `GetUserIDByPublicSlug` reverses in SQL, so it cannot drift without
+// breaking profile links first.
+//
+// A real username could in principle be exactly `user-` followed by ten
+// lowercase hex digits.  The only consequence is a tooltip shown to someone
+// who did not need it, so the pattern is deliberately strict rather than
+// defensive.
+
+/** The prefix go-api/internal/pii puts on a masked handle. */
+export const MASKED_USERNAME_PREFIX = "user-";
+
+/** `user-` plus exactly ten lowercase hex characters, anchored. */
+const MASKED_USERNAME_RE = /^user-[0-9a-f]{10}$/;
+
+/**
+ * True when `username` is a masked handle rather than a name its owner chose.
+ *
+ * Use it to decide whether to explain the placeholder to the viewer — never
+ * to decide whether to link to the profile. Masked handles resolve: the
+ * profile lookup falls back to a slug query precisely so these users stay
+ * reachable.
+ */
+export function isMaskedUsername(username: string | null | undefined): boolean {
+  if (!username) return false;
+  return MASKED_USERNAME_RE.test(username);
+}

--- a/next-app/src/locales/en-spa.js
+++ b/next-app/src/locales/en-spa.js
@@ -172,6 +172,7 @@ const en = {
     action_dropped: 'dropped',
   },
   communityDiscovery: {
+    maskedUser: "This user hasn't set a public display name yet",
     welcomePinned: 'PINNED',
     welcomeEyebrow: 'COMMUNITY NOTICE',
     welcomeTitle: 'Welcome to the AnimeGoClub community',

--- a/next-app/src/locales/en.ts
+++ b/next-app/src/locales/en.ts
@@ -49,6 +49,9 @@ const en = {
   // Anime watchers
   anime: {
     watchers: 'watching', watchersMore: '+',
+    // Shown when the API returned a masked handle instead of a chosen
+    // name — see lib/publicUsername.ts and go-api/internal/pii.
+    maskedUser: "This user hasn't set a public display name yet",
     loadError: 'Failed to load', noAnime: 'No anime found',
   },
   // The quick-subscribe + overlaid on poster cards across the home,

--- a/next-app/src/locales/zh-spa.js
+++ b/next-app/src/locales/zh-spa.js
@@ -227,6 +227,7 @@ const zh = {
     action_dropped: '弃坑了',
   },
   communityDiscovery: {
+    maskedUser: '这位用户还没有设置公开显示名',
     welcomePinned: '置顶',
     welcomeEyebrow: '社区公告',
     welcomeTitle: '欢迎来到 AnimeGoClub 社区',

--- a/next-app/src/locales/zh.ts
+++ b/next-app/src/locales/zh.ts
@@ -101,6 +101,9 @@ const zh = {
   // Anime watchers
   anime: {
     watchers: '人在追', watchersMore: '还有',
+    // Shown when the API returned a masked handle instead of a chosen
+    // name — see lib/publicUsername.ts and go-api/internal/pii.
+    maskedUser: '这位用户还没有设置公开显示名',
     loadError: '加载失败', noAnime: '暂无番剧',
   },
   // The quick-subscribe + overlaid on poster cards across the home,


### PR DESCRIPTION
Nothing constrained the *shape* of `users.username` — only its length
(`0001_init.up.sql`, CHECK 3..50). Some people registered with a contact
detail, and since the username is both the public display name and the
`/u/{username}` routing key, it went out through anonymous endpoints and got
server-rendered into `/anime/{id}` — a route that is ISR-prerendered,
Cloudflare edge-cached and indexed.

The email exists to recover an account. It was never meant to be a display
name.

## The two commits

**`9a8b858`** stops it. New `internal/pii`: a contact-shaped username is
replaced with `user-` + ten hex characters of its MD5 at the serialization
boundary of every public response. Everything else passes through
byte-for-byte, so nobody who picked a real name sees any change.

**`11b2be1`** tells the affected people. `SafeUser.Username` is masked for
everyone including the owner, plus a `usernameHidden` boolean so the settings
page can explain the handle.

## Worth a careful look

**The MD5 choice.** Postgres ships `md5()` as a core function, so
`GetUserIDByPublicSlug` can reverse the handle in SQL without pgcrypto. The
Go side hashes raw bytes with no case folding so the two agree —
`TestSlug_MatchesPostgresMd5Contract` pins it, and the value was also
cross-checked against an independent MD5 implementation. This is not a
security hash and the doc comment says so.

**Where masking is *not* applied.** `/api/auth/me`, `PATCH /api/auth/me` and
the admin views keep the real value; they need it to be usable. Everything
else goes through `pii.PublicUsername`.

**Keeping masked profiles reachable.** Masking the handle would have 404'd
the profiles of exactly the users being protected, including for people
already following them. `resolveUserHandle` tries the indexed username lookup
first and only falls back to the slug query when the handle carries the
prefix *and* the first lookup missed, so the common path stays on the unique
index and a real username beginning `user-` still wins.

**The detection line.** Any `@` counts, and so does any all-digit name of 7+
characters (QQ numbers run 5-11, mainland mobiles are 11). A false positive
costs someone a display name until they rename; a false negative publishes a
contact address. The asymmetry is deliberate and the tests state it.

**Both write paths are closed.** Registration *and* `PATCH /api/auth/me` —
without the second one, the settings page is a back door.

## Tests

```
go-api     30 packages green (go test ./... -count=1)
next-app   911 pass / 0 fail (was 905)
tsc        31 errors — exactly the base-branch baseline, zero new
eslint     clean on every touched file
next build exit 0, /anime/[id] still ● prerendered
```

`TestWatchers_MasksContactShapedUsernames` was mutation-verified: dropping the
`pii` call and its now-unused import fails with `watchers response leaked …`,
so the test is not vacuous.

Verified against a live local stack, not just unit tests: a user whose stored
username is an address gets the opaque handle plus the settings callout; a
user with an ordinary name sees neither; registration rejects an address with
the new message.

## Deploying — the fix is not live until the caches are purged

`/anime/{id}` is served with `stale-while-revalidate=31535940`. Merging and
deploying is **not** sufficient: the already-cached HTML keeps serving the old
values. Purge Cloudflare and let ISR regenerate for `/anime/*` and `/u/*`,
then confirm all three come back empty:

```bash
curl -s "https://animegoclub.com/api/anime/199409/watchers" | grep -o '@[a-z.]*'
curl -s "https://animegoclub.com/anime/199409" | grep -c '@qq\.com'
curl -s "https://animegoclub.com/api/community/discussions/trending?windowHours=8760" | grep -o '@qq\.com'
```

## Not in this change

Stored usernames are untouched — this masks on the way out rather than
rewriting the table, so nothing is destroyed and the change is revertible.
Affected users can rename themselves via the settings page; a bulk migration
is not needed and is not proposed.
