### PR TITLE
fix(home): give the hero a Chinese synopsis, and widen the trending row

### DIFF
--- a/go-api/internal/db/gen/anime_cache.sql.go
+++ b/go-api/internal/db/gen/anime_cache.sql.go
@@ -1121,6 +1121,20 @@ SELECT
     status,
     format,
     description,
+    -- The Chinese synopsis channels, carried for the same reason title_hant is
+    -- carried: this endpoint returns every variant and the Next layer picks one
+    -- with pickDescription(). Without them the homepage hero — which reads the
+    -- top 5 of this list — printed an English synopsis under a Chinese title,
+    -- on a site whose whole acquisition channel is Chinese search.
+    --
+    -- The two *_source columns come along even though nothing renders them yet.
+    -- pickDescription() answers a missing source field with null rather than an
+    -- error, so omitting them would leave a future source badge silently blank
+    -- instead of obviously broken — and they are ten bytes each.
+    description_cn,
+    description_cn_source,
+    description_hant,
+    description_hant_source,
     ARRAY(
         SELECT g.genre
         FROM anime_genres g
@@ -1145,28 +1159,32 @@ LIMIT $3 OFFSET $4
 `
 
 type GetSeasonalAnimeRow struct {
-	AnilistID       int32    `json:"anilistId"`
-	TitleRomaji     *string  `json:"titleRomaji"`
-	TitleEnglish    *string  `json:"titleEnglish"`
-	TitleNative     *string  `json:"titleNative"`
-	TitleChinese    *string  `json:"titleChinese"`
-	TitleHant       *string  `json:"titleHant"`
-	TitleHantSource *string  `json:"titleHantSource"`
-	TitleHantSeo    *string  `json:"titleHantSeo"`
-	CoverImageUrl   *string  `json:"coverImageUrl"`
-	BannerImageUrl  *string  `json:"bannerImageUrl"`
-	CoverImageColor *string  `json:"coverImageColor"`
-	PosterAccent    *string  `json:"posterAccent"`
-	AverageScore    *float64 `json:"averageScore"`
-	BangumiScore    *float64 `json:"bangumiScore"`
-	Episodes        *int32   `json:"episodes"`
-	Season          *string  `json:"season"`
-	SeasonYear      *int32   `json:"seasonYear"`
-	Status          *string  `json:"status"`
-	Format          *string  `json:"format"`
-	Description     *string  `json:"description"`
-	Genres          []string `json:"genres"`
-	DiscussionCount int64    `json:"discussionCount"`
+	AnilistID             int32    `json:"anilistId"`
+	TitleRomaji           *string  `json:"titleRomaji"`
+	TitleEnglish          *string  `json:"titleEnglish"`
+	TitleNative           *string  `json:"titleNative"`
+	TitleChinese          *string  `json:"titleChinese"`
+	TitleHant             *string  `json:"titleHant"`
+	TitleHantSource       *string  `json:"titleHantSource"`
+	TitleHantSeo          *string  `json:"titleHantSeo"`
+	CoverImageUrl         *string  `json:"coverImageUrl"`
+	BannerImageUrl        *string  `json:"bannerImageUrl"`
+	CoverImageColor       *string  `json:"coverImageColor"`
+	PosterAccent          *string  `json:"posterAccent"`
+	AverageScore          *float64 `json:"averageScore"`
+	BangumiScore          *float64 `json:"bangumiScore"`
+	Episodes              *int32   `json:"episodes"`
+	Season                *string  `json:"season"`
+	SeasonYear            *int32   `json:"seasonYear"`
+	Status                *string  `json:"status"`
+	Format                *string  `json:"format"`
+	Description           *string  `json:"description"`
+	DescriptionCn         *string  `json:"descriptionCn"`
+	DescriptionCnSource   *string  `json:"descriptionCnSource"`
+	DescriptionHant       *string  `json:"descriptionHant"`
+	DescriptionHantSource *string  `json:"descriptionHantSource"`
+	Genres                []string `json:"genres"`
+	DiscussionCount       int64    `json:"discussionCount"`
 }
 
 // Paginated season listing.  Backs /api/anime/seasonal (cache-first path)
@@ -1216,6 +1234,10 @@ func (q *Queries) GetSeasonalAnime(ctx context.Context, season *string, seasonYe
 			&i.Status,
 			&i.Format,
 			&i.Description,
+			&i.DescriptionCn,
+			&i.DescriptionCnSource,
+			&i.DescriptionHant,
+			&i.DescriptionHantSource,
 			&i.Genres,
 			&i.DiscussionCount,
 		); err != nil {

--- a/go-api/internal/db/queries/anime_cache.sql
+++ b/go-api/internal/db/queries/anime_cache.sql
@@ -110,6 +110,20 @@ SELECT
     status,
     format,
     description,
+    -- The Chinese synopsis channels, carried for the same reason title_hant is
+    -- carried: this endpoint returns every variant and the Next layer picks one
+    -- with pickDescription(). Without them the homepage hero — which reads the
+    -- top 5 of this list — printed an English synopsis under a Chinese title,
+    -- on a site whose whole acquisition channel is Chinese search.
+    --
+    -- The two *_source columns come along even though nothing renders them yet.
+    -- pickDescription() answers a missing source field with null rather than an
+    -- error, so omitting them would leave a future source badge silently blank
+    -- instead of obviously broken — and they are ten bytes each.
+    description_cn,
+    description_cn_source,
+    description_hant,
+    description_hant_source,
     ARRAY(
         SELECT g.genre
         FROM anime_genres g

--- a/next-app/src/app/[lang]/page.tsx
+++ b/next-app/src/app/[lang]/page.tsx
@@ -83,7 +83,11 @@ async function safeSeasonal(
 
 async function safeTrending(): Promise<TrendingItem[]> {
   try {
-    return await apiGet<TrendingItem[]>("/api/anime/trending?limit=10", {
+    // 14, not 10. The grid is `repeat(auto-fill, minmax(160px, 1fr))`, so the
+    // extra four fill the row that ten already left ragged at most widths. The
+    // server needs nothing: Trending caches maxLimit (20) rows and slices to
+    // the per-request limit after the cache lookup, so this stays one fetch.
+    return await apiGet<TrendingItem[]>("/api/anime/trending?limit=14", {
       revalidate: 60,
     });
   } catch (err) {

--- a/next-app/src/components/anime/HeroCarousel.tsx
+++ b/next-app/src/components/anime/HeroCarousel.tsx
@@ -2,7 +2,7 @@
 
 import Link from "@/components/ui/LocaleLink";
 import { genreLabel } from "@/lib/contentLabels";
-import { pickTitle, stripHtml, truncate } from "@/lib/formatters";
+import { pickDescription, pickTitle, stripHtml, truncate } from "@/lib/formatters";
 import type { Dict, Lang } from "@/lib/i18n";
 import { useLang } from "@/lib/lang-client";
 import type { SeasonalAnime } from "@/lib/types";
@@ -12,9 +12,18 @@ import styles from "./HeroCarousel.module.css";
 
 const INTERVAL_MS = 5000;
 
+// The seasonal endpoint returns more than SeasonalAnime declares — banner,
+// description and the genre array have always arrived here undeclared, and the
+// Chinese synopsis channels join them now. Declared beside `description`
+// rather than on SeasonalAnime because that is where the untyped-but-present
+// fields already live; moving the whole set up is a separate job.
 type CarouselAnime = SeasonalAnime & {
   bannerImageUrl?: string | null;
   description?: string | null;
+  descriptionCn?: string | null;
+  descriptionCnSource?: string | null;
+  descriptionHant?: string | null;
+  descriptionHantSource?: string | null;
   genres?: string[];
 };
 
@@ -180,9 +189,14 @@ export default function HeroCarousel({ animeList, dict, lang }: HeroCarouselProp
         const desktopArt = anime.bannerImageUrl || anime.coverImageUrl || "";
         const mobileArt = anime.coverImageUrl || desktopArt;
         const title = pickTitle(anime, lang);
-        const description = anime.description
-          ? truncate(stripHtml(anime.description), 130)
-          : null;
+        // Same ladder the detail page uses. This read `anime.description`
+        // directly, which is the AniList English synopsis — so the hero printed
+        // English prose under a Chinese title, on the one surface every visitor
+        // sees first. pickDescription falls back to exactly that string when no
+        // Chinese synopsis exists, so nothing goes blank; it just stops being
+        // the only option.
+        const synopsis = pickDescription(anime, lang).text;
+        const description = synopsis ? truncate(stripHtml(synopsis), 130) : null;
 
         return (
           <article


### PR DESCRIPTION
The hero printed an **English synopsis under a Chinese title**, on the one surface every visitor sees first, on a site whose entire acquisition channel is Chinese search. It read `anime.description` directly — the AniList string — because that was the only description `/api/anime/seasonal` returned.

`pickDescription()` and the whole `descriptionCn` / `descriptionHant` ladder already existed for the detail page. The data simply never reached the homepage.

So `GetSeasonalAnime` now carries the two Chinese synopsis channels alongside the title variants it already carried, and the hero picks with the same helper the detail page uses. A Traditional reader gets `description_hant` when it exists and Simplified when it does not — the ladder's documented intent, because an English synopsis is a different language and Simplified prose is not.

**The payload objection was measured, not assumed.** `/api/anime/seasonal` is fetched only by server components — two `page.tsx` call sites, no browser fetch anywhere in the tree — so the extra columns travel next-app → go-api over the Docker network on one host and never reach a reader. Descriptions were already 35% of that response (7.9KB of 22.2KB across 20 rows).

The two `*_source` columns come along even though nothing renders them yet. `pickDescription()` answers a missing source field with `null` rather than an error, so leaving them out would make a future source badge silently blank instead of obviously broken — and they are ten bytes each.

## Trending: 10 → 14

The grid is `repeat(auto-fill, minmax(160px, 1fr))`, so the extra four fill the row ten left ragged at most widths. No server change is needed: `Trending` caches `maxLimit` (20) rows and slices to the per-request limit *after* the cache lookup, and `parseLimit(qs.Get("limit"), 10, 20)` already accepts 14.

## Test plan

- [x] `go build` / `go vet` / `go test ./...` clean, plus `go vet -tags=integration ./...`
- [x] `tsc --noEmit` clean, 1435 unit tests pass, eslint ratchet OK
- [x] Against a locally rebuilt go-api, `/api/anime/seasonal` returns `descriptionCn`
- [x] Hero renders Chinese at `/`, English at `/en`, and the Simplified fallback at `/zh-Hant` (local DB has no hant backfill, which is the fallback arm)
- [x] Production `/api/anime/trending?limit=14` returns 14 rows
- [ ] After deploy: confirm `/zh-Hant` gets Traditional rather than the Simplified fallback, since production *does* have `description_hant`

## Note, not part of this change

The Simplified synopsis for BLEACH contains an untranslated word — "各 realm 开始". That is an artifact in `description_cn` from the LLM translation tier, not something this diff touches. Worth a look at the enrichment output separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)