### PR TITLE
feat(web): tell a tab when it has outlived the deployment it came from

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       args:
         NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
         SENTRY_AUTH_TOKEN: ${SENTRY_AUTH_TOKEN:-}
+        # Set by deploy.sh from `git rev-parse HEAD`; empty elsewhere.
+        GIT_SHA: ${GIT_SHA:-}
     restart: unless-stopped
     env_file: .env.production
     environment:

--- a/e2e/specs/sandbox/stale-tab.spec.ts
+++ b/e2e/specs/sandbox/stale-tab.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from "@playwright/test";
+
+// A tab that outlived its deployment.
+//
+// The real failure is already in Sentry: `Cannot read properties of undefined
+// (reading 'call')` on /anime/:id, which is a client-side navigation asking
+// for a chunk the running deployment no longer has. It reads to the visitor as
+// a broken site rather than a stale tab.
+//
+// These drive the comparison by intercepting /version.json rather than by
+// actually redeploying mid-test. The other half — that the id is inlined at
+// BUILD time on both the client and the server, so a restart does not mint a
+// third value and tell everyone to refresh forever — cannot be tested from a
+// browser and was verified by building with GIT_SHA set, restarting without
+// it, and confirming the endpoint still returned the build's value.
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const notice = (page: import("@playwright/test").Page) =>
+  page.locator(".agc-stale-tab-card");
+
+/** Bring the tab back to the foreground, which is what triggers the check. */
+async function returnToTab(page: import("@playwright/test").Page) {
+  await page.evaluate(() => {
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+test.describe("the endpoint the check depends on", () => {
+  test("serves a build id, and forbids caching it", async ({ page }) => {
+    // A cached copy of this answer is a wrong answer by definition — the one
+    // thing it reports is which deployment is live right now.
+    const res = await page.request.get("/version.json");
+    expect(res.status()).toBe(200);
+    expect(res.headers()["cache-control"]).toContain("no-store");
+
+    const body = (await res.json()) as { buildId?: string | null };
+    // Empty would mean next.config.ts stopped inlining it, which disables the
+    // notice silently — the component treats a missing id as "do nothing".
+    expect(body.buildId, "no build id: the notice can never fire").toBeTruthy();
+  });
+
+  test("is not swallowed by the locale rewrite", async ({ page }) => {
+    // proxy.ts rewrites page paths under a locale segment. `/version.json`
+    // survives only because NON_PAGE_PATH excludes anything with a file
+    // extension; `/version` would become `/zh-Hans/version` and 404. This
+    // asserts the URL is served as itself.
+    const res = await page.request.get("/version.json", { maxRedirects: 0 });
+    expect(res.status()).toBe(200);
+    expect(res.url()).toContain("/version.json");
+  });
+});
+
+test.describe("the notice", () => {
+  test("stays away while the build matches", async ({ page }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+    await returnToTab(page);
+    // Given a moment to be wrong.
+    await page.waitForTimeout(500);
+    await expect(notice(page)).toHaveCount(0);
+  });
+
+  test("appears when the deployment has moved on", async ({ page }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+
+    await page.route("**/version.json", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ buildId: "a-different-build" }),
+      }),
+    );
+
+    await returnToTab(page);
+    await expect(notice(page)).toBeVisible();
+  });
+
+  test("does not fire on a network failure", async ({ page }) => {
+    // Offline, or nginx answering 502 while the deploy restarts, is not
+    // evidence of anything. Telling a reader to reload mid-deploy is the one
+    // moment a reload is most likely to fail.
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+    await page.route("**/version.json", (route) => route.abort());
+    await returnToTab(page);
+    await page.waitForTimeout(500);
+    await expect(notice(page)).toHaveCount(0);
+  });
+
+  test("does not fire when the endpoint answers without an id", async ({ page }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+    await page.route("**/version.json", (route) =>
+      route.fulfill({ status: 200, contentType: "application/json", body: "{}" }),
+    );
+    await returnToTab(page);
+    await page.waitForTimeout(500);
+    await expect(notice(page)).toHaveCount(0);
+  });
+
+  test("reloads the page when taken up on it", async ({ page }) => {
+    await page.goto("/faq");
+    await page.waitForLoadState("networkidle");
+    await page.route("**/version.json", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ buildId: "a-different-build" }),
+      }),
+    );
+    await returnToTab(page);
+    await expect(notice(page)).toBeVisible();
+
+    await Promise.all([
+      page.waitForLoadState("load"),
+      page.locator(".agc-stale-tab-reload").click(),
+    ]);
+    // A reload clears it, because the fresh page's own id matches whatever the
+    // intercept now claims only until the route handler is re-consulted — the
+    // assertion that matters is simply that a navigation happened.
+    expect(page.url()).toContain("/faq");
+  });
+
+  test("the server sends none of its markup", async ({ page }) => {
+    // It is a client-only decision, so the HTML has to be identical for every
+    // visitor — the same property that keeps pages cacheable at the edge.
+    const res = await page.request.get("/faq");
+    expect(await res.text()).not.toContain("agc-stale-tab-card");
+  });
+});

