### PR TITLE
fix: silence injected third-party errors in Sentry, and stop a failed handle write from looking successful

### DIFF
--- a/next-app/instrumentation-client.ts
+++ b/next-app/instrumentation-client.ts
@@ -11,17 +11,52 @@
 // Env: NEXT_PUBLIC_SENTRY_DSN (must be public-prefixed so it's bundled
 // into the client). DSN-missing = SDK no-ops internally; no manual guard.
 import * as Sentry from "@sentry/nextjs";
+import { DENIED_URL_PATTERNS, IGNORED_ERROR_PATTERNS } from "@/lib/sentryFilters";
+
+// One attempt per page load. See beforeSend.
+let replayRequested = false;
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.1,
   debug: false,
+
+  // Errors are reported at 100% — `tracesSampleRate` above governs tracing
+  // only. Worth stating because the `client_sample_rate: 0.1` that appears in
+  // every event's trace context reads like an error sample rate and is not
+  // one; multiplying issue counts by ten gives a number ten times too big.
+
+  // Injected third-party scripts, mostly from in-app WebViews. Rationale for
+  // each pattern lives in lib/sentryFilters.ts, next to the tests that pin
+  // them to the exact strings Sentry reported.
+  //
+  // These matter beyond quota. EventFilters runs as an event processor, which
+  // @sentry/core resolves BEFORE beforeSend (client.js `_processEvent`), so a
+  // filtered error never reaches the Replay block below and never triggers its
+  // download. Before this, an extension's syntax error on someone's phone
+  // pulled half a megabyte of Replay SDK onto that phone — 88 times.
+  ignoreErrors: IGNORED_ERROR_PATTERNS,
+  denyUrls: DENIED_URL_PATTERNS,
+
   // Replay intentionally omitted from init. The full replay SDK (~500 kB
   // gzipped) is loaded lazily on first error so it does not bloat the
   // landing-page bundle. replaysSessionSampleRate stays 0 (no background
-  // recording); on-error capture is wired below via beforeSend.
+  // recording); on-error capture is wired below.
+  //
+  // ⚠️ Neither `replaysSessionSampleRate` nor `replaysOnErrorSampleRate` is
+  // set, and on-error capture needs the latter above 0. Until one is
+  // configured this download most likely records nothing. Left as-is rather
+  // than removed or enabled: turning it on starts uploading session
+  // recordings of real users, which is a privacy and quota decision, not a
+  // cleanup. Decide, then either set a rate or delete the block.
   beforeSend(event) {
-    if (event.level === "error" || event.level === "fatal") {
+    // Guarded, and deliberately not reset on failure. lazyLoadIntegration
+    // fetches from https://browser.sentry-cdn.com, and this site's users are
+    // overwhelmingly in mainland China, where that origin is not dependable.
+    // Retrying per error would mean a stream of failing script tags on
+    // exactly the sessions already going badly.
+    if (!replayRequested && (event.level === "error" || event.level === "fatal")) {
+      replayRequested = true;
       Sentry.lazyLoadIntegration("replayIntegration")
         .then((ReplayIntegration) => {
           Sentry.addIntegration(

--- a/next-app/src/app/library/_hooks/useFileHandles.js
+++ b/next-app/src/app/library/_hooks/useFileHandles.js
@@ -1,11 +1,25 @@
 "use client";
 // @ts-nocheck
 import { useState, useEffect, useCallback, useRef } from 'react';
+import * as Sentry from '@sentry/nextjs';
 import { isFsaSupported } from '@/lib/library/handles/fsaFeatureCheck.js';
 import { ensurePermission } from '@/lib/library/handles/permissionGate.js';
 import { makeFileHandleStore } from '@/lib/library/handles/fileHandleStore.js';
 import { probeRootStatus } from '@/lib/library/handles/probeRoot.js';
 import { pickLargestSameExt } from '@/lib/library/enumerator.js';
+
+/**
+ * The picker rejects with AbortError when the user dismisses it. Every browser
+ * that implements showDirectoryPicker uses that name, so this is a decision
+ * signal rather than a fault and must never reach Sentry — it would be by far
+ * the most common "error" the library surface produces.
+ *
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+function isAbortError(err) {
+  return Boolean(err) && typeof err === 'object' && err.name === 'AbortError';
+}
 
 /** @typedef {import('@/lib/library/types').HandleRecord} HandleRecord */
 /** @typedef {import('@/lib/library/handles/probeRoot.js').RootStatus} RootStatus */
@@ -110,7 +124,16 @@ export function useFileHandles({ db }) {
       const record = await store.saveRoot(handle, libraryId);
       await refresh();
       return record;
-    } catch {
+    } catch (err) {
+      // Dismissing the picker rejects with AbortError. That is a decision,
+      // not a fault, and reporting it would bury the real failures under it.
+      //
+      // Everything else gets reported. This was a bare `catch` returning
+      // null, which meant a browser that could not write to IndexedDB at all
+      // — a locked or read-only profile, a full disk — presented as a folder
+      // picker that simply did nothing when you chose a folder, with no trace
+      // in Sentry and nothing for the user to act on.
+      if (!isAbortError(err)) Sentry.captureException(err);
       return null;
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/next-app/src/lib/library/handles/fileHandleStore.js
+++ b/next-app/src/lib/library/handles/fileHandleStore.js
@@ -15,6 +15,24 @@ import { ulid } from '../ulid.js';
 const _handleCache = new Map();
 
 /**
+ * True when a rejected `put` failed because the value could not be cloned.
+ *
+ * Checks `inner` as well as the error itself: Dexie wraps the underlying
+ * DOMException, and which of the two carries the name depends on where the
+ * failure surfaced. Missing the wrapped form would send a genuine clone
+ * failure down the rethrow path and break the stub fallback the test doubles
+ * depend on.
+ *
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+export function isCloneError(err) {
+  if (!err || typeof err !== 'object') return false;
+  const e = /** @type {{ name?: unknown, inner?: { name?: unknown } }} */ (err);
+  return e.name === 'DataCloneError' || e.inner?.name === 'DataCloneError';
+}
+
+/**
  * Create a fileHandle store repo bound to the given Dexie instance.
  *
  * @param {import('dexie').Dexie} db
@@ -42,8 +60,24 @@ export function makeFileHandleStore(db) {
       const row = { ...base, handle };
       await db.fileHandles.put(row);
       return /** @type {HandleRecord} */ ({ ...row });
-    } catch {
-      // DataCloneError: store a serializable stub
+    } catch (err) {
+      // ONLY a clone failure earns the stub, and this used to be a bare
+      // `catch` that assumed every failure was one.
+      //
+      // The stub is a lossy fallback: the record that reaches IDB has no real
+      // handle in it, and the live one survives purely in the module-level
+      // _handleCache, which dies with the page. So when a `put` failed for any
+      // other reason — a locked or read-only browser profile raising
+      // NoModificationAllowedError, a full disk, a closing database — the old
+      // code would quietly write a stub instead. If that second write happened
+      // to succeed, the user's watch folder came back empty on their next
+      // visit with nothing logged anywhere, which is one of the shapes the
+      // "watch folder sometimes stops working" reports took.
+      //
+      // Anything that is not a clone failure is a real storage failure and has
+      // to reach the caller.
+      if (!isCloneError(err)) throw err;
+
       const row = { ...base, handle: { __stub: true, name: handle.name } };
       await db.fileHandles.put(row);
       return /** @type {HandleRecord} */ ({ ...row, handle });

--- a/next-app/src/lib/library/handles/fileHandleStore.test.js
+++ b/next-app/src/lib/library/handles/fileHandleStore.test.js
@@ -1,0 +1,185 @@
+import { describe, expect, test } from 'bun:test';
+import { isCloneError, makeFileHandleStore } from './fileHandleStore.js';
+
+// The invariant: a `put` that fails for a reason OTHER than "this value
+// cannot be cloned" must reach the caller, and must not leave a stub behind.
+//
+// The stub exists so test doubles — whose fake handles carry function
+// properties that structuredClone rejects — can still be persisted. It is a
+// lossy record: the live handle survives only in a module-level cache that
+// dies with the page. Writing one in response to a real storage failure
+// silently converts "your watch folder is saved" into "your watch folder is
+// saved until you close the tab", with nothing logged.
+
+/** Minimal Dexie-shaped double: only what makeFileHandleStore actually calls. */
+function makeDb({ failWith = null, failTimes = Infinity } = {}) {
+  const rows = [];
+  let putCalls = 0;
+
+  const table = {
+    async put(row) {
+      putCalls += 1;
+      if (failWith && putCalls <= failTimes) throw failWith;
+      const at = rows.findIndex((r) => r.id === row.id);
+      if (at === -1) rows.push(row);
+      else rows[at] = row;
+      return row.id;
+    },
+    where(field) {
+      return {
+        equals(value) {
+          return { async first() { return rows.find((r) => r[field] === value) ?? null; } };
+        },
+      };
+    },
+    async toArray() { return [...rows]; },
+    async delete(id) {
+      const at = rows.findIndex((r) => r.id === id);
+      if (at !== -1) rows.splice(at, 1);
+    },
+  };
+
+  return { db: { fileHandles: table }, rows, putCalls: () => putCalls };
+}
+
+/** A handle shaped like the real thing, minus anything structuredClone hates. */
+const cloneableHandle = { name: 'Anime', kind: 'directory' };
+
+/** What a test double's handle looks like: a function property kills the clone. */
+const uncloneableHandle = { name: 'Anime', kind: 'directory', queryPermission: () => 'granted' };
+
+function domException(name) {
+  const err = new Error(name);
+  err.name = name;
+  return err;
+}
+
+describe('isCloneError', () => {
+  test('recognises the error directly', () => {
+    expect(isCloneError(domException('DataCloneError'))).toBe(true);
+  });
+
+  test('recognises it wrapped by Dexie', () => {
+    // Dexie re-throws the underlying DOMException on `.inner`; which of the
+    // two carries the name depends on where the failure surfaced.
+    expect(isCloneError({ name: 'DexieError', inner: { name: 'DataCloneError' } })).toBe(true);
+  });
+
+  test('is not fooled by other storage failures', () => {
+    for (const name of [
+      'NoModificationAllowedError',
+      'QuotaExceededError',
+      'InvalidStateError',
+      'UnknownError',
+      'AbortError',
+    ]) {
+      expect(isCloneError(domException(name))).toBe(false);
+    }
+  });
+
+  test('handles non-objects', () => {
+    for (const value of [null, undefined, 'DataCloneError', 42]) {
+      expect(isCloneError(value)).toBe(false);
+    }
+  });
+});
+
+describe('saveRoot — the happy path is unchanged', () => {
+  test('stores the live handle', async () => {
+    const { db, rows } = makeDb();
+    const store = makeFileHandleStore(db);
+
+    const record = await store.saveRoot(cloneableHandle, 'lib-1');
+
+    expect(record.libraryId).toBe('lib-1');
+    expect(record.handle).toBe(cloneableHandle);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].handle).toBe(cloneableHandle);
+  });
+
+  test('is idempotent per library', async () => {
+    const { db, rows } = makeDb();
+    const store = makeFileHandleStore(db);
+
+    const first = await store.saveRoot(cloneableHandle, 'lib-1');
+    const second = await store.saveRoot(cloneableHandle, 'lib-1');
+
+    expect(second.id).toBe(first.id);
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('saveRoot — a clone failure still falls back to the stub', () => {
+  test('writes a stub and returns the live handle', async () => {
+    // Only the first put fails, mirroring the real sequence: the handle is
+    // rejected, the stub is accepted.
+    const { db, rows, putCalls } = makeDb({ failWith: domException('DataCloneError'), failTimes: 1 });
+    const store = makeFileHandleStore(db);
+
+    const record = await store.saveRoot(uncloneableHandle, 'lib-1');
+
+    expect(putCalls()).toBe(2);
+    expect(rows[0].handle).toEqual({ __stub: true, name: 'Anime' });
+    // The caller still gets the live object for this session.
+    expect(record.handle).toBe(uncloneableHandle);
+  });
+
+  test('a later read hydrates the live handle from the cache', async () => {
+    const { db } = makeDb({ failWith: domException('DataCloneError'), failTimes: 1 });
+    const store = makeFileHandleStore(db);
+
+    await store.saveRoot(uncloneableHandle, 'lib-2');
+    const found = await store.findByLibrary('lib-2');
+
+    expect(found.handle).toBe(uncloneableHandle);
+  });
+});
+
+describe('saveRoot — a real storage failure propagates', () => {
+  // This is the behaviour change. Each of these used to be swallowed and
+  // answered with a stub.
+  const STORAGE_FAILURES = [
+    'NoModificationAllowedError', // locked or read-only browser profile
+    'QuotaExceededError', // disk or origin quota
+    'InvalidStateError', // database closing
+    'UnknownError', // corrupt IDB
+  ];
+
+  for (const name of STORAGE_FAILURES) {
+    test(`${name} reaches the caller`, async () => {
+      const { db } = makeDb({ failWith: domException(name) });
+      const store = makeFileHandleStore(db);
+
+      await expect(store.saveRoot(cloneableHandle, 'lib-1')).rejects.toThrow(name);
+    });
+
+    test(`${name} does not leave a stub behind`, async () => {
+      // The damaging half. A stub written here looks like a saved watch
+      // folder and is gone on the next page load.
+      const { db, rows, putCalls } = makeDb({ failWith: domException(name) });
+      const store = makeFileHandleStore(db);
+
+      await store.saveRoot(cloneableHandle, 'lib-1').catch(() => {});
+
+      expect(putCalls()).toBe(1); // no retry
+      expect(rows).toHaveLength(0);
+    });
+  }
+
+  test('a transient failure is still not treated as a clone failure', async () => {
+    // The nastiest ordering: the first put fails for a real reason and the
+    // second would succeed. The old code persisted a stub here and returned
+    // as if all was well.
+    const { db, rows, putCalls } = makeDb({
+      failWith: domException('NoModificationAllowedError'),
+      failTimes: 1,
+    });
+    const store = makeFileHandleStore(db);
+
+    await expect(store.saveRoot(cloneableHandle, 'lib-1')).rejects.toThrow(
+      'NoModificationAllowedError',
+    );
+    expect(putCalls()).toBe(1);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/next-app/src/lib/sentryFilters.test.ts
+++ b/next-app/src/lib/sentryFilters.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import { eventFiltersIntegration } from "@sentry/core";
+import { DENIED_URL_PATTERNS, IGNORED_ERROR_PATTERNS, matchesIgnored } from "./sentryFilters";
+
+// The strings below are copied verbatim from animego-org/javascript-nextjs on
+// 2026-08-18. That is the whole point of the file: a filter list is only
+// trustworthy if it is pinned to the messages it was written against, and a
+// pattern that stops matching after an SDK or extension update fails
+// silently — the errors simply come back and nobody notices they left.
+//
+// The second half matters more than the first. Over-broad filtering is the
+// real hazard here, because it removes a class of error from Sentry without
+// removing it from production.
+
+const SEEN_NOISE = {
+  hasSelector:
+    "Failed to execute 'querySelectorAll' on 'Document': 'a[href*=\"http\"][target=\"_blank\"][rel=\"noopener\"]:has(img)' is not a valid selector.",
+  hasSelectorWithType:
+    "SyntaxError: Failed to execute 'querySelectorAll' on 'Document': 'a[href*=\"http\"][target=\"_blank\"][rel=\"noopener\"]:has(img)' is not a valid selector.",
+  lidNotify: "LIDNotifyId is not defined",
+  lidNotifyWithType: "ReferenceError: LIDNotifyId is not defined",
+  underscoreG: "Can't find variable: _G",
+  notGranted: "not granted",
+  notGrantedWithType: "TypeError: not granted",
+};
+
+describe("the noise we set out to silence", () => {
+  for (const [name, message] of Object.entries(SEEN_NOISE)) {
+    test(`drops ${name}`, () => {
+      expect(matchesIgnored(message)).toBe(true);
+    });
+  }
+});
+
+describe("errors that must still reach Sentry", () => {
+  // Sentry matches the bare `value` and `"Type: value"`, so both forms are
+  // checked wherever the distinction could matter.
+  const REAL = [
+    // The three issues currently attributed to this application. If a filter
+    // change ever swallows one of these, the suite says so.
+    "Cannot read properties of null (reading 'removeChild')",
+    "TypeError: Cannot read properties of null (reading 'removeChild')",
+    "NoModificationAllowedError: An attempt was made to write to a file or directory which could not be modified due to the state of the underlying filesystem.",
+    "Cannot read properties of undefined (reading 'call')",
+
+    // Deliberately NOT filtered even though one instance looked like injected
+    // script noise: a truncated or corrupted bundle produces exactly this, and
+    // that is something worth being woken up for.
+    "SyntaxError: Unexpected token '}'",
+
+    // Same family as the /search removeChild — external DOM mutation showing
+    // up inside React. Filtering it would hide a real React problem too.
+    "Cannot set properties of undefined (setting '__reactFiber$xwuabbpxdh')",
+
+    // Network and API failures.
+    "TypeError: Failed to fetch",
+    "TypeError: network error",
+    "NotFoundError: A requested file or directory could not be found at the time an operation was processed.",
+  ];
+
+  for (const message of REAL) {
+    test(`keeps: ${message.slice(0, 58)}`, () => {
+      expect(matchesIgnored(message)).toBe(false);
+    });
+  }
+});
+
+describe("the patterns are no broader than they look", () => {
+  test("'not granted' is anchored, not a substring", () => {
+    // A bare substring would swallow anything that happened to contain the
+    // phrase — including copy we might write ourselves.
+    expect(matchesIgnored("Permission was not granted for the watch folder")).toBe(false);
+    expect(matchesIgnored("not granted")).toBe(true);
+  });
+
+  test("the selector rule only covers invalid-selector errors", () => {
+    expect(matchesIgnored("Failed to execute 'querySelectorAll' on 'Document'")).toBe(false);
+    expect(matchesIgnored("track is not a valid selector")).toBe(true);
+  });
+
+  test("every pattern is a string or a RegExp", () => {
+    // Sentry silently ignores anything else, which would look like a working
+    // filter that does nothing.
+    for (const pattern of IGNORED_ERROR_PATTERNS) {
+      expect(typeof pattern === "string" || pattern instanceof RegExp).toBe(true);
+    }
+  });
+});
+
+describe("denyUrls", () => {
+  test("matches extension origins", () => {
+    const extensionUrls = [
+      "chrome-extension://abcdefghijklmnop/content.js",
+      "moz-extension://1234-5678/inject.js",
+      "safari-extension://com.example.ext/script.js",
+      "safari-web-extension://ABCD/script.js",
+    ];
+    for (const url of extensionUrls) {
+      expect(DENIED_URL_PATTERNS.some((p) => p.test(url))).toBe(true);
+    }
+  });
+
+  test("never matches our own bundles", () => {
+    // Sentry resolves the last valid frame URL, which for our code is the
+    // Next static chunk path.
+    const ours = [
+      "https://animegoclub.com/_next/static/chunks/4bd1b696-e356ca5ba0218e27.js",
+      "app:///_next/static/chunks/9945-e65dabd9a75df177.js",
+      "https://animegoclub.com/jassub/wasm/worker.bundle.js",
+    ];
+    for (const url of ours) {
+      expect(DENIED_URL_PATTERNS.some((p) => p.test(url))).toBe(false);
+    }
+  });
+});
+
+// The checks above exercise a reimplementation of Sentry's matcher, on
+// purpose. This one runs the patterns through the integration that actually
+// ships, so the wiring is verified rather than assumed — the failure this
+// guards against is an SDK change quietly making a pattern stop matching,
+// which looks exactly like the noise coming back.
+describe("through the real @sentry/core EventFilters integration", () => {
+  const integration = eventFiltersIntegration({
+    ignoreErrors: IGNORED_ERROR_PATTERNS,
+    denyUrls: DENIED_URL_PATTERNS,
+  });
+  const client = { getOptions: () => ({}) } as never;
+
+  const event = (type: string, value: string, filename?: string) => ({
+    exception: {
+      values: [
+        { type, value, ...(filename ? { stacktrace: { frames: [{ filename }] } } : {}) },
+      ],
+    },
+  });
+  const dropped = (type: string, value: string, filename?: string) =>
+    integration.processEvent?.(event(type, value, filename) as never, {} as never, client) === null;
+
+  test("drops the injected-script noise", () => {
+    expect(dropped("SyntaxError", SEEN_NOISE.hasSelector)).toBe(true);
+    expect(dropped("ReferenceError", SEEN_NOISE.lidNotify)).toBe(true);
+    expect(dropped("ReferenceError", SEEN_NOISE.underscoreG)).toBe(true);
+    expect(dropped("TypeError", SEEN_NOISE.notGranted)).toBe(true);
+  });
+
+  test("keeps the errors attributed to this application", () => {
+    expect(dropped("TypeError", "Cannot read properties of null (reading 'removeChild')")).toBe(false);
+    expect(dropped("Error", "NoModificationAllowedError: An attempt was made to write to a file or directory which could not be modified due to the state of the underlying filesystem.")).toBe(false);
+    expect(dropped("TypeError", "Cannot read properties of undefined (reading 'call')")).toBe(false);
+    expect(dropped("SyntaxError", "Unexpected token '}'")).toBe(false);
+  });
+
+  test("denyUrls drops extension frames and spares ours", () => {
+    expect(dropped("TypeError", "boom", "chrome-extension://abc/content.js")).toBe(true);
+    expect(
+      dropped("TypeError", "boom", "https://animegoclub.com/_next/static/chunks/4bd.js"),
+    ).toBe(false);
+  });
+});

--- a/next-app/src/lib/sentryFilters.ts
+++ b/next-app/src/lib/sentryFilters.ts
@@ -1,0 +1,84 @@
+// Which browser errors are ours, and which belong to somebody else's script.
+//
+// Separate from instrumentation-client.ts because that file calls
+// Sentry.init() at module load, so importing it from a test would initialise
+// the SDK. The patterns are the part worth testing anyway: a pattern that is
+// slightly too broad does not fail loudly, it just quietly stops reporting a
+// class of real bug, and nobody finds out until they go looking for an error
+// that should have been there.
+//
+// Every entry below is justified by an issue actually seen in
+// animego-org/javascript-nextjs. Nothing is added speculatively from a
+// generic "common browser noise" list — an unused pattern is a blind spot
+// with no upside.
+//
+// Matching semantics, verified against @sentry/core 10.54
+// (integrations/eventFilters.js, utils/string.js): a string pattern is a
+// SUBSTRING test, a RegExp is `.test()`, and both run against `event.message`,
+// the last exception's `value`, and `"Type: value"`.
+
+/**
+ * Errors that cannot originate in this application.
+ *
+ * Sentry applies these in the EventFilters event processor, which runs before
+ * `beforeSend` (client.js `_processEvent`: `_prepareEvent(...).then(prepared
+ * => processBeforeSend(...))`). That ordering is load-bearing here — see the
+ * Replay note in instrumentation-client.ts.
+ */
+export const IGNORED_ERROR_PATTERNS: Array<string | RegExp> = [
+  // 88 events and climbing, all from in-app WebViews on Android in China.
+  //
+  //   Failed to execute 'querySelectorAll' on 'Document':
+  //   'a[href*="http"][target="_blank"][rel="noopener"]:has(img)'
+  //   is not a valid selector.
+  //
+  // Three things identify it as injected: the stack below Sentry's own
+  // setInterval wrapper is all `<anonymous>` frames, the mechanism is
+  // `auto.browser.browserapierrors.setInterval` (a polling loop), and the
+  // browser is Chrome WebView 97 — `:has()` needs Chrome 105.
+  //
+  // Safe to drop as a whole class rather than by that one selector string:
+  // the only querySelectorAll in this codebase is
+  // `art.video.querySelectorAll("track")`, a literal that cannot be invalid.
+  // If dynamic selectors ever get built here, narrow this entry first.
+  "is not a valid selector",
+
+  // Injected globals from host apps and extensions. Each names a symbol that
+  // appears nowhere in this repository.
+  "LIDNotifyId",
+  "Can't find variable: _G",
+
+  // A permission refusal surfaced as an error. Anchored rather than a bare
+  // "not granted" substring, which would be broad enough to swallow a future
+  // message of our own.
+  /^(?:TypeError: )?not granted$/,
+];
+
+/**
+ * Frames from these origins are never ours.
+ *
+ * Categorical rather than observational: an error whose stack comes from an
+ * extension URL cannot be an application bug, so this can never hide one.
+ * It does NOT catch the WebView case above — those frames are `<anonymous>`
+ * and carry no URL at all, which is why the message patterns exist too.
+ */
+export const DENIED_URL_PATTERNS: RegExp[] = [
+  /^chrome-extension:\/\//,
+  /^moz-extension:\/\//,
+  /^safari-(?:web-)?extension:\/\//,
+  /^webkit-masked-url:/,
+];
+
+/**
+ * Sentry's matcher, reimplemented for the tests.
+ *
+ * Deliberately a copy rather than an import: the point of the suite is to
+ * pin what these patterns do to the exact strings Sentry reported, and
+ * borrowing the SDK's matcher would make the test agree with the SDK by
+ * construction even if the SDK changed underneath us.
+ */
+export function matchesIgnored(message: string): boolean {
+  return IGNORED_ERROR_PATTERNS.some((pattern) =>
+    typeof pattern === "string" ? message.includes(pattern) : pattern.test(message),
+  );
+}


### PR DESCRIPTION
Two fixes found by triaging the thirteen unresolved issues in Sentry. Independent of #89 — no file overlap, branched from `main`, mergeable in either order.

## `0ddfc96` — stop reporting other people's scripts

Five of the thirteen unresolved issues are not this application's code. The largest has 88 events and is still climbing:

```
SyntaxError: Failed to execute 'querySelectorAll' on 'Document':
'a[href*="http"][target="_blank"][rel="noopener"]:has(img)' is not a valid selector.
```

Three things identify it as injected rather than ours:

- the frames below Sentry's own `setInterval` wrapper are all `<anonymous>` — code with no source URL
- the mechanism is `auto.browser.browserapierrors.setInterval`, a polling loop
- every event comes from **Chrome WebView 97**, which predates `:has()` by eight major versions

The only `querySelectorAll` in this codebase is `art.video.querySelectorAll("track")`, a literal that cannot be invalid. This is a host app's content script scanning the page it is displaying, on the user's device, after our HTML arrives.

**Quota is the smaller half of the cost.** `beforeSend` lazy-loads the ~500 kB Replay SDK on the first error of *any* kind, from `browser.sentry-cdn.com` — so an extension's syntax error on someone's phone in China pulled half a megabyte onto that phone, over an origin that is not dependable from there, 88 times.

Filtering fixes that too, and the ordering is load-bearing: EventFilters runs as an event processor, and `@sentry/core` resolves those *before* `beforeSend` (`client.js` `_processEvent`), so a filtered error never reaches the Replay block. The block is now also guarded to one attempt per page load, and deliberately not retried on failure — repeating a failing script fetch on exactly the sessions already going badly is not an improvement.

### Why the patterns are a separate module

They are the part that can go wrong quietly. A pattern that is slightly too broad does not fail loudly; it stops reporting a class of real bug, and nobody notices until they go looking for an error that should have been there.

So each entry is pinned by a test to the exact string Sentry reported, and a second suite asserts that the errors currently attributed to this application still get through. **Nothing was added from a generic "common browser noise" list** — an unused pattern is a blind spot with no upside.

Two candidates were deliberately left unfiltered:

- `SyntaxError: Unexpected token '}'` — a truncated or corrupted bundle produces exactly this, and that is worth being woken up for
- the `__reactFiber$` assignment error — same family as the `/search` `removeChild` issue that is genuinely ours

The last test runs the patterns through `@sentry/core`'s real `eventFiltersIntegration` rather than the local reimplementation, so the wiring is verified rather than assumed. The failure it guards against is an SDK change making a pattern silently stop matching, which looks identical to the noise returning.

### Documented, not changed

Neither `replaysSessionSampleRate` nor `replaysOnErrorSampleRate` is configured, and on-error capture needs the latter above zero. **Until one is set, this download most likely records nothing.** Left as-is rather than removed or enabled: turning it on starts uploading session recordings of real users, which is a decision rather than a cleanup.

## `230b215` — a failed handle write no longer looks like a successful one

`persist()` in `fileHandleStore` had a bare `catch` whose comment named a single cause:

```js
} catch {
  // DataCloneError: store a serializable stub
```

The stub is a lossy record. The handle it writes to IndexedDB is `{ __stub: true, name }`; the live `FileSystemDirectoryHandle` survives only in a module-level Map that dies with the page. That trade is right for the case it was written for — test doubles carry function properties that `structuredClone` rejects — and wrong for every other way a `put` can fail.

IndexedDB writes also reject with `NoModificationAllowedError` on a locked or read-only browser profile, `QuotaExceededError` on a full disk, `InvalidStateError` on a closing database. In each of those the old code swallowed the reason, wrote a stub, and returned as though the folder had been saved. **If the retry happened to succeed, the user's watch folder came back empty on their next visit with nothing logged anywhere** — one of the shapes the "watch folder sometimes stops working" reports took.

Sentry has 17 events of exactly that error on `/library`, reported as an unhandled rejection with no stacktrace — which is what an async DOMException crossing `await` boundaries looks like.

Only a genuine clone failure now earns the stub. The check reads `inner` as well as the error itself, because Dexie wraps the underlying DOMException and which of the two carries the name depends on where the failure surfaced.

Fixing that alone would have turned a silent downgrade into a silent nothing, because `pickFolder` had the same shape one layer up — a bare `catch` returning null. A browser that could not write to IndexedDB at all presented as a folder picker that did nothing when you chose a folder, with no trace anywhere. It now reports anything that is not an `AbortError`; dismissing the picker is a decision, not a fault, and reporting it would bury the real failures underneath it.

## Verification

- `bun test` — **952 pass, 0 fail** (911 before; +24 filter tests, +17 handle-store tests)
- `bunx tsc --noEmit` — 31 errors, byte-identical to `main`'s pre-existing baseline; **zero in the changed files**
- `bunx eslint` on every changed file — 2 errors, both pre-existing and unchanged (confirmed by stashing)
- `bun run build` — exit 0, and the patterns are present in the shipped client chunks with `ignoreErrors:[...e.ignoreErrors||[` showing the SDK merged them into `init` rather than them sitting as a dangling string
- **Mutation-tested**: restoring the bare `catch` fails five tests, ignoring the Dexie-wrapped clone error fails one, always-stubbing fails five, and the restored code is green

## Not in this PR

- **The `/search` `removeChild` issue** — 156 events since 31 May, the largest one that really is ours. The stack is entirely React DOM internals with no application frame, meaning the DOM was mutated outside React during a commit. Pinning it needs either a local repro or Seer, and Seer returns `402 No budget for Seer Autofix`.
- **`Cannot read properties of undefined (reading 'call')`** on `/anime/:id`, 7 events — the classic shape of an old tab requesting a chunk that a deploy has replaced.
