### PR TITLE
fix(privacy): redirect /u/ routes that carry a contact-shaped handle

### DIFF
--- a/next-app/src/app/u/[username]/_lib/canonicalHandle.ts
+++ b/next-app/src/app/u/[username]/_lib/canonicalHandle.ts
@@ -1,0 +1,41 @@
+// Resolving a /u/ path param to the handle that is allowed to be shown.
+//
+// The API answers to both a stored username and the masked handle that
+// go-api/internal/pii substitutes for contact-shaped ones, but only the
+// handle may appear on screen or in a URL. Every /u/ route renders its path
+// param — into the title, the canonical, the back-link, the pagination hrefs
+// — so a request carrying the raw form would put it all back on the page.
+// That is the one surface the serialization masking cannot reach, because
+// these routes render the param rather than a response field.
+//
+// The check asks the API rather than re-deriving "is this contact-shaped?"
+// in TypeScript. A second copy of that rule would drift from the Go one, and
+// the failure mode is rendering an address while believing it is fine.
+
+import { apiGet, ApiError } from "@/lib/api";
+
+interface ProfileHandle {
+  username: string;
+}
+
+/**
+ * The handle this profile should be addressed by.
+ *
+ * Returns `null` when there is no such user — callers map that to
+ * `notFound()`, matching what the list endpoints already do on 404.
+ */
+export async function canonicalHandle(handle: string): Promise<string | null> {
+  try {
+    const data = await apiGet<ProfileHandle>(
+      `/api/users/${encodeURIComponent(handle)}`,
+      { cache: "no-store" },
+    );
+    return data?.username ?? null;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return null;
+    // Any other failure (500, network) must not decide the URL. Returning
+    // the input leaves the page to render as before rather than bouncing
+    // the visitor somewhere on the strength of a failed request.
+    return handle;
+  }
+}

--- a/next-app/src/app/u/[username]/followers/page.tsx
+++ b/next-app/src/app/u/[username]/followers/page.tsx
@@ -13,11 +13,12 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import type { CSSProperties } from "react";
 import { apiGet, apiGetPaged, ApiError } from "@/lib/api";
 import { getDict, getLang } from "@/lib/i18n";
 import { decodeUsername } from "@/lib/username";
+import { canonicalHandle } from "../_lib/canonicalHandle";
 import FollowListRow from "../_components/FollowListRow";
 import type { FollowListItem } from "../_components/types";
 
@@ -114,6 +115,16 @@ const emptyStyle: CSSProperties = {
 export default async function FollowersPage({ params, searchParams }: PageProps) {
   const { username: usernameSlug } = await params;
   const username = decodeUsername(usernameSlug);
+  // Redirect before rendering: every href on this page is built from the
+  // param, so a raw contact-shaped handle would end up in the canonical,
+  // the back-link and the pagination URLs. Permanent — that form of the
+  // URL should leave the index. See _lib/canonicalHandle.
+  const handle = await canonicalHandle(username);
+  if (handle === null) notFound();
+  if (handle !== username) {
+    permanentRedirect(`/u/${encodeURIComponent(handle)}/followers`);
+  }
+
   const sp = await searchParams;
   const page = Math.max(1, Number(sp.page) || 1);
 

--- a/next-app/src/app/u/[username]/following/page.tsx
+++ b/next-app/src/app/u/[username]/following/page.tsx
@@ -7,11 +7,12 @@
 
 import type { Metadata } from "next";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import type { CSSProperties } from "react";
 import { apiGet, apiGetPaged, ApiError } from "@/lib/api";
 import { getDict, getLang } from "@/lib/i18n";
 import { decodeUsername } from "@/lib/username";
+import { canonicalHandle } from "../_lib/canonicalHandle";
 import FollowListRow from "../_components/FollowListRow";
 import type { FollowListItem } from "../_components/types";
 
@@ -108,6 +109,16 @@ const emptyStyle: CSSProperties = {
 export default async function FollowingPage({ params, searchParams }: PageProps) {
   const { username: usernameSlug } = await params;
   const username = decodeUsername(usernameSlug);
+  // Redirect before rendering: every href on this page is built from the
+  // param, so a raw contact-shaped handle would end up in the canonical,
+  // the back-link and the pagination URLs. Permanent — that form of the
+  // URL should leave the index. See _lib/canonicalHandle.
+  const handle = await canonicalHandle(username);
+  if (handle === null) notFound();
+  if (handle !== username) {
+    permanentRedirect(`/u/${encodeURIComponent(handle)}/following`);
+  }
+
   const sp = await searchParams;
   const page = Math.max(1, Number(sp.page) || 1);
 

--- a/next-app/src/app/u/[username]/page.tsx
+++ b/next-app/src/app/u/[username]/page.tsx
@@ -14,7 +14,7 @@
 // primary content — the page is fully rendered on first paint.
 
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { apiGet, ApiError } from "@/lib/api";
 import { getDict, getLang } from "@/lib/i18n";
 import { decodeUsername } from "@/lib/username";
@@ -108,6 +108,19 @@ export default async function UserProfilePage({ params }: PageProps) {
   ]);
 
   if (!profile) notFound();
+
+  // The API answers to both the stored username and the masked handle, but
+  // only the handle may appear on screen or in a URL. When a contact-shaped
+  // username is what reached us, this route was rendering it into the title,
+  // the canonical and the body — the one surface the serialization masking in
+  // go-api/internal/pii could not reach, because it renders the path param
+  // rather than the response.
+  //
+  // Permanent, not temporary: the address form of this URL should leave the
+  // index rather than be kept alive as an alternate.
+  if (profile.username !== username) {
+    permanentRedirect(`/u/${encodeURIComponent(profile.username)}`);
+  }
 
   const isSelf = me?.username === username;
   const isLoggedIn = me !== null;


### PR DESCRIPTION
Follow-up to #86, which is already deployed.

That PR masked usernames at the serialization boundary of every public
response. It missed the one surface that boundary cannot reach: the `/u/`
routes render their **path param**, not a response field.

Confirmed on production after the deploy — the API was clean while
`/u/{address}` still returned 200 with the address in the `<title>`, in the
self-referencing canonical, and twelve times in the body.

## The change

All three `/u/` routes resolve the param through the API and permanently
redirect when it is not the handle the profile should be addressed by. 308
rather than 307: that form of the URL should leave the index, not survive as
an alternate.

`_lib/canonicalHandle.ts` does the lookup for the two list routes, which had
no reason to fetch the profile otherwise. It asks the API rather than
re-deriving "is this contact-shaped?" in TypeScript — a second copy of that
rule would drift from the Go one, and the failure mode is rendering an
address while believing it is fine. A non-404 failure returns the input
unchanged, so a flaky request never bounces a visitor somewhere.

## No redirect loop — checked, not assumed

```
GET /api/users/user-8c73f3856f     → username: user-8c73f3856f   (equal → no redirect)
GET /api/users/2548537435@qq.com   → username: user-8c73f3856f   (differs → redirect once)
```

The API answers to both forms and always returns the masked one, so the
redirect target is a fixed point.

## Tests

```
next-app   911 pass / 0 fail
tsc        31 errors — the base-branch baseline, zero new
eslint     clean on every touched file
next build exit 0, /anime/[id] still prerendered
```

## After merging

Needs a deploy to take effect. No cache purge required this time — the `/u/`
routes are `force-dynamic`, so there is nothing cached to invalidate.