### PR TITLE
test(library): catch a cover that renders but never decodes

### DIFF
--- a/e2e/fixtures/dexie-seed.ts
+++ b/e2e/fixtures/dexie-seed.ts
@@ -243,6 +243,20 @@ export interface SeedSeriesSpec {
    * is why the default below falls back to `titleZh` instead of a generic name.
    */
   titleEn?: string;
+  /**
+   * Cover URL, as the dandanplay match writes it. Defaults to "" — which is a
+   * blind spot worth naming: with no poster, `SeriesCard`'s `safePoster` guard
+   * resolves to null and the card renders its monogram fallback, so the page
+   * makes NO image request at all. Every library spec was therefore green
+   * through the 3.13.0 next/image migration that left /library rendering 26
+   * empty cards and 115 console 400s.
+   *
+   * Seed a real URL to exercise the image path. Use a NON-AniList host: the
+   * whole point is that these covers come from wherever the match returned,
+   * and `remotePatterns` only allows s4.anilist.co, so a call site that
+   * forgets `unoptimized` 400s here and silently renders nothing.
+   */
+  posterUrl?: string;
   totalEpisodes?: number;
   /** The v6 binding. Omit to seed a series watch sync must skip as unbound. */
   anilistId?: number;
@@ -396,7 +410,7 @@ export async function seedLibrary(
           titleZh: spec.titleZh ?? `E2E 测试系列 ${i + 1}`,
           titleEn: spec.titleEn ?? spec.titleZh ?? `E2E Test Series ${i + 1}`,
           type: "tv",
-          posterUrl: "",
+          posterUrl: spec.posterUrl ?? "",
           totalEpisodes: spec.totalEpisodes ?? 12,
           confidence: 1.0,
           createdAt: now - i * 1000,

--- a/e2e/specs/sandbox/library.spec.ts
+++ b/e2e/specs/sandbox/library.spec.ts
@@ -42,6 +42,67 @@ test.describe("/library — sandbox journeys", () => {
     ).toEqual([]);
   });
 
+  // Regression: 3.13.0 moved FadeImage onto next/image and /library rendered
+  // 26 empty cards with 115 console 400s. `remotePatterns` allows only
+  // s4.anilist.co, while these covers are whatever the dandanplay match
+  // returned — img.dandanplay.net, a bgm mirror, sometimes plain http. The
+  // optimizer 400s on those and FadeImage has no onError, so nothing appears.
+  //
+  // Nothing caught it. The build, the type check and the lint cannot: it is a
+  // runtime host check against an optional prop. The library specs could not
+  // either, because the fixture seeded `posterUrl: ""` and the card fell back
+  // to its monogram — the page never requested an image.
+  //
+  // Two assertions, because either alone would have missed it:
+  //   · the src must not be routed through /_next/image — the actual rule
+  //   · naturalWidth > 0 — the element, its box and its layout were all
+  //     correct while it was broken; only the decode was missing, so every
+  //     visibility- or geometry-based check was blind to it
+  test("library cover from a non-AniList host actually loads", async ({ page }) => {
+    const errors = collectConsoleErrors(page);
+
+    // A 1x1 PNG, so "did it decode" is answerable without reaching the real
+    // host. The URL still has to be a foreign one — that is what is on trial.
+    const POSTER = "https://img.dandanplay.net/e2e/cover.jpg";
+    await page.route(POSTER, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "image/png",
+        body: Buffer.from(
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+          "base64",
+        ),
+      }),
+    );
+
+    await page.goto("/welcome");
+    await seedLibrary(page, { series: [{ posterUrl: POSTER }] });
+
+    await page.goto("/library");
+    await expect(page.getByTestId("series-grid")).toBeVisible({ timeout: 10_000 });
+
+    // By testid, not `.locator("img").first()`. The card has exactly one <img>
+    // today, so position would work — and would silently retarget the day
+    // someone adds a badge image above it.
+    const cover = page.getByTestId("series-poster").first();
+    await expect(cover).toBeVisible({ timeout: 10_000 });
+
+    // The rule: a cover whose host we cannot enumerate must bypass the
+    // optimizer. If someone drops `unoptimized`, this is the line that fails,
+    // and it fails for the right reason rather than on a timeout.
+    await expect(cover).toHaveAttribute("src", POSTER);
+
+    await expect
+      .poll(() => cover.evaluate((el: HTMLImageElement) => el.naturalWidth), {
+        timeout: 10_000,
+        message: "cover element rendered but never decoded",
+      })
+      .toBeGreaterThan(0);
+
+    await page.waitForLoadState("networkidle");
+    expect(errors, `Unexpected console errors:\n${errors.join("\n")}`).toEqual([]);
+  });
+
   test("empty library shows DropZone import prompt", async ({ page }) => {
     const errors = collectConsoleErrors(page);
 

--- a/next-app/src/app/[lang]/library/_components/SeriesCard.tsx
+++ b/next-app/src/app/[lang]/library/_components/SeriesCard.tsx
@@ -651,7 +651,15 @@ function SeriesCard({
 
         <div style={s.posterWrap}>
           {safePoster ? (
-            <FadeImage src={safePoster} alt={title} width={280} height={420} unoptimized style={s.poster} />
+            <FadeImage
+              src={safePoster}
+              alt={title}
+              width={280}
+              height={420}
+              unoptimized
+              data-testid="series-poster"
+              style={s.poster}
+            />
           ) : (
             <div style={s.monogram} data-testid="monogram" aria-hidden>
               {initial}


### PR DESCRIPTION
The 3.13.0 next/image migration left /library showing 26 empty cards and 115
console 400s, and nothing in the repo noticed. This is the check that would
have.

Why the existing library specs stayed green: the fixture seeded
`posterUrl: ""`, so `SeriesCard`'s safePoster guard resolved to null and the
card rendered its monogram fallback. The page never requested an image at all.
`posterUrl` is now seedable, and its doc comment says why leaving it empty is
a blind spot rather than a neutral default.

The new spec seeds a cover on img.dandanplay.net -- a foreign host on purpose,
since that is the whole point: remotePatterns allows only s4.anilist.co, and a
call site that forgets `unoptimized` 400s on anything else. A page.route stub
serves a 1x1 PNG so "did it decode" is answerable without reaching the real
host or depending on it being up.

Two assertions, because either alone would have missed this:

  · src must equal the original URL, not /_next/image?... -- that is the rule
    being protected, and it fails immediately and legibly rather than on a
    timeout.
  · naturalWidth > 0 -- while broken, the element existed, was visible, and
    had exactly the right box. Only the decode was missing. Every
    visibility-based and geometry-based check was structurally blind to it,
    which is the same shape as the scrollIntoView carousel bug.

Also gives the poster a data-testid. The card has exactly one <img> today so
position would work, and would silently retarget the day someone adds a badge
image above it.

Not executed against the broken state: running the sandbox suite needs the
full stack, and the negative case would mean deliberately re-breaking prod
code. The assertion follows from get-img-props.js, where the `unoptimized`
branch returns the src unchanged while the optimized one rewrites it to
/_next/image -- so removing `unoptimized` fails the first assertion by
construction. CI runs the suite against this PR's own code.