### PR TITLE
fix(privacy): keep contact-shaped handles out of /u/ metadata

### DIFF
--- a/next-app/src/app/u/[username]/_lib/canonicalHandle.ts
+++ b/next-app/src/app/u/[username]/_lib/canonicalHandle.ts
@@ -19,23 +19,43 @@ interface ProfileHandle {
 }
 
 /**
- * The handle this profile should be addressed by.
+ * The handle this profile should be addressed by, or `null` when it could not
+ * be established — no such user, or the lookup failed.
  *
- * Returns `null` when there is no such user — callers map that to
- * `notFound()`, matching what the list endpoints already do on 404.
+ * The two failure modes collapse into one return value on purpose. Echoing
+ * the input back on an error would be the safe default for a redirect
+ * decision but the wrong one for a title: a flaky request would put the
+ * address straight back into the head, which is the leak this exists to
+ * close. Callers pick their own behaviour for `null`, and both choices are
+ * safe:
+ *
+ *   - metadata falls back to a neutral title, naming nobody
+ *   - the list routes simply do not redirect, and their own fetch still
+ *     404s if the user genuinely does not exist
  */
 export async function canonicalHandle(handle: string): Promise<string | null> {
   try {
     const data = await apiGet<ProfileHandle>(
-      `/api/users/${encodeURIComponent(handle)}`,
+      `/api/users/${encodePathSegment(handle)}`,
       { cache: "no-store" },
     );
     return data?.username ?? null;
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) return null;
-    // Any other failure (500, network) must not decide the URL. Returning
-    // the input leaves the page to render as before rather than bouncing
-    // the visitor somewhere on the strength of a failed request.
-    return handle;
+    return null;
   }
+}
+
+/**
+ * `encodeURIComponent` for a path segment, minus the over-encoding of `@`.
+ *
+ * RFC 3986 allows `@` unescaped in a path segment, but encodeURIComponent
+ * percent-encodes it anyway, and the Go router matches the literal — so
+ * `/api/users/x%40y.com` 404s while `/api/users/x@y.com` resolves. Without
+ * this, the exact handles that need resolving (the contact-shaped ones) are
+ * the only ones that never resolve, and the caller silently falls back to
+ * "unknown user".
+ */
+export function encodePathSegment(segment: string): string {
+  return encodeURIComponent(segment).replace(/%40/g, "@");
 }

--- a/next-app/src/app/u/[username]/followers/page.tsx
+++ b/next-app/src/app/u/[username]/followers/page.tsx
@@ -120,8 +120,10 @@ export default async function FollowersPage({ params, searchParams }: PageProps)
   // the back-link and the pagination URLs. Permanent — that form of the
   // URL should leave the index. See _lib/canonicalHandle.
   const handle = await canonicalHandle(username);