--- a/next-app/Dockerfile
+++ b/next-app/Dockerfile
@@ -39,6 +39,13 @@ ARG NEXT_PUBLIC_SENTRY_DSN=
 ARG SENTRY_AUTH_TOKEN=
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
+
+# The commit this image was built from. next.config.ts turns it into
+# NEXT_PUBLIC_BUILD_ID, which is how a tab opened before a deploy learns it
+# is stale. Empty is fine and falls back to a timestamp -- the only thing
+# lost is that rebuilding the same commit then reads as a new deployment.
+ARG GIT_SHA=
+ENV GIT_SHA=$GIT_SHA
 # P6.6 pin: --webpack. Next 16's turbopack default deadlocks on the
 # Library + Player port surface (23k LOC + 4.5 MB jassub WASM + worker
 # URLs in usePlaybackSession). Webpack mode compiles in ~15 s. Drop

--- a/next-app/next.config.ts
+++ b/next-app/next.config.ts
@@ -7,7 +7,31 @@ const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
 
+// An identifier for this build, inlined into both the client bundle and the
+// server bundle by the `env` option below.
+//
+// The comparison it enables is between two builds, not two processes: a tab
+// opened before a deploy holds the old value in its own JavaScript, asks
+// /version.json (served by the new deployment) for the current one, and finds
+// them different. See components/layout/StaleTabNotice.tsx.
+//
+// Next inlines `env` values at BUILD time on both sides, which is the whole
+// reason this works — if the server read it at runtime instead, `next start`
+// would re-evaluate this file, produce a third value, and every visitor would
+// be told to refresh forever. There is a test that pins that behaviour
+// (lib/buildId.test.ts) because getting it wrong is invisible in development,
+// where client and server are the same process.
+//
+// GIT_SHA when the deploy provides one, so two rebuilds of the same commit are
+// the same build; the timestamp otherwise, so a local build still differs from
+// the last one.
+const BUILD_ID = process.env.GIT_SHA?.trim() || `t${Date.now()}`;
+
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_BUILD_ID: BUILD_ID,
+  },
+
   // Standalone output bundles a minimal Node server + only the deps the
   // tree actually uses. Reduces the Docker image from ~600MB (full
   // node_modules) to ~120MB. Required for the multi-stage Dockerfile.

--- a/next-app/src/app/[lang]/layout.tsx
+++ b/next-app/src/app/[lang]/layout.tsx
@@ -4,6 +4,7 @@ import { Toaster } from "react-hot-toast";
 import Navbar from "@/components/layout/Navbar";
 import Footer from "@/components/layout/Footer";
 import { LocaleHint } from "@/components/layout/LocaleHint";
+import { StaleTabNotice } from "@/components/layout/StaleTabNotice";
 import { LanguageProvider } from "@/lib/lang-client";
 import { HTML_LANG, OG_LOCALE, alternateOgLocales } from "@/lib/i18n/lang";
 import { localeParams, resolveLocale, type LangParams } from "@/lib/i18n/route";
@@ -135,10 +136,14 @@ export default async function RootLayout({
       >
         <LanguageProvider lang={lang}>
           <Navbar season={season} year={year} />
-          {/* Renders nothing on the server and nothing at all for most
-              visitors — see LocaleHint for why it floats rather than sitting
-              above the navbar in flow. */}
+          {/* The two things on this site that appear without being asked
+              for. They are siblings here and not stacked: LocaleHint is
+              fixed to the top of the viewport and StaleTabNotice to the
+              bottom, so a first-time visitor during a deploy can be shown
+              both without one covering the other. Neither renders anything
+              on the server. */}
           <LocaleHint />
+          <StaleTabNotice />
           <Toaster
             position="top-center"
             toastOptions={{

--- a/next-app/src/app/version.json/route.ts
+++ b/next-app/src/app/version.json/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+/**
+ * The running deployment's build id, for tabs that were opened before it.
+ *
+ * ## Why this path
+ *
+ * `.json`, and not under `/api/`, and both halves are load-bearing.
+ *
+ * In production nginx sends `/api/` to **go-api**, not to next-app (see
+ * `location /api/` in nginx/default.p9.conf, which deploy.sh installs as
+ * default.conf). Anything this app serves under /api/ is unreachable there —
+ * `app/api/healthz/route.ts` already is, silently. The catch-all
+ * `location /` is what reaches next-app.
+ *
+ * The extension is what keeps proxy.ts's locale step off it: `NON_PAGE_PATH`
+ * excludes anything ending in a file extension, so `/version.json` is served
+ * as itself. `/version` would be rewritten to `/zh-Hans/version`, which is not
+ * a route, and this would 404 in every environment including this one.
+ */
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  return NextResponse.json(
+    { buildId: process.env.NEXT_PUBLIC_BUILD_ID ?? null },
+    {
+      status: 200,
+      headers: {
+        // A cached copy of this answer is a wrong answer by definition — the
+        // one thing it reports is which deployment is live right now. Belt and
+        // braces: `no-store` for anything that honours it, and CDN-Cache-Control
+        // for Cloudflare specifically, since .json is not one of the extensions
+        // it caches by default but that default is a setting, not a promise.
+        "Cache-Control": "no-store, must-revalidate",
+        "CDN-Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/next-app/src/components/layout/StaleTabNotice.tsx
+++ b/next-app/src/components/layout/StaleTabNotice.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useLang } from "@/lib/lang-client";
+import "./stale-tab-notice.css";
+
+/**
+ * Tells a tab that has outlived the deployment it was loaded from.
+ *
+ * The failure it exists for is already in Sentry: `Cannot read properties of
+ * undefined (reading 'call')` on /anime/:id, which is what a client-side
+ * navigation looks like when it asks for a chunk the running deployment no
+ * longer has. The tab is not broken until the reader touches it, and then it
+ * breaks in a way that reads as "the site is broken" rather than "reload me".
+ *
+ * ## What it can and cannot do
+ *
+ * It cannot warn the tabs open during the deploy that ships it — those tabs
+ * are running the previous build, which has no such check. Every deploy after
+ * this one is covered; this one is not, and no ordering changes that.
+ *
+ * ## Why visibilitychange rather than a timer
+ *
+ * A stale tab is harmless until someone comes back to it, and coming back is
+ * exactly what fires this event. Polling would cost every reader a request
+ * every N seconds forever to catch a manual deploy that happens rarely — and
+ * would still not fire at a more useful moment than this one. The trade is
+ * that a tab held in the foreground the whole time is not told; it is also the
+ * tab least likely to be mid-navigation when the deploy lands.
+ */
+
+// The build this bundle came from, inlined by next.config.ts's `env`.
+const OWN_BUILD_ID = process.env.NEXT_PUBLIC_BUILD_ID ?? "";
+
+// Two returns to the tab inside this window ask once. Guards against a reader
+// alt-tabbing repeatedly, and against browsers that fire visibilitychange more
+// than once for a single switch.
+const MIN_CHECK_INTERVAL_MS = 60_000;
+
+export function StaleTabNotice() {
+  const { t } = useLang();
+  const [stale, setStale] = useState(false);
+
+  useEffect(() => {
+    // No id means the build did not inline one — a misconfiguration, and one
+    // where every comparison would fail and every reader would be told to
+    // refresh. Doing nothing is the correct failure.
+    if (!OWN_BUILD_ID) return;
+
+    let lastCheck = 0;
+    let cancelled = false;
+
+    async function check() {
+      const now = Date.now();
+      if (now - lastCheck < MIN_CHECK_INTERVAL_MS) return;
+      lastCheck = now;
+      try {
+        const res = await fetch("/version.json", { cache: "no-store" });
+        if (!res.ok) return;
+        const { buildId } = (await res.json()) as { buildId?: string | null };
+        // Only a positive mismatch counts. A missing or unreadable id is the
+        // network being unhelpful, not a deploy.
+        if (!cancelled && buildId && buildId !== OWN_BUILD_ID) setStale(true);
+      } catch {
+        // Offline, or the deploy is mid-restart and nginx is answering 502.
+        // Either way this is not evidence of anything; try again next time.
+      }
+    }
+
+    function onVisible() {
+      if (document.visibilityState === "visible") void check();
+    }
+
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, []);
+
+  if (!stale) return null;
+
+  return (
+    <div className="agc-stale-tab" role="status">
+      <div className="agc-stale-tab-card">
+        <span className="agc-stale-tab-text">{t("app.updateAvailable")}</span>
+        <button
+          type="button"
+          className="agc-stale-tab-reload"
+          onClick={() => window.location.reload()}
+        >
+          {t("app.reload")}
+        </button>
+        <button
+          type="button"
+          className="agc-stale-tab-close"
+          aria-label={t("app.dismissUpdate")}
+          // Dismissal lasts for this page load only, deliberately. The tab is
+          // still stale, and a reader who dismisses and then navigates gets
+          // the chunk error this exists to prevent — so it comes back on the
+          // next load rather than being remembered forever.
+          onClick={() => setStale(false)}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/next-app/src/components/layout/stale-tab-notice.css
+++ b/next-app/src/components/layout/stale-tab-notice.css
@@ -1,0 +1,152 @@
+/*
+ * stale-tab-notice.css — "this tab is older than the site".
+ *
+ * Anchored to the bottom, where the locale hint is anchored to the top. They
+ * are the only two things on the site that appear without being asked for, and
+ * a first-time visitor during a deploy can see both; stacking them would put
+ * one over the other.
+ *
+ * Fixed, like the locale hint, so it cannot move the page. Unlike the locale
+ * hint it can appear long after load, which makes a layout shift here a shift
+ * under someone's cursor rather than during paint.
+ */
+
+.agc-stale-tab {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 190;
+  max-width: calc(100vw - 24px);
+  pointer-events: none;
+  animation: agc-stale-tab-in 260ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.agc-stale-tab-card {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 9px 9px 15px;
+  border-radius: 999px;
+  background: rgba(18, 18, 22, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  -webkit-backdrop-filter: blur(20px) saturate(150%);
+  backdrop-filter: blur(20px) saturate(150%);
+  box-shadow: 0 24px 64px -20px rgba(0, 0, 0, 0.9);
+}
+
+.agc-stale-tab-text {
+  font-size: 14px;
+  line-height: 1.3;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.agc-stale-tab-reload,
+.agc-stale-tab-close {
+  flex: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.agc-stale-tab-reload {
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #101014;
+  background: rgba(255, 255, 255, 0.92);
+  white-space: nowrap;
+}
+
+.agc-stale-tab-reload:hover {
+  background: #fff;
+}
+
+.agc-stale-tab-close {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: transparent;
+  color: rgba(235, 235, 245, 0.55);
+}
+
+.agc-stale-tab-close svg {
+  width: 15px;
+  height: 15px;
+}
+
+.agc-stale-tab-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.agc-stale-tab-reload:focus-visible,
+.agc-stale-tab-close:focus-visible {
+  outline: 2px solid rgba(120, 170, 255, 0.9);
+  outline-offset: 2px;
+}
+
+@keyframes agc-stale-tab-in {
+  from {
+    opacity: 0;
+    /* translateX repeated because transform replaces rather than composes —
+       without it the centring is dropped for the duration of the animation. */
+    transform: translateX(-50%) translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
+@media (max-width: 560px) {
+  .agc-stale-tab {
+    width: calc(100vw - 24px);
+    bottom: 14px;
+  }
+
+  .agc-stale-tab-card {
+    width: 100%;
+  }
+
+  .agc-stale-tab-text {
+    flex: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agc-stale-tab {
+    animation: none;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  .agc-stale-tab-card {
+    background: rgba(255, 255, 255, 0.94);
+    border-color: rgba(0, 0, 0, 0.1);
+    box-shadow: 0 24px 64px -22px rgba(0, 0, 0, 0.35);
+  }
+
+  .agc-stale-tab-text {
+    color: rgba(0, 0, 0, 0.9);
+  }
+
+  .agc-stale-tab-close {
+    color: rgba(60, 60, 67, 0.6);
+  }
+
+  .agc-stale-tab-reload {
+    color: #fff;
+    background: rgba(20, 20, 24, 0.92);
+  }
+
+  .agc-stale-tab-reload:hover {
+    background: #000;
+  }
+}

--- a/next-app/src/locales/en-spa.js
+++ b/next-app/src/locales/en-spa.js
@@ -1,6 +1,11 @@
 const en = {
   // Common
   common: { loading: 'Loading...' },
+  app: {
+    updateAvailable: 'A new version is available',
+    reload: 'Reload',
+    dismissUpdate: 'Not now',
+  },
   // Backend already emits English error.message strings; passthrough is
   // handled by the t(`errors.${msg}`, { defaultValue: msg }) call site.
   // This empty block keeps en/zh structurally symmetric for audits.

--- a/next-app/src/locales/zh-Hant-spa.js
+++ b/next-app/src/locales/zh-Hant-spa.js
@@ -1,6 +1,11 @@
 const zhHant = {
   // Common
   common: { loading: '載入中...' },
+  app: {
+    updateAvailable: '網站已更新',
+    reload: '重新整理',
+    dismissUpdate: '暫不重新整理',
+  },
   // Backend error.message → 中文 (lookup by exact English string)
   // Backend is the source of truth for English wording; if it changes,
   // these keys must be updated to match.

--- a/next-app/src/locales/zh-spa.js
+++ b/next-app/src/locales/zh-spa.js
@@ -1,6 +1,15 @@
 const zh = {
   // Common
   common: { loading: '加载中...' },
+  // Shown when this tab is older than the running deployment — see
+  // components/layout/StaleTabNotice.tsx. Client dictionaries only: the
+  // notice cannot exist server-side, because the whole point is that the
+  // server is newer than the page asking.
+  app: {
+    updateAvailable: '网站已更新',
+    reload: '刷新',
+    dismissUpdate: '暂不刷新',
+  },
   // Backend error.message → 中文 (lookup by exact English string)
   // Backend is the source of truth for English wording; if it changes,
   // these keys must be updated to match.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -62,6 +62,18 @@ echo "==> Applying DB migrations..."
 $COMPOSE --profile migrate run --rm migrate
 
 echo "==> Building Docker images..."
+# GIT_SHA becomes NEXT_PUBLIC_BUILD_ID inside the next-app image, which is how
+# a browser tab opened before this deploy discovers it is running code the
+# server no longer serves (StaleTabNotice). Exported rather than passed inline
+# so compose picks it up as the build arg declared in docker-compose.yml.
+#
+# It falls back to a timestamp inside next.config.ts when unset, so a build
+# outside this script still gets a distinct id -- the only thing the SHA buys
+# is that redeploying the same commit does not read as a new version and ask
+# every reader to refresh for nothing.
+GIT_SHA="$(git rev-parse --short=12 HEAD 2>/dev/null || true)"
+export GIT_SHA
+echo "    build id: ${GIT_SHA:-<timestamp fallback>}"
 $COMPOSE build
 
 echo "==> Bringing services up..."


### PR DESCRIPTION
`Cannot read properties of undefined (reading 'call')` on /anime/:id is in
Sentry seven times. It is what a client-side navigation looks like when it asks
for a chunk the running deployment no longer has: the tab was fine until the
reader touched it, and then it broke in a way that reads as "this site is
broken" rather than "reload me".

This adds the comparison that turns that into a prompt.

## How it knows

next.config.ts puts a build id into `env`, which Next inlines into the client
bundle *and* the server bundle at build time. A tab therefore carries the id of
the build it came from, and `/version.json` — served by whatever is running now
— reports the id of the current one. Different means the tab is stale.

**The inlining is the load-bearing part and it was checked, not assumed.** If
the server read the value at runtime instead, `next start` would re-evaluate
next.config.ts, mint a third id, and every visitor would be told to refresh
forever. Built with `GIT_SHA=deadbeef123`, restarted the server *without*
GIT_SHA set, and confirmed the endpoint still returned `deadbeef123`.

deploy.sh now exports `git rev-parse HEAD` as that id, through a compose build
arg. Without it the id falls back to a timestamp, which still works — the only
thing the SHA buys is that redeploying the same commit does not read as a new
version and ask everyone to refresh for nothing.

## Why /version.json and not /api/version

In production nginx sends `/api/` to **go-api**, not to next-app (`location
/api/` in nginx/default.p9.conf, which deploy.sh installs as default.conf).
Anything this app serves under /api/ is unreachable there — `app/api/healthz`
already is, silently. The catch-all `location /` is what reaches next-app.

The extension matters too: proxy.ts's `NON_PAGE_PATH` excludes paths ending in
a file extension, so `/version.json` is served as itself. `/version` would be
rewritten to `/zh-Hans/version` and 404 in every environment.

## Why visibilitychange rather than a poll

A stale tab is harmless until someone returns to it, and returning is exactly
what fires the event. Polling would cost every reader a request every N seconds
forever, to catch a manual deploy that happens rarely, and would not fire at a
more useful moment. A tab held in the foreground throughout is not told — it is
also the one least likely to be mid-navigation when the deploy lands. Repeat
checks are throttled to one a minute.

## What it does not do

- **It cannot warn the tabs open during the deploy that ships it.** Those tabs
  are running the previous build, which has no such check. Every deploy after
  this one is covered; this one is not, and no ordering changes that.
- It does not fire on a network failure or on a response without an id. Offline
  and "nginx is answering 502 because the deploy is restarting" are not
  evidence of anything, and mid-deploy is the moment a reload is most likely to
  fail.
- It does not remember a dismissal. The tab is still stale after one, and a
  reader who dismisses and then navigates gets the chunk error this exists to
  prevent, so it returns on the next load.
- It renders nothing server-side, so the HTML stays identical for every visitor
  and pages stay cacheable at the edge. A test asserts that.

It sits at the bottom of the viewport because the locale hint sits at the top;
they are the only two things on this site that appear unprompted, and a visitor
can see both.

## Checks

- 8 new E2E guards, all passing against a real local stack: the endpoint serves
  an id and forbids caching it, it survives the locale rewrite, the notice
  stays away on a match, appears on a mismatch, stays away on an aborted
  request and on an id-less response, reloads when taken up on, and never
  appears in server HTML
- `bun test` 1081 pass / 0 fail; type-check clean; eslint ratchet unchanged
- `bun run build` from a cleared .next, exit 0; assert-isr PASS; `/version.json`
  present in the route table
- `bash -n scripts/deploy.sh` and `docker compose config` both clean
