### PR TITLE
fix(e2e): a fixture that makes an upstream call it does not need, a route nothing warms, and a log tail that cannot reach the failure

### DIFF
--- a/.github/workflows/e2e-sandbox.yml
+++ b/.github/workflows/e2e-sandbox.yml
@@ -197,8 +197,21 @@ jobs:
             fi
             sleep 1
           done
+          # /anime/0 is here to compile the `[lang]/anime/[id]` segment, which
+          # nothing else in this list reaches. Turbopack compiles a segment on
+          # its first request, so without this the first /anime/<id> in the
+          # whole suite pays for it — inside a spec's own timeout, under three
+          # workers' load.
+          #
+          # The id is 0 rather than the routing fixture's 21 ON PURPOSE. Both
+          # `generateMetadata` and the page bail on `anilistId <= 0` BEFORE
+          # calling loadDetail, so 0 compiles the route and makes no API call
+          # at all. Warming a real id here would be actively harmful: this step
+          # runs before globalSetup seeds anything, so the miss would be a
+          # genuine 404 — and `loadDetail` fetches with `revalidate: 60`, so
+          # Next would serve that 404 back for a minute after the row existed.
           for route in / /login /register /forgot-password /reset-password/warmup \
-                       /welcome /library /player /admin; do
+                       /welcome /library /player /admin /anime/0; do
             code=000
             for attempt in $(seq 1 10); do
               code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 120 "http://localhost:3000${route}")
@@ -268,11 +281,18 @@ jobs:
         # gone the moment the runner is reclaimed. `docker compose logs`
         # after a container is recreated shows nothing, which is how a
         # previous prod post-mortem lost its evidence — grab them here.
+        # The tails are 4000, not 200, because 200 could not reach the
+        # failure. go-api emits a steady stream of background enrichment
+        # logs, so by the time this step runs the last 200 lines are all
+        # from after the suite finished — the requests that actually failed
+        # have scrolled off. A post-mortem that has to be repeated because
+        # the evidence step captured the wrong window costs more than the
+        # log lines do.
         run: |
           echo "───── next dev ─────"
-          tail -200 /tmp/next-dev.log || true
+          tail -4000 /tmp/next-dev.log || true
           echo "───── containers ─────"