-  if (handle === null) notFound();
-  if (handle !== username) {
+  // null = could not establish it (unknown user, or the lookup failed). Do
+  // not redirect on a guess — the list fetch below still 404s when the user
+  // genuinely does not exist.
+  if (handle !== null && handle !== username) {
     permanentRedirect(`/u/${encodeURIComponent(handle)}/followers`);
   }
 

--- a/next-app/src/app/u/[username]/following/page.tsx
+++ b/next-app/src/app/u/[username]/following/page.tsx
@@ -114,8 +114,10 @@ export default async function FollowingPage({ params, searchParams }: PageProps)
   // the back-link and the pagination URLs. Permanent — that form of the
   // URL should leave the index. See _lib/canonicalHandle.
   const handle = await canonicalHandle(username);
-  if (handle === null) notFound();
-  if (handle !== username) {
+  // null = could not establish it (unknown user, or the lookup failed). Do
+  // not redirect on a guess — the list fetch below still 404s when the user
+  // genuinely does not exist.
+  if (handle !== null && handle !== username) {
     permanentRedirect(`/u/${encodeURIComponent(handle)}/following`);
   }
 

--- a/next-app/src/app/u/[username]/page.tsx
+++ b/next-app/src/app/u/[username]/page.tsx
@@ -18,6 +18,7 @@ import { notFound, permanentRedirect } from "next/navigation";
 import { apiGet, ApiError } from "@/lib/api";
 import { getDict, getLang } from "@/lib/i18n";
 import { decodeUsername } from "@/lib/username";
+import { canonicalHandle, encodePathSegment } from "./_lib/canonicalHandle";
 import FollowButton from "./_components/FollowButton";
 import WatchingSection from "./_components/WatchingSection";
 import ShareButtonIsland from "./_components/ShareButtonIsland";
@@ -50,7 +51,10 @@ async function fetchMe(): Promise<{ username: string } | null> {
 
 async function fetchProfile(username: string): Promise<UserProfileData | null> {
   try {
-    return await apiGet<UserProfileData>(`/api/users/${encodeURIComponent(username)}`, {
+    // encodePathSegment, not encodeURIComponent: the latter over-encodes '@'
+    // and the Go router matches the literal, so a contact-shaped handle would
+    // 404 here and the redirect below would never be reached.
+    return await apiGet<UserProfileData>(`/api/users/${encodePathSegment(username)}`, {
       cache: "no-store",
     });
   } catch (err) {
@@ -63,12 +67,46 @@ async function fetchProfile(username: string): Promise<UserProfileData | null> {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { username: usernameSlug } = await params;
-  const username = decodeUsername(usernameSlug);
-  const [lang, dict] = await Promise.all([getLang(), getDict()]);
-  // dict.profile.titleSuffix = "'s Watchlist" / "的追番"
+  const requested = decodeUsername(usernameSlug);
+
+  // This function — not the page body — is where a contact-shaped handle was
+  // reaching the response. It never consulted the API, so the raw param went
+  // straight into the title, the description, the canonical, and the og /
+  // twitter tags. The page component could not prevent it: metadata is built
+  // independently, and for these handles the profile fetch 404s anyway, so
+  // the body was already the not-found state while the head still carried the
+  // address.
+  //
+  // Resolve first. Unknown handles fall back to a neutral title rather than
+  // echoing whatever string was in the URL — that echo is the whole leak.
+  const [lang, dict, resolved] = await Promise.all([
+    getLang(),
+    getDict(),
+    canonicalHandle(requested),
+  ]);
+  const username = resolved ?? "";
   const suffix = dict.profile.titleSuffix;
-  const title = `${username} ${suffix}`;
-  const canonical = `/u/${encodeURIComponent(username)}`;
+  const title = username ? `${username} ${suffix}` : "AnimeGoClub";
+  const canonical = username ? `/u/${encodeURIComponent(username)}` : undefined;
+
+  if (!username) {
+    // No such user. Say nothing identifying, and do not offer a canonical
+    // for a URL that resolves to a not-found page.
+    return { title: { absolute: "AnimeGoClub" }, robots: { index: false, follow: false } };
+  }
+
+  // The visitor asked for this profile by a handle that is not the one it
+  // should be addressed by — in practice, the stored contact-shaped username
+  // rather than the masked handle. The page component redirects, but that
+  // redirect cannot set a status code: the root loading.tsx puts every route
+  // behind a Suspense boundary, so the shell has already flushed by the time
+  // the component runs and Next falls back to a client-side navigation.
+  //
+  // So the status stays 200 for a crawler, and without this the URL would be
+  // indexable — with clean content, but with the address in the URL itself.
+  // noindex keeps it out, and the canonical below still points at the handle
+  // form so any existing index entry consolidates there.
+  const addressedByAlias = username !== requested;
 
   return {
     title: { absolute: `${title} · AnimeGoClub` },
@@ -76,6 +114,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       lang === "zh"
         ? `${username} 的追番列表和社交主页 — AnimeGoClub`
         : `${username}'s watchlist and social profile on AnimeGoClub`,
+    ...(addressedByAlias ? { robots: { index: false, follow: false } } : {}),
     alternates: {
       canonical,
       languages: {


### PR DESCRIPTION
Follow-up to #87, which is deployed and did not close the hole.

I verified against production after that deploy: `/u/{address}` still served
the address. The guard #87 added was in the page component, and that is not
where the leak was.

## Two things were wrong

**The leak was in `generateMetadata`.** Metadata is built independently of the
page component and never consulted the API, so the raw path param went into
the title, the description, the canonical and the og / twitter tags. The body
was already the not-found state — every occurrence I had counted was a meta
tag, which is why a guard in the body could never have helped.

**The API 404s on an over-encoded handle.** `encodeURIComponent` escapes `@`,
which RFC 3986 allows unescaped in a path segment, and the Go router matches
the literal — `/api/users/x%40y.com` misses while `/api/users/x@y.com`
resolves. So contact-shaped handles were the only ones that could never
resolve, which is exactly backwards.

## What now happens

`generateMetadata` resolves the handle before using it. An unknown handle gets
a neutral title naming nobody rather than echoing the URL — that echo was the
whole leak. When the requested handle differs from the canonical one, the
response is `noindex, nofollow` with the canonical pointing at the handle
form, so any existing index entry consolidates there.

That noindex is load-bearing, not decoration. The redirect cannot set a
status code: the root `loading.tsx` puts every route behind a Suspense
boundary, so the shell has flushed by the time the page component runs and
Next falls back to a client-side navigation. Browsers land on the handle URL;
crawlers get 200. Without the noindex the address-bearing URL would have
become **indexable** — strictly worse than before, when it 404'd.

Fixing the status code properly means addressing the root `loading.tsx`
streaming behaviour, which is the same root cause as the soft-404 in #85.
Out of scope here.

## Measured

Same URL, script payloads stripped so only what a reader or crawler sees is
counted:

| | occurrences of the address |
|---|---|
| production today | 6 |
| this branch | 0 |

The single remaining occurrence anywhere in the response is inside the RSC
flight payload, which serializes the route segments. That is the URL the
requester typed, not a disclosure to anyone else.

```
/u/{address}          noindex, nofollow   canonical → /u/{handle}
/u/{handle}           index, follow       canonical → itself
/u/{ordinary name}    index, follow       canonical → itself   (unchanged)
```

## Tests

```
next-app   911 pass / 0 fail
tsc        31 errors — the base-branch baseline, zero new
eslint     clean on every touched file
next build exit 0, /anime/[id] still prerendered
```

Verified against the production API rather than a mock, by pointing a local
dev server at it.