### PR TITLE
fix(home): stop the hero rail from scrolling the page back to itself

### DIFF
--- a/next-app/src/components/anime/HeroCarousel.tsx
+++ b/next-app/src/components/anime/HeroCarousel.tsx
@@ -100,11 +100,28 @@ export default function HeroCarousel({ animeList, dict, lang }: HeroCarouselProp
     };
   }, [currentIndex, isPaused, len, next]);
 
+  // Centre the active item in the rail's own scroller — and nothing else.
+  //
+  // This was `activeRailRef.current.scrollIntoView({block: "nearest", inline:
+  // "center"})`, which walks EVERY scrollable ancestor, the document included.
+  // The intent was only ever the rail's horizontal overflow (it scrolls at
+  // ≤900px; above that the five items are a grid that fits). What it actually
+  // did was scroll the page: a reader who had scrolled past the hero got yanked
+  // back to it on the next rotation, every five seconds. `block: "nearest"` is
+  // a no-op when the element is already visible, which is exactly why this
+  // survived review — it is invisible until someone scrolls away and waits.
+  //
+  // Setting scrollLeft on the container cannot move anything but the container.
   useEffect(() => {
-    activeRailRef.current?.scrollIntoView({
+    const item = activeRailRef.current;
+    const list = item?.parentElement;
+    if (!item || !list) return;
+    if (list.scrollWidth <= list.clientWidth) return;
+
+    const centred = item.offsetLeft - (list.clientWidth - item.clientWidth) / 2;
+    list.scrollTo({
+      left: Math.max(0, Math.min(centred, list.scrollWidth - list.clientWidth)),
       behavior: prefersReducedMotion ? "auto" : "smooth",
-      block: "nearest",
-      inline: "center",
     });
   }, [currentIndex, prefersReducedMotion]);
 


### PR DESCRIPTION
Scroll past the hero on the homepage and, within a rotation, the page yanks back up to it. Reproduced against production: scroll to `y=1400`, and 700ms later the document is at `y=476` and cannot be moved past it while the carousel is running.

The cause is one call. The rail centres its active item with

```js
activeRailRef.current.scrollIntoView({ block: "nearest", inline: "center" })
```

and `scrollIntoView` walks **every** scrollable ancestor, the document included. The intent was only ever the rail's own horizontal overflow — it scrolls at ≤900px, and above that the five items are a grid that already fits. What it actually did was scroll the window, once per slide, forever.

`block: "nearest"` is why this survived review: it is a no-op whenever the element is already visible, so the bug does not exist until a reader scrolls away and waits five seconds. Every check that looks at the hero looks at it while it is on screen — including the Playwright pass on this branch's parent.

Setting `scrollLeft` on the container cannot move anything but the container, so the fix computes the centred offset and calls `list.scrollTo`. The early return when the rail is not overflowing keeps the desktop case doing nothing at all, which is what it was supposed to do before.

## Test plan

- [x] 1440 (rail not scrollable): `window.scrollY` holds at 1400 across 14s — more than two rotations
- [x] 768 (rail scrollable): `scrollY` holds at 1400 **and** the rail reaches `scrollLeft=112`, so the centring it exists for still happens
- [x] `tsc --noEmit` clean, 1435 unit tests pass, eslint ratchet OK
- [ ] Manual on production after deploy: scroll to the community section and stay there through two rotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)