-          docker compose --env-file .env.production logs --tail=200 || true
+          docker compose --env-file .env.production logs --tail=4000 || true
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/e2e/fixtures/pg.ts
+++ b/e2e/fixtures/pg.ts
@@ -338,6 +338,28 @@ export async function ensureAnimeDetail(anime: SeedAnimeDetail): Promise<void> {
     INSERT INTO anime_characters (anime_id, display_order, name_en, role)
     VALUES (${anime.anilistId}, 0, 'E2E Protagonist', 'MAIN')
   `;
+
+  // Verify the postcondition this function's whole name is a promise about.
+  //
+  // The failure it guards is silent and expensive: a row that exists but
+  // reads as stale renders as a 404 when AniList is unreachable, and the
+  // spec that trips over it reports "expected 200, received 404" — a
+  // sentence with no fixture in it. Chasing that from the other end costs a
+  // CI round trip per hypothesis. It is what happened when `locale-routing`
+  // was "fixed" with `ensureAnimeCached`, whose row satisfies none of this.
+  const [seeded] = await sql`
+    SELECT (SELECT count(*) FROM anime_studios WHERE anime_id = ${anime.anilistId}) AS studios,
+           (SELECT count(*) FROM anime_characters
+             WHERE anime_id = ${anime.anilistId} AND role IS NOT NULL) AS characters
+  `;
+  if (Number(seeded?.studios ?? 0) === 0 || Number(seeded?.characters ?? 0) === 0) {
+    throw new Error(
+      `ensureAnimeDetail(${anime.anilistId}): seeded row is still stale ` +
+        `(studios=${seeded?.studios}, characters-with-role=${seeded?.characters}). ` +
+        `isStale trips on either being empty, so /anime/${anime.anilistId} would ` +
+        `go to AniList and 404 whenever that call fails.`,
+    );
+  }
 }
 
 /**

--- a/e2e/globalSetup.ts
+++ b/e2e/globalSetup.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url";
 import {
   cleanupTestUsersInPostgres,
   closePg,
-  ensureAnimeCached,
+  ensureAnimeDetail,
   ensureSeedUserInPostgres,
 } from "./fixtures/pg";
 
@@ -23,9 +23,18 @@ import {
  * in the run failed together — intermittently, and more often as the suite grew
  * and ran more of it concurrently.
  *
- * One cached row removes the dependency. The specs only ever assert status,
- * `h1` presence and the canonical URL, so the row's contents do not matter —
- * its existence does.
+ * Removing the dependency takes `ensureAnimeDetail`, NOT `ensureAnimeCached`.
+ * That distinction is the whole fix and it is not obvious: a row from
+ * `ensureAnimeCached` exists but has no studios and no characters, and
+ * `isStale` (go-api/internal/anime/detail.go) trips on either of those
+ * independently of `cached_at`. A stale row sends the handler to AniList
+ * anyway, so seeding it that way changes nothing that matters here — which is
+ * exactly what happened when this fixture was first added, and why the
+ * assertions kept failing after it.
+ *
+ * The specs only ever assert status, `h1` presence and the canonical URL, so
+ * the row's CONTENTS do not matter. What matters is that it looks complete
+ * enough that nothing goes upstream to complete it.
  */
 const ROUTING_FIXTURE_ANILIST_ID = 21;
 
@@ -93,7 +102,7 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
   // Seeded here rather than in the spec that reads it: `locale-routing` never
   // writes to Postgres at all, and a per-spec fixture would race the other
   // workers under `fullyParallel`. Global setup runs once, before any of them.
-  await ensureAnimeCached({
+  await ensureAnimeDetail({
     anilistId: ROUTING_FIXTURE_ANILIST_ID,
     titleRomaji: "E2E Routing Fixture",
     titleChinese: "E2E 路由固定装置",


### PR DESCRIPTION
Four changes to the sandbox suite, found while diagnosing a failure they turned out **not** to explain. Read the last section before the rest.

## 1. The routing fixture seeds a row that still goes upstream

`globalSetup` seeds anilistId 21 with `ensureAnimeCached`. That row has no studios and no characters, and `isStale` (`go-api/internal/anime/detail.go:584-592`) trips on either of those independently of `cached_at` — so the handler calls AniList anyway, every time, for a page whose fixture exists precisely so it would not have to.

`ensureAnimeDetail` is the helper that seeds a row the detail page can serve without going upstream, and its own docstring says so.

This is a real defect in the fixture. It is **not** shown to be the cause of anything (below).

## 2. Nothing warms `[lang]/anime/[id]`

The warm-up loop covers `/ /login /register /forgot-password /reset-password/warmup /welcome /library /player /admin`. The sandbox runs `next dev`, and Turbopack compiles a route segment on its first request — so the first `/anime/<id>` in the suite pays for that compile inside a spec's own timeout, under three workers' load.

The id added is **0, not 21, deliberately**. Both `generateMetadata` and the page bail on `anilistId <= 0` *before* calling `loadDetail`, so 0 compiles the route and makes no API call. Warming a real id here would be actively harmful: this step runs before `globalSetup` seeds anything, and `loadDetail` fetches with `revalidate: 60`, so Next would serve the resulting 404 back for a minute after the row existed.

## 3. The failure-log tails cannot reach the failure

`--tail=200`, against a go-api that emits a steady stream of background enrichment logs. By the time the dump step runs, the last 200 lines are all from *after* the suite finished; the requests that failed have scrolled off.

This one I can show cost something concrete: diagnosing the failure below, I drew two wrong conclusions from exactly that truncation, and had to retract the first one after discovering the window I was reading did not contain the failure. Raised to 4000.

## 4. `ensureAnimeDetail` verifies its own postcondition

It now reads back studios and role-bearing characters and throws naming the fixture if the row still reads as stale.

Without it the symptom is `expected 200, received 404` in a spec that mentions no fixture at all. That is how (1) came to exist: the fixture was added, the helper was wrong, the issue was closed on the strength of the seed being present, and nothing said otherwise.

## What this does NOT fix, and how I know

The suite fails roughly half the time — always the same six specs, always all-or-nothing. My hypothesis was that they depend on a live AniList fetch and that (1) removes it. **I tested that and it is wrong.**

Two runs with `graphql.anilist.co` pointed at `127.0.0.1` inside the go-api container (`getent` confirmed the override in both):

| | AniList | fixture | result |
|---|---|---|---|
| fix | severed | `ensureAnimeDetail` | 34 passed |
| control | severed | `ensureAnimeCached` (unchanged) | **34 passed** |

The control passes too, so this branch is not what makes them green — and the failures happen when AniList is **reachable**, which is the opposite of the story. The cause is still unknown and #101 stays open.

Eight runs of evidence that it is not code-dependent, for whoever picks it up:

```
05:18  FAIL topic    05:31  PASS main    05:36  FAIL topic
05:51  FAIL main     05:52  PASS topic   <- concurrent, different runners, opposite outcomes
05:59  PASS topic    06:05  PASS topic
```

main fails identically to a topic branch, and two overlapping runs disagree.

## Test plan

- [x] `tsc --noEmit` on `e2e/` — 12 pre-existing errors before and after, zero new
- [x] AniList-severed run, fix branch: 34 passed
- [x] AniList-severed run, control without the fixture change: 34 passed — **the discriminating check, and it disconfirms the rationale I started with**
- [ ] Whether this reduces the failure rate at all is unmeasured. It should be judged on the four defects being real, not on a flake it does not explain.