### PR TITLE
feat(i18n): make the other languages findable, and disclose converted synopses

### DIFF
--- a/e2e/specs/sandbox/locale-hint.spec.ts
+++ b/e2e/specs/sandbox/locale-hint.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect, type Browser, type Page } from "@playwright/test";
+
+// The one-time offer to read the page in the browser's language.
+//
+// Everything here needs its own browser context, because the input under test
+// is `navigator.languages` and Playwright can only set that per context. That
+// is also why these guards live in a file of their own rather than joining
+// locale-routing.spec.ts, which shares one page across its tests.
+//
+// Two failure modes are worth the cost of these tests. The first is the hint
+// pointing the wrong way — offering Traditional to someone already reading it,
+// or offering anything to a reader whose language we do not publish. The
+// second is quieter and worse: the hint reappearing after a visitor has
+// answered. It is shown unprompted, so a visitor who dismisses it and sees it
+// again has no way to make it stop.
+
+/** A fresh context with a given Accept-Language, and no stored decision. */
+async function visit(browser: Browser, locale: string, path: string) {
+  const context = await browser.newContext({
+    locale,
+    storageState: { cookies: [], origins: [] },
+  });
+  const page = await context.newPage();
+  const errors: string[] = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+  await page.goto(path);
+  await page.waitForLoadState("networkidle");
+  return { context, page, errors };
+}
+
+const card = (page: Page) => page.locator(".agc-locale-hint-card");
+
+test.describe("who gets offered what", () => {
+  // Both halves matter. A hint that never fires is invisible; a hint that
+  // fires for everyone is a popup on every first page view of the site.
+  const cases: Array<{ locale: string; path: string; offer: string | null; why: string }> = [
+    { locale: "zh-TW", path: "/faq", offer: "以繁體中文瀏覽？", why: "Taiwan reads Traditional" },
+    { locale: "zh-HK", path: "/faq", offer: "以繁體中文瀏覽？", why: "so does Hong Kong" },
+    { locale: "en-US", path: "/faq", offer: "View this page in English?", why: "English exists too" },
+    { locale: "zh-CN", path: "/zh-Hant/faq", offer: "用简体中文浏览？", why: "and it works in reverse" },
+    { locale: "zh-CN", path: "/faq", offer: null, why: "already on their language" },
+    { locale: "en-US", path: "/en/faq", offer: null, why: "same, on the English tree" },
+    { locale: "ja-JP", path: "/faq", offer: null, why: "we do not publish Japanese" },
+  ];
+
+  for (const { locale, path, offer, why } of cases) {
+    test(`${locale} on ${path} — ${why}`, async ({ browser }) => {
+      const { context, page, errors } = await visit(browser, locale, path);
+      if (offer === null) {
+        await expect(card(page)).toHaveCount(0);
+      } else {
+        await expect(card(page)).toBeVisible();
+        // The copy is in the language being offered, not the one being read.
+        // A reader on the Simplified tree has to see Traditional characters to
+        // know what is on the other side of the button.
+        await expect(page.locator(".agc-locale-hint-text")).toHaveText(offer);
+      }
+      expect(errors, "the hint must not throw during hydration").toEqual([]);
+      await context.close();
+    });
+  }
+});
+
+test.describe("it asks once", () => {
+  test("dismissing it keeps it away, on reload and on other routes", async ({ browser }) => {
+    const { context, page } = await visit(browser, "zh-TW", "/faq");
+    await expect(card(page)).toBeVisible();
+
+    await page.locator(".agc-locale-hint-close").click();
+    await expect(card(page)).toHaveCount(0);
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    await expect(card(page), "it came back after a reload").toHaveCount(0);
+
+    await page.goto("/calendar");
+    await page.waitForLoadState("networkidle");
+    await expect(card(page), "it came back on another route").toHaveCount(0);
+
+    await context.close();
+  });
+
+  test("accepting switches locale and does not ask again", async ({ browser }) => {
+    const { context, page } = await visit(browser, "zh-TW", "/faq");
+
+    await page.locator(".agc-locale-hint-accept").click();
+    await page.waitForURL(/\/zh-Hant\//);
+    expect(new URL(page.url()).pathname).toBe("/zh-Hant/faq");
+    expect(await page.locator("html").getAttribute("lang")).toBe("zh-Hant");
+
+    await page.waitForLoadState("networkidle");
+    await expect(card(page)).toHaveCount(0);
+
+    await context.close();
+  });
+
+  test("accepting keeps the page and its query string", async ({ browser }) => {
+    // A switcher that drops the reader on the home page is a worse
+    // experience and tells Google the alternate is not really an alternate.
+    const { context, page } = await visit(browser, "zh-TW", "/search?q=frieren");
+
+    await page.locator(".agc-locale-hint-accept").click();
+    await page.waitForURL(/\/zh-Hant\/search/);
+    expect(page.url()).toContain("q=frieren");
+
+    await context.close();
+  });
+});
+
+test.describe("it stays out of the way", () => {
+  test("the server sends no hint markup at all", async ({ browser }) => {
+    // The decision is client-side precisely so the HTML is identical for
+    // every visitor — that is what keeps pages cacheable at the edge and
+    // keeps a crawler from being served a variant. If this fails, the hint
+    // has started varying the response.
+    // The empty storageState is not optional: without it the context inherits
+    // the project's ./.auth/user.json, which only exists after globalSetup has
+    // run. A signed-in session would also change what the proxy does.
+    const context = await browser.newContext({
+      locale: "zh-TW",
+      storageState: { cookies: [], origins: [] },
+    });
+    const res = await context.request.get("/faq");
+    const body = await res.text();
+    expect(body).not.toContain("agc-locale-hint-card");
+    expect(body).not.toContain("以繁體中文瀏覽");
+    await context.close();
+  });
+
+  test("it does not push the page down", async ({ browser }) => {
+    // The navbar is position: sticky, so a hint inserted above it in flow
+    // would move the whole document after hydration — a layout shift on the
+    // one view Core Web Vitals measures. Fixed positioning is what prevents
+    // that, and this asserts the navbar has not moved.
+    const { context, page } = await visit(browser, "zh-TW", "/faq");
+    await expect(card(page)).toBeVisible();
+
+    const nav = await page.locator("nav").first().boundingBox();
+    await page.locator(".agc-locale-hint-close").click();
+    await expect(card(page)).toHaveCount(0);
+    const navAfter = await page.locator("nav").first().boundingBox();
+
+    expect(nav?.y).toBe(navAfter?.y);
+    await context.close();
+  });
+
+  test("it does not steal focus", async ({ browser }) => {
+    // It appears without being asked for. Taking the caret from someone
+    // mid-sentence to offer them a translation is worse than not offering.
+    const { context, page } = await visit(browser, "zh-TW", "/faq");
+    await expect(card(page)).toBeVisible();
+    const focused = await page.evaluate(() => document.activeElement?.className ?? "");
+    expect(focused).not.toContain("agc-locale-hint");
+    await context.close();
+  });
+});

--- a/next-app/src/app/[lang]/anime/[id]/page.tsx
+++ b/next-app/src/app/[lang]/anime/[id]/page.tsx
@@ -527,8 +527,19 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
   //     machine text out of Google's snippets entirely — the same SERP
   //     boundary that keeps generateMetadata / JSON-LD on the English
   //     original applies one layer down here.
+  //   - 'opencc': a Simplified-to-Traditional conversion of one of the above.
+  //     It arrived with zh-Hant and was briefly the one machine-made source
+  //     that carried neither a note nor nosnippet, because both flags named
+  //     their sources individually — so the identical prose was disclosed on
+  //     /anime/:id and undisclosed on /zh-Hant/anime/:id.
   //   - 'manual' still does not exist; our own editorial text will have no
   //     reason to be held out of snippets when it does.
+  //
+  // nosnippet is therefore computed from "is there any provenance at all"
+  // rather than from a list of sources. A tier added later is held out of
+  // snippets until someone decides otherwise, which is the direction this
+  // should fail in — the same reason title_hant_seo names the sources it
+  // admits instead of the one it excludes.
   //
   // Neither flag is gated on bgmId. bgmId only decides whether the bangumi
   // credit is a link: a row that lost its binding after the summary was
@@ -536,6 +547,13 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
   // republishing the text.
   const isBangumiSummary = desc.source === "bangumi";
   const isLlmSummary = desc.source === "llm";
+  const isConvertedSummary = desc.source === "opencc";
+  // A conversion inherits the honesty debt of what it converted. The
+  // Simplified text under a zh-Hant page is very often the LLM translation,
+  // and "converted to Traditional" alone would quietly drop the far more
+  // important half of that sentence.
+  const convertedFromLlm = isConvertedSummary && detail.descriptionCnSource === "llm";
+  const summaryIsDerived = desc.source !== null && desc.source !== undefined;
   const bgmSummaryHref = detail.bgmId
     ? `https://bgm.tv/subject/${detail.bgmId}`
     : undefined;
@@ -692,13 +710,17 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
                 needsToggle={descNeedsToggle}
                 expandLabel={dict.detail.readMore}
                 collapseLabel={dict.detail.collapse}
-                nosnippet={isBangumiSummary || isLlmSummary}
+                nosnippet={summaryIsDerived}
                 sourceLabel={
                   isBangumiSummary
                     ? dict.detail.summaryFromBangumi
                     : isLlmSummary
                       ? dict.detail.summaryFromLlm
-                      : undefined
+                      : convertedFromLlm
+                        ? dict.detail.summaryConvertedFromLlm
+                        : isConvertedSummary
+                          ? dict.detail.summaryConverted
+                          : undefined
                 }
                 sourceHref={isBangumiSummary ? bgmSummaryHref : undefined}
               />

--- a/next-app/src/app/[lang]/layout.tsx
+++ b/next-app/src/app/[lang]/layout.tsx
@@ -3,6 +3,7 @@ import { Sora, DM_Sans, JetBrains_Mono } from "next/font/google";
 import { Toaster } from "react-hot-toast";
 import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
+import { LocaleHint } from "@/components/layout/LocaleHint";
 import { LanguageProvider } from "@/lib/lang-client";
 import { HTML_LANG, OG_LOCALE, alternateOgLocales } from "@/lib/i18n/lang";
 import { localeParams, resolveLocale, type LangParams } from "@/lib/i18n/route";
@@ -134,6 +135,10 @@ export default async function RootLayout({
       >
         <LanguageProvider lang={lang}>
           <Navbar season={season} year={year} />
+          {/* Renders nothing on the server and nothing at all for most
+              visitors — see LocaleHint for why it floats rather than sitting
+              above the navbar in flow. */}
+          <LocaleHint />
           <Toaster
             position="top-center"
             toastOptions={{

--- a/next-app/src/components/layout/Footer.tsx
+++ b/next-app/src/components/layout/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from "@/components/ui/LocaleLink";
+import { LanguageMenu } from "@/components/layout/LanguageMenu";
 import type { CSSProperties } from "react";
 import type { Dict } from "@/lib/i18n";
 
@@ -192,6 +193,11 @@ export default function Footer({ dict, season, year }: FooterProps) {
           <span style={s.copyright}>
             {dict.footer.copyright.replace("{year}", yearStr)}
           </span>
+          {/* Says which language version you are reading, and opens the same
+              menu the navbar does. This is the whole of apple.com's locale
+              affordance — they carry no banner, no modal and no geo
+              detection, just a footer control naming the current version. */}
+          <LanguageMenu variant="named" />
           <span style={s.credits}>
             {dict.footer.dataCredits}
             <a

--- a/next-app/src/components/layout/LanguageMenu.tsx
+++ b/next-app/src/components/layout/LanguageMenu.tsx
@@ -187,9 +187,23 @@ export function LanguageMenuInline({ onPicked }: { onPicked?: () => void }) {
 
 /**
  * A trigger plus its own popup, for the logged-out navbar where there is no
- * account menu to live inside.
+ * account menu to live inside, and for the footer.
+ *
+ * `variant` is the difference between the two placements:
+ *
+ *   compact — the navbar. A globe and the two-character short label, because
+ *             the bar already overflows at 375px.
+ *   named   — the footer. The locale's full endonym, and the popup opens
+ *             upward because there is nothing below it.
+ *
+ * The named variant is the pattern apple.com uses, checked rather than
+ * recalled: neither apple.com nor apple.com/tw carries a language banner, a
+ * modal, or any geo-detection UI. What they have is one footer control that
+ * states the version you are on -- "United States", "台灣" -- and opens a
+ * chooser. Naming the current version is the whole affordance: a reader who
+ * cannot tell which one they are on has no reason to look for the control.
  */
-export function LanguageMenu() {
+export function LanguageMenu({ variant = "compact" }: { variant?: "compact" | "named" }) {
   const { t, switchTo } = useLang();
   const current = useCurrentLocale();
   const [open, setOpen] = useState(false);
@@ -230,21 +244,35 @@ export function LanguageMenu() {
   }, [open, current, focusAt]);
 
   return (
-    <div className="agc-lang-wrap" ref={wrapRef}>
+    <div
+      className={`agc-lang-wrap${variant === "named" ? " agc-lang-wrap--up" : ""}`}
+      ref={wrapRef}
+    >
       <button
         type="button"
         ref={triggerRef}
-        className="agc-lang-trigger"
+        className={`agc-lang-trigger${variant === "named" ? " agc-lang-trigger--named" : ""}`}
         aria-haspopup="menu"
         aria-expanded={open}
-        aria-label={t("nav.language")}
+        // The compact trigger reads as a bare glyph, so it needs the label
+        // spoken. The named one already says which version you are on, and
+        // an aria-label would replace that text rather than add to it.
+        aria-label={variant === "compact" ? t("nav.language") : undefined}
         onClick={() => setOpen((v) => !v)}
       >
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <circle cx="12" cy="12" r="10" />
           <path d="M2 12h20M12 2a15 15 0 0 1 0 20M12 2a15 15 0 0 0 0 20" />
         </svg>
-        <span aria-hidden="true">{LOCALE_LABEL[current].short}</span>
+        {variant === "named" ? (
+          // Not aria-hidden, unlike the short label: this text IS the
+          // information. And not a dictionary key -- 繁體中文 has to read
+          // 繁體中文 to an English reader too, which is why LOCALE_LABEL is
+          // keyed by locale rather than by the reader's language.
+          <span>{LOCALE_LABEL[current].endonym}</span>
+        ) : (
+          <span aria-hidden="true">{LOCALE_LABEL[current].short}</span>
+        )}
       </button>
 
       {open && (

--- a/next-app/src/components/layout/LocaleHint.tsx
+++ b/next-app/src/components/layout/LocaleHint.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { usePathname } from "next/navigation";
+import { useLang } from "@/lib/lang-client";
+import { DEFAULT_LOCALE, LOCALE_LABEL, splitLocale, type Locale } from "@/lib/i18n/locale";
+import { preferredLocale } from "@/lib/i18n/preferredLocale";
+import "./locale-hint.css";
+
+/**
+ * A one-time offer to read the page in the language the browser asks for.
+ *
+ * This is the Airbnb / Booking pattern, and explicitly NOT apple.com's —
+ * Apple carries no banner, no modal and no geo-detection UI anywhere, only
+ * the footer control that names the current version (LanguageMenu's `named`
+ * variant). Both are in the site now because they answer different questions:
+ * the footer one tells a reader where they are, this one tells a reader that
+ * somewhere else exists.
+ *
+ * Four things it deliberately does not do:
+ *
+ * **It does not redirect.** Google's multi-regional guidance is explicit that
+ * automatic language redirects stop users *and crawlers* from reaching the
+ * other versions, and Googlebot crawls from one place — a redirect would hide
+ * two thirds of this site from the index. It also could not work where it
+ * matters: /anime/* is served from the Cloudflare edge cache on a hit, and
+ * proxy.ts does not run at all on those requests.
+ *
+ * **It does not read anything server-side.** No Accept-Language, no
+ * CF-IPCountry. The rendered HTML is byte-identical for every visitor, which
+ * is what keeps the page cacheable at the edge and keeps a crawler from being
+ * served a variant.
+ *
+ * **It does not enter the layout.** The navbar is `position: sticky`, so a bar
+ * inserted above it in flow would push the whole document down after
+ * hydration — a layout shift on the first view for every new visitor, which
+ * is the one view Core Web Vitals actually measures. This floats below the
+ * navbar instead and moves nothing.
+ *
+ * **It does not take focus.** It appears without being asked for; stealing the
+ * caret from someone mid-sentence to offer them a translation is worse than
+ * not offering it. `role="status"` announces it politely and leaves the
+ * keyboard where it was.
+ */
+
+/** Copy for each locale, in that locale. */
+const HINT: Record<Locale, { question: string; accept: string; dismiss: string }> = {
+  // Never a dictionary lookup, for the same reason LOCALE_LABEL is not one:
+  // the entire message is "this exists in your language", and it can only
+  // carry that if it is written in the language being offered. A reader on
+  // the Simplified tree has to see 繁體字 to know what is on the other side.
+  "zh-Hans": { question: "用简体中文浏览？", accept: "切换", dismiss: "关闭" },
+  "zh-Hant": { question: "以繁體中文瀏覽？", accept: "切換", dismiss: "關閉" },
+  en: { question: "View this page in English?", accept: "Switch", dismiss: "Dismiss" },
+};
+
+// Versioned so that changing the copy can re-ask if it is ever worth it.
+// Bumping this re-prompts everyone, so it is not something to do casually.
+const DECIDED_KEY = "agc:locale-hint:v1";
+
+/** localStorage throws in Safari private mode; a hint is not worth a crash. */
+function hasDecided(): boolean {
+  try {
+    return window.localStorage.getItem(DECIDED_KEY) !== null;
+  } catch {
+    // Unreadable storage means we cannot promise "once", and showing it on
+    // every page load would be worse than never showing it.
+    return true;
+  }
+}
+
+function recordDecision(value: string): void {
+  try {
+    window.localStorage.setItem(DECIDED_KEY, value);
+  } catch {
+    // Nothing to do. The hint is already hidden for this page view; the cost
+    // of a failed write is that it may return on the next one.
+  }
+}
+
+/**
+ * "Has this visitor already answered?" as an external store.
+ *
+ * useSyncExternalStore rather than an effect that calls setState, because
+ * that is what this actually is: a value the server cannot know, read once on
+ * the client, changed by an event. `getServerSnapshot` returning "decided" is
+ * what makes the server render nothing without a second pass, so the markup
+ * is identical for every visitor and stays cacheable at the edge.
+ */
+const listeners = new Set<() => void>();
+let cached: "unknown" | "decided" | "open" = "unknown";
+
+function subscribe(onChange: () => void): () => void {
+  listeners.add(onChange);
+  return () => {
+    listeners.delete(onChange);
+  };
+}
+
+function getSnapshot(): "decided" | "open" {
+  if (cached === "unknown") cached = hasDecided() ? "decided" : "open";
+  return cached;
+}
+
+function getServerSnapshot(): "decided" {
+  return "decided";
+}
+
+/** Answered — hide it here and in any other copy currently mounted. */
+function settle(value: string): void {
+  recordDecision(value);
+  cached = "decided";
+  for (const onChange of listeners) onChange();
+}
+
+export function LocaleHint() {
+  const pathname = usePathname();
+  const { switchTo } = useLang();
+  const state = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  // Returns on the server and for anyone who has answered before, so nothing
+  // below this line ever runs where `navigator` does not exist.
+  if (state === "decided") return null;
+
+  const current = pathname ? splitLocale(pathname).locale : DEFAULT_LOCALE;
+  const suggested = preferredLocale(navigator.languages, current);
+  if (!suggested) return null;
+
+  const copy = HINT[suggested];
+
+  return (
+    <div className="agc-locale-hint" role="status">
+      <div className="agc-locale-hint-card" lang={suggested}>
+        <svg
+          className="agc-locale-hint-globe"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <path d="M2 12h20M12 2a15 15 0 0 1 0 20M12 2a15 15 0 0 0 0 20" />
+        </svg>
+
+        <span className="agc-locale-hint-text">{copy.question}</span>
+
+        <button
+          type="button"
+          className="agc-locale-hint-accept"
+          onClick={() => {
+            settle(suggested);
+            switchTo(suggested);
+          }}
+        >
+          {copy.accept}
+        </button>
+
+        <button
+          type="button"
+          className="agc-locale-hint-close"
+          aria-label={copy.dismiss}
+          onClick={() => settle("dismissed")}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* The offered language named in full, for a reader who wants to be sure
+          what "切換" is going to do before pressing it. */}
+      <span className="agc-locale-hint-endonym" aria-hidden="true">
+        {LOCALE_LABEL[suggested].endonym}
+      </span>
+    </div>
+  );
+}

--- a/next-app/src/components/layout/language-menu.css
+++ b/next-app/src/components/layout/language-menu.css
@@ -158,3 +158,43 @@
     transition: none;
   }
 }
+
+/* ─── the footer variant ──────────────────────────────────────────────────
+   apple.com's pattern: one control that states which version you are on,
+   spelled out, with no banner and no geo detection anywhere on the page.
+   Naming the version is the affordance — a reader who cannot tell which one
+   they are reading has no reason to go looking for a switcher. */
+
+.agc-lang-trigger--named {
+  gap: 7px;
+  padding: 6px 11px;
+  font-size: 13px;
+  /* The navbar trigger is a glyph and can afford to be quiet. This one is a
+     sentence about the page, so it sits at the same weight as the copyright
+     line beside it rather than competing with it. */
+  color: rgba(235, 235, 245, 0.6);
+}
+
+.agc-lang-trigger--named:hover,
+.agc-lang-trigger--named[aria-expanded="true"] {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+/* Opens upward: it is the last row of the document, and a popup below it
+   would render off-screen and scroll the page on open. */
+.agc-lang-wrap--up .agc-lang-pop {
+  top: auto;
+  bottom: calc(100% + 10px);
+  right: auto;
+  left: 0;
+}
+
+@media (max-width: 640px) {
+  /* The footer bottom row wraps at this width, so the control can end up
+     against the right edge; anchoring the popup to the trigger's left keeps
+     it on screen either way. */
+  .agc-lang-wrap--up .agc-lang-pop {
+    left: 0;
+    right: auto;
+  }
+}

--- a/next-app/src/components/layout/locale-hint.css
+++ b/next-app/src/components/layout/locale-hint.css
@@ -1,0 +1,181 @@
+/*
+ * locale-hint.css — the one-time "this page exists in your language" offer.
+ *
+ * Fixed rather than in flow, and that is the load-bearing property here. The
+ * navbar is position: sticky, so anything inserted above it in the document
+ * pushes the entire page down the moment hydration finishes — a layout shift
+ * on a first-time visitor's first view, which is precisely the view Core Web
+ * Vitals scores. Floating costs nothing and moves nothing.
+ */
+
+.agc-locale-hint {
+  position: fixed;
+  /* Below the sticky navbar rather than over it. Covering the navigation to
+     offer a translation would take away the control the reader is most
+     likely to want if they disagree with the offer. */
+  top: 68px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 180;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  max-width: calc(100vw - 24px);
+  /* Nothing here should ever swallow a click meant for the page underneath. */
+  pointer-events: none;
+  animation: agc-locale-hint-in 260ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.agc-locale-hint-card {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 9px 9px 14px;
+  border-radius: 999px;
+  background: rgba(18, 18, 22, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  -webkit-backdrop-filter: blur(20px) saturate(150%);
+  backdrop-filter: blur(20px) saturate(150%);
+  box-shadow: 0 24px 64px -20px rgba(0, 0, 0, 0.9);
+}
+
+.agc-locale-hint-globe {
+  width: 17px;
+  height: 17px;
+  flex: none;
+  color: rgba(235, 235, 245, 0.55);
+}
+
+.agc-locale-hint-text {
+  font-size: 14px;
+  line-height: 1.3;
+  color: rgba(255, 255, 255, 0.92);
+  white-space: nowrap;
+}
+
+.agc-locale-hint-accept,
+.agc-locale-hint-close {
+  flex: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.agc-locale-hint-accept {
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #101014;
+  background: rgba(255, 255, 255, 0.92);
+  white-space: nowrap;
+}
+
+.agc-locale-hint-accept:hover {
+  background: #fff;
+}
+
+.agc-locale-hint-close {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: transparent;
+  color: rgba(235, 235, 245, 0.55);
+}
+
+.agc-locale-hint-close svg {
+  width: 15px;
+  height: 15px;
+}
+
+.agc-locale-hint-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.agc-locale-hint-accept:focus-visible,
+.agc-locale-hint-close:focus-visible {
+  outline: 2px solid rgba(120, 170, 255, 0.9);
+  outline-offset: 2px;
+}
+
+.agc-locale-hint-endonym {
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: rgba(235, 235, 245, 0.42);
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.8);
+}
+
+@keyframes agc-locale-hint-in {
+  from {
+    opacity: 0;
+    /* translateX is repeated because transform replaces, not composes — the
+       centring above would be dropped mid-animation without it. */
+    transform: translateX(-50%) translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+@media (max-width: 560px) {
+  .agc-locale-hint {
+    top: 60px;
+    width: calc(100vw - 24px);
+  }
+
+  .agc-locale-hint-card {
+    width: 100%;
+  }
+
+  .agc-locale-hint-text {
+    /* The question is the one thing that may wrap on a narrow screen; the
+       two controls keep their size so they stay tappable. */
+    white-space: normal;
+    flex: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agc-locale-hint {
+    animation: none;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  .agc-locale-hint-card {
+    background: rgba(255, 255, 255, 0.94);
+    border-color: rgba(0, 0, 0, 0.1);
+    box-shadow: 0 24px 64px -22px rgba(0, 0, 0, 0.35);
+  }
+
+  .agc-locale-hint-text {
+    color: rgba(0, 0, 0, 0.9);
+  }
+
+  .agc-locale-hint-globe,
+  .agc-locale-hint-close {
+    color: rgba(60, 60, 67, 0.6);
+  }
+
+  .agc-locale-hint-accept {
+    color: #fff;
+    background: rgba(20, 20, 24, 0.92);
+  }
+
+  .agc-locale-hint-accept:hover {
+    background: #000;
+  }
+
+  .agc-locale-hint-endonym {
+    color: rgba(60, 60, 67, 0.55);
+    text-shadow: none;
+  }
+}

--- a/next-app/src/lib/i18n/preferredLocale.test.ts
+++ b/next-app/src/lib/i18n/preferredLocale.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { preferredLocale } from "./preferredLocale";
+import { LOCALES, type Locale } from "./locale";
+
+// The hint this feeds is shown once per visitor and then never again, so a
+// wrong answer is not something the visitor can correct by reloading — they
+// dismiss it and it is gone. That asymmetry is why the decision lives in a
+// pure function with a table of real Accept-Language values rather than
+// inside a component where it can only be checked by hand.
+
+describe("Chinese tags resolve by script, not by region name", () => {
+  const cases: Array<[string, Locale]> = [
+    // Traditional-using regions.
+    ["zh-TW", "zh-Hant"],
+    ["zh-HK", "zh-Hant"],
+    ["zh-MO", "zh-Hant"],
+    ["zh-Hant", "zh-Hant"],
+    ["zh-Hant-TW", "zh-Hant"],
+    ["zh-Hant-HK", "zh-Hant"],
+    // Simplified-using regions.
+    ["zh-CN", "zh-Hans"],
+    ["zh-SG", "zh-Hans"],
+    ["zh-MY", "zh-Hans"],
+    ["zh-Hans", "zh-Hans"],
+    ["zh-Hans-CN", "zh-Hans"],
+  ];
+
+  for (const [tag, want] of cases) {
+    test(`${tag} -> ${want}`, () => {
+      // Current is `en` so any Chinese preference is a real suggestion.
+      expect(preferredLocale([tag], "en")).toBe(want);
+    });
+  }
+
+  test("bare zh resolves to Simplified", () => {
+    // A coin flip in the standard, and deliberately called this way: a
+    // browser set up by a Traditional reader almost always carries a region
+    // or script subtag, and guessing Simplified fails into "no hint shown"
+    // rather than into a hint pointing the wrong way.
+    expect(preferredLocale(["zh"], "en")).toBe("zh-Hans");
+  });
+
+  test("case and whitespace do not change the answer", () => {
+    expect(preferredLocale(["  ZH-tw  "], "en")).toBe("zh-Hant");
+    expect(preferredLocale(["ZH-HANT-hk"], "en")).toBe("zh-Hant");
+  });
+});
+
+describe("only the first recognised tag counts", () => {
+  test("a reader already on their first choice gets no hint", () => {
+    expect(preferredLocale(["zh-CN", "en"], "zh-Hans")).toBeNull();
+    expect(preferredLocale(["en-US", "zh-TW"], "en")).toBeNull();
+  });
+
+  test("and the lower-ranked tag is NOT used as a fallback", () => {
+    // The failure this prevents: ["zh-CN", "en"] on the Simplified tree
+    // scanning past the satisfied preference and suggesting English, which
+    // would move a reader off the page they asked for.
+    expect(preferredLocale(["zh-CN", "en"], "zh-Hans")).toBeNull();
+  });
+
+  test("tags we do not serve are skipped, not treated as a match", () => {
+    expect(preferredLocale(["fr-FR", "de", "zh-TW"], "zh-Hans")).toBe("zh-Hant");
+  });
+
+  test("a list of nothing we serve produces no hint", () => {
+    expect(preferredLocale(["fr", "de", "ja", "ko"], "zh-Hans")).toBeNull();
+  });
+});
+
+describe("degenerate input", () => {
+  test.each([
+    ["undefined", undefined],
+    ["empty list", []],
+    ["empty strings", ["", "   "]],
+  ])("%s produces no hint", (_name, input) => {
+    expect(preferredLocale(input as string[] | undefined, "zh-Hans")).toBeNull();
+  });
+});
+
+describe("it can only ever suggest a locale the site publishes", () => {
+  test("every possible answer is in LOCALES", () => {
+    const tags = ["zh-TW", "zh-CN", "zh", "en-GB", "zh-Hant", "fr", "ja"];
+    for (const tag of tags) {
+      const got = preferredLocale([tag], "en");
+      if (got !== null) expect(LOCALES).toContain(got);
+    }
+  });
+
+  test("an unpublished locale is not offered", () => {
+    // Simulates zh-Hant being pulled from LOCALES. A hint that survived that
+    // would point at a 404, which is worse than no hint: hreflang aside, it
+    // is a dead end handed to the one visitor who wanted that language.
+    const withoutHant = LOCALES.filter((l) => l !== "zh-Hant");
+    expect(preferredLocale(["zh-TW"], "zh-Hans", withoutHant)).toBeNull();
+    // …and the Simplified path still works, so the narrowing is specific.
+    expect(preferredLocale(["en-US"], "zh-Hans", withoutHant)).toBe("en");
+  });
+});

--- a/next-app/src/lib/i18n/preferredLocale.ts
+++ b/next-app/src/lib/i18n/preferredLocale.ts
@@ -1,0 +1,75 @@
+import { DEFAULT_LOCALE, LOCALES, type Locale } from "./locale";
+
+/**
+ * Which published locale a browser's language list is asking for.
+ *
+ * This is the whole decision behind the locale hint, kept out of the
+ * component so it can be tested without a browser — `navigator.languages` is
+ * the one input that cannot be reproduced in a unit test, and it is also the
+ * only part of this that is genuinely simple.
+ *
+ * ## What the tags actually look like
+ *
+ * Chinese is the case that needs care, because the script is what matters to
+ * us and most browsers send a region instead:
+ *
+ *   zh-TW, zh-HK, zh-MO   Taiwan, Hong Kong, Macau — Traditional
+ *   zh-CN, zh-SG, zh-MY   mainland, Singapore, Malaysia — Simplified
+ *   zh-Hant, zh-Hans      the script stated outright, rare but unambiguous
+ *   zh                    bare, and ambiguous
+ *
+ * Bare `zh` resolves to Simplified. It is a genuine coin flip in the
+ * standard, but a browser configured by someone reading Traditional
+ * overwhelmingly carries a region or script subtag, whereas bare `zh` is what
+ * a default install emits. Guessing Simplified also fails softer: it is the
+ * un-prefixed tree the visitor is already on, so the hint simply does not
+ * appear rather than appearing wrongly.
+ *
+ * ## Why only the first match counts
+ *
+ * The list is ordered by preference. If the first tag we recognise is the
+ * locale already being served, the visitor is reading what they asked for and
+ * there is nothing to suggest — even if a lower-ranked tag maps elsewhere.
+ * Scanning past it would let `["zh-CN", "en"]` pull a Simplified reader onto
+ * the English tree, which is the opposite of the point.
+ */
+export function preferredLocale(
+  languages: readonly string[] | undefined,
+  current: Locale = DEFAULT_LOCALE,
+  published: readonly Locale[] = LOCALES,
+): Locale | null {
+  for (const tag of languages ?? []) {
+    const match = localeForTag(tag, published);
+    if (!match) continue;
+    // First recognised tag wins, whichever way it goes.
+    return match === current ? null : match;
+  }
+  return null;
+}
+
+/** One BCP-47 tag to a published locale, or null if we do not serve it. */
+function localeForTag(tag: string, published: readonly Locale[]): Locale | null {
+  const lower = (tag ?? "").trim().toLowerCase();
+  if (!lower) return null;
+
+  const [base, ...rest] = lower.split("-");
+  const subtags = new Set(rest);
+
+  let candidate: Locale | null = null;
+
+  if (base === "zh") {
+    if (subtags.has("hant") || subtags.has("tw") || subtags.has("hk") || subtags.has("mo")) {
+      candidate = "zh-Hant";
+    } else {
+      // hans / cn / sg / my, and bare zh — see the note above.
+      candidate = "zh-Hans";
+    }
+  } else if (base === "en") {
+    candidate = "en";
+  }
+
+  // A locale we can name but do not publish is not a suggestion. This is what
+  // keeps the function honest when LOCALES shrinks: dropping a locale must
+  // stop it being offered, not leave a hint pointing at a 404.
+  return candidate && published.includes(candidate) ? candidate : null;
+}

--- a/next-app/src/locales/en.ts
+++ b/next-app/src/locales/en.ts
@@ -79,6 +79,8 @@ const en = {
     // surfaces if a future phase shows the Bangumi text to en as well.
     summaryFromBangumi: 'Summary from Bangumi',
     summaryFromLlm: 'Summary machine-translated from the English original',
+    summaryConverted: 'Summary converted from Simplified Chinese',
+    summaryConvertedFromLlm: 'Summary machine-translated, then converted to Traditional Chinese',
     linkCopied: 'Link copied!',
     linkCopyFailed: 'Copy failed — please copy the link manually',
     openPlayer: '▶ Play with Danmaku',

--- a/next-app/src/locales/zh-Hant.ts
+++ b/next-app/src/locales/zh-Hant.ts
@@ -152,6 +152,8 @@ const zhHant = {
     // community-written summary rather than AniList's description.
     summaryFromBangumi: '簡介來自 Bangumi',
     summaryFromLlm: '簡介由 AI 翻譯自英文原文',
+    summaryConverted: '簡介由簡體中文轉換',
+    summaryConvertedFromLlm: '簡介由 AI 翻譯自英文原文，再轉換為繁體',
     linkCopied: '連結已複製',
     linkCopyFailed: '複製失敗，請手動複製連結',
     openPlayer: '▶ 彈幕播放',

--- a/next-app/src/locales/zh.ts
+++ b/next-app/src/locales/zh.ts
@@ -130,6 +130,11 @@ const zh = {
     // community-written summary rather than AniList's description.
     summaryFromBangumi: '简介来自 Bangumi',
     summaryFromLlm: '简介由 AI 翻译自英文原文',
+    // Only reachable on the Traditional tree today, but every dictionary
+    // carries them: a key that exists in one dictionary and not another
+    // renders as its own key path, silently.
+    summaryConverted: '简介由简体中文转换',
+    summaryConvertedFromLlm: '简介由 AI 翻译自英文原文，再转换为繁体',
     linkCopied: '链接已复制',
     linkCopyFailed: '复制失败，请手动复制链接',
     openPlayer: '▶ 弹幕播放',


### PR DESCRIPTION
Three locales shipped in #91 with one way to move between them: a two-character
toggle in the navbar. A reader who did not already know the other trees existed
had no reason to look for it. This adds the two affordances that tell them, and
fixes a disclosure gap the third locale opened.

## A footer control that names the version you are reading

apple.com's pattern, checked rather than recalled. Neither apple.com nor
apple.com/tw carries a language banner, a modal, or any geo-detection UI; what
they have is one footer link stating the current version -- "United States",
"台灣" -- that opens a chooser.

Naming the version is the affordance. A reader who cannot tell which one they
are on has no reason to go looking for a switcher, and "繁" in a 56px navbar
does not tell them.

`LanguageMenu` grows a `named` variant for it: the full endonym instead of the
short label, popup opening upward because it is the last row of the document.
It deliberately carries no `aria-label` -- the compact trigger needs one
because it reads as a bare glyph, but here the text *is* the information and an
aria-label would replace it rather than add to it.

## A one-time offer, which is not Apple's pattern

`LocaleHint` is the Airbnb/Booking shape, kept separate because it answers a
different question: the footer says where you are, this says somewhere else
exists. Four things it does not do, each for a specific reason:

**It does not redirect.** Google's multi-regional guidance is explicit that
automatic language redirects stop users *and crawlers* from reaching the other
versions. Googlebot crawls from one place, so a redirect would hide two thirds
of this site from the index. It also could not work where it matters: /anime/*
is served from the Cloudflare edge on a hit, and proxy.ts does not run at all
on those requests.

**It reads nothing server-side.** No Accept-Language, no CF-IPCountry. The HTML
is byte-identical for every visitor, which is what keeps pages cacheable at the
edge and keeps a crawler from being served a variant. A test asserts the server
response contains none of the hint's markup.

**It does not enter the layout.** The navbar is `position: sticky`, so a bar
inserted above it in flow would push the document down after hydration -- a
layout shift on a first-time visitor's first view, which is the view Core Web
Vitals scores. It floats instead, and a test asserts the navbar does not move.

**It does not take focus.** It appears unprompted; taking the caret from
someone mid-sentence to offer them a translation is worse than not offering.
`role="status"` announces it politely.

The decision is a pure function, `preferredLocale`, so the one input that
cannot be reproduced in a unit test -- `navigator.languages` -- is the only
thing left in the component. 22 tests cover it, including that bare `zh`
resolves to Simplified (a coin flip in the standard, called this way because a
Traditional reader's browser almost always carries a region or script subtag,
and guessing Simplified fails into "no hint" rather than into a wrong hint) and
that only the *first* recognised tag counts, so `["zh-CN", "en"]` on the
Simplified tree suggests nothing rather than pulling the reader to English.

The copy is a Record keyed by locale, never a dictionary lookup, for the same
reason LOCALE_LABEL is not one: the entire message is "this exists in your
language", and it can only carry that if it is written in the language being
offered.

## A converted synopsis said nothing about being converted

Found while checking that synopses were actually trilingual. They are --
`description_hant` is an OpenCC conversion of `description_cn`, which is itself
either Bangumi's prose or the LLM translation -- but the attribution and the
`nosnippet` flag both named their sources individually:

    nosnippet={isBangumiSummary || isLlmSummary}

`opencc` is neither. So the identical prose was disclosed as machine-made on
/anime/:id and undisclosed on /zh-Hant/anime/:id, where Google was also free to
lift it as a snippet.

nosnippet is now computed from "is there any provenance at all" rather than
from a list of sources, so a tier added later is held out of snippets until
someone decides otherwise. Same direction of failure as title_hant_seo naming
the sources it admits instead of the one it excludes.

The label also inherits the honesty debt of what was converted: the Simplified
text under a zh-Hant page is usually the LLM translation, and "converted from
Simplified" alone would drop the more important half of that sentence. Two keys
rather than one -- `summaryConverted` and `summaryConvertedFromLlm` -- and both
land in all three dictionaries, because a key present in one and missing from
another renders as its own key path with no error.

## Verification

- `bun test` 1103 pass / 0 fail (+22 for preferredLocale)
- `bunx tsc --noEmit` clean; eslint ratchet unchanged at 88/102
- `bun run build` from a cleared .next, exit 0; assert-isr PASS
- E2E, against a real local stack: `locale-hint.spec.ts` 13/13 new,
  `locale-routing.spec.ts` 31/31
- Checked in a browser across seven language/path combinations, including that
  an English-preferring visitor on `/` is *not* switched -- URL unchanged,
  `html lang="zh-CN"`, Chinese `<h1>`, hint merely offered

One implementation note worth keeping: the hint uses `useSyncExternalStore`
rather than an effect that calls setState, because that is what it is -- a
value the server cannot know, read once on the client, changed by an event.
`getServerSnapshot` returning "decided" is what makes the server render nothing
without a second pass.
