### PR TITLE
feat(email): send as our own domain, so the three checks can align

### DIFF
--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -353,16 +353,33 @@ func main() {
 	}
 	isProd := os.Getenv("GO_ENV") == "production"
 
-	// Gmail SMTP sender — when GMAIL_USER/GMAIL_APP_PASSWORD are
-	// unset (dev without email), NoopSender lets forgot-password
-	// still return 200 (privacy/enumeration parity) while logging
-	// the skipped send.  Same semantic as Express.
+	// Transactional email, in order of preference.  When none is
+	// configured (dev without email), NoopSender lets forgot-password
+	// still return 200 (privacy/enumeration parity) while logging the
+	// skipped send.  Same semantic as Express.
+	//
+	// The relay is tried first because it is the only path that can
+	// send as an address at our own domain, which is what lets SPF,
+	// DKIM and DMARC align.  Gmail stays as the fallback so a host
+	// that has not been given relay credentials yet keeps sending
+	// instead of going quietly dark — the failure this ordering exists
+	// to avoid is a half-finished migration in which nobody notices
+	// mail stopped, because the handler returns 200 either way.
 	var emailSender email.Sender = email.NoopSender{}
-	if smtp, err := email.NewSMTPSender(cfg.GmailUser, cfg.GmailAppPassword); err == nil {
-		emailSender = smtp
-		slog.Info("email: Gmail SMTP configured", "user", cfg.GmailUser)
-	} else {
-		slog.Warn("email: Gmail SMTP not configured, password-reset emails will be skipped")
+	switch relay, relayErr := email.NewRelaySender(
+		cfg.SMTPHost, cfg.SMTPUser, cfg.SMTPPassword, cfg.MailFrom,
+	); {
+	case relayErr == nil:
+		emailSender = relay
+		slog.Info("email: SMTP relay configured", "host", cfg.SMTPHost, "from", cfg.MailFrom)
+	default:
+		if gmail, gmailErr := email.NewSMTPSender(cfg.GmailUser, cfg.GmailAppPassword); gmailErr == nil {
+			emailSender = gmail
+			slog.Warn("email: falling back to Gmail — mail will NOT align with our domain",
+				"user", cfg.GmailUser, "relayErr", relayErr)
+		} else {
+			slog.Warn("email: no sender configured, password-reset emails will be skipped")
+		}
 	}
 
 	authHandlers := auth.NewHandlers(q, signer, emailSender, cfg.ClientOrigin, cfg.JWTExpiresIn, cfg.JWTRefreshExpiresIn, isProd)

--- a/go-api/internal/config/config.go
+++ b/go-api/internal/config/config.go
@@ -44,10 +44,26 @@ type Config struct {
 	// days.  Same cookie maxAge is set when the token is issued.
 	JWTRefreshExpiresIn time.Duration
 
-	// GmailUser + GmailAppPassword — credentials for transactional
-	// email (password reset).  Both empty → email sending is skipped
-	// (forgot-password still returns 200 to avoid enumeration), matches
-	// Express's behavior when env vars are unset.
+	// SMTPHost/User/Password + MailFrom — the PREFERRED transactional
+	// email path: an arbitrary submission relay sending as an address
+	// at a domain we control, so SPF, DKIM and DMARC can all align on
+	// it.  SMTPHost is host:port.  SMTPUser is the relay's AUTH
+	// username and is NOT required to be an address — MailFrom is the
+	// address that goes in `MAIL FROM` and `From:`.
+	SMTPHost     string
+	SMTPUser     string
+	SMTPPassword string
+	MailFrom     string
+
+	// GmailUser + GmailAppPassword — the FALLBACK, used only when the
+	// SMTP_* set above is incomplete.  Kept so a deploy that has not
+	// been given relay credentials yet keeps sending rather than going
+	// silently dark.  Mail sent this way is from gmail.com and cannot
+	// align with our own domain, which is the reason it is no longer
+	// first choice.
+	//
+	// All of it empty → sending is skipped entirely (forgot-password
+	// still returns 200 to avoid enumeration), matching Express.
 	GmailUser        string
 	GmailAppPassword string
 
@@ -85,6 +101,10 @@ func Load() (*Config, error) {
 		JWTRefreshSecret:    os.Getenv("JWT_REFRESH_SECRET"),
 		JWTExpiresIn:        accessTTL,
 		JWTRefreshExpiresIn: refreshTTL,
+		SMTPHost:            os.Getenv("SMTP_HOST"),
+		SMTPUser:            os.Getenv("SMTP_USER"),
+		SMTPPassword:        os.Getenv("SMTP_PASSWORD"),
+		MailFrom:            os.Getenv("MAIL_FROM"),
 		GmailUser:           os.Getenv("GMAIL_USER"),
 		GmailAppPassword:    os.Getenv("GMAIL_APP_PASSWORD"),
 		ClientOrigin:        getEnv("CLIENT_ORIGIN", "http://localhost:3000"),

--- a/go-api/internal/email/email.go
+++ b/go-api/internal/email/email.go
@@ -1,16 +1,43 @@
-// Package email — transactional Gmail SMTP sender for password-reset
-// email.  Uses Go stdlib net/smtp with smtp.PlainAuth against
-// smtp.gmail.com:587 (STARTTLS upgrade is handled automatically by
-// net/smtp.SendMail when the server advertises STARTTLS).
+// Package email — transactional SMTP sender for password-reset email.
+// Uses Go stdlib net/smtp with smtp.PlainAuth (STARTTLS upgrade is
+// handled automatically by net/smtp.SendMail when the server
+// advertises it).
 //
 // The Sender interface is the small consumer-facing contract:
 // production wires SMTPSender; tests pass a stub or NoopSender.
 // Handler code never imports net/smtp directly.
 //
+// TWO CONSTRUCTORS, AND WHY
+//
+//   - NewSMTPSender(user, appPassword) — Gmail.  Sends as the Gmail
+//     account itself.  This is the historical path and stays the
+//     fallback so an unconfigured deploy keeps working.
+//   - NewRelaySender(host, user, password, from) — any submission
+//     relay.  Needed because sending as an address at our OWN domain
+//     is the only way SPF, DKIM and DMARC can all align on it, and
+//     Gmail cannot do that: it signs with gmail.com no matter what
+//     From header we set.
+//
+// ─── envelope sender vs From header ────────────────────────────────
+//
+// These are different fields and different checks read them, which is
+// invisible on Gmail because there they happen to be the same string:
+//
+//   - The ENVELOPE sender (SMTP `MAIL FROM`) is what the receiver
+//     runs SPF against.
+//   - The `From:` HEADER is what the reader sees, and what DMARC
+//     requires SPF or DKIM to be ALIGNED with.
+//
+// A relay's AUTH username is frequently not an address at all —
+// Resend's is the literal string "resend" — so using it as the
+// envelope sender the way the Gmail path does would put garbage in
+// `MAIL FROM` and get the message rejected before any of this
+// matters.  They are separate fields on SMTPSender for that reason.
+//
 // Configuration semantics match Express service/email.service.js:
-// when GMAIL_USER or GMAIL_APP_PASSWORD is empty, the sender silently
-// no-ops (logs a warn, returns nil).  Login flows still work; only
-// forgot-password's email delivery is skipped.
+// when nothing is configured the sender silently no-ops (logs a warn,
+// returns nil).  Login flows still work; only forgot-password's email
+// delivery is skipped.
 package email
 
 import (
@@ -19,6 +46,7 @@ import (
 	"fmt"
 	"log/slog"
 	"mime"
+	"net"
 	"net/smtp"
 	"strings"
 )
@@ -50,17 +78,25 @@ const resetSubject = "【AnimeGo】重置你的密码"
 // path always uses smtp.SendMail.
 type sendMailFunc func(addr string, a smtp.Auth, from string, to []string, msg []byte) error
 
-// SMTPSender holds the Gmail SMTP credentials + the From header used
-// for all outgoing reset emails.
+// SMTPSender holds submission credentials + the two sender identities
+// used for all outgoing reset emails.
 //
 // sendFn is test-only — defaults to smtp.SendMail in production via
-// NewSMTPSender.  Tests override it to verify the message bytes
+// either constructor.  Tests override it to verify the message bytes
 // without making a real network call.
 type SMTPSender struct {
-	host        string // smtp.gmail.com:587
-	user        string // sender Gmail address
-	appPassword string // Gmail App Password (NOT account password)
-	fromHeader  string // "AnimeGo <user@gmail.com>"
+	host       string // "smtp.gmail.com:587" — host:port
+	serverName string // "smtp.gmail.com" — bare host, PlainAuth's identity check
+	user       string // AUTH username; NOT necessarily an address
+	password   string // Gmail App Password, or the relay's API key
+
+	// envelopeFrom is SMTP `MAIL FROM` — the address SPF is evaluated
+	// against.  Must be a real address the relay is allowed to send
+	// for, which is why it cannot just reuse `user`.
+	envelopeFrom string
+	// fromHeader is the `From:` header — what the reader sees and what
+	// DMARC alignment is judged on.  "AnimeGo <addr>".
+	fromHeader string
 
 	sendFn sendMailFunc
 }
@@ -80,11 +116,58 @@ func NewSMTPSender(user, appPassword string) (*SMTPSender, error) {
 	}
 	cleaned := stripAllWhitespace(appPassword)
 	return &SMTPSender{
-		host:        gmailSMTPHost,
-		user:        user,
-		appPassword: cleaned,
-		fromHeader:  fmt.Sprintf("AnimeGo <%s>", user),
-		sendFn:      smtp.SendMail,
+		host:       gmailSMTPHost,
+		serverName: gmailSMTPServer,
+		user:       user,
+		password:   cleaned,
+		// On Gmail all three collapse to the account address, which is
+		// exactly why the distinction between them is easy to miss
+		// until a relay makes them differ.
+		envelopeFrom: user,
+		fromHeader:   fmt.Sprintf("AnimeGo <%s>", user),
+		sendFn:       smtp.SendMail,
+	}, nil
+}
+
+// NewRelaySender constructs a sender against an arbitrary SMTP
+// submission relay, sending as `from` — an address at a domain we
+// control.
+//
+// This is the constructor that makes DMARC alignment possible.
+// Gmail can put any string in a From header, but it signs with
+// gmail.com and its envelope sender is a gmail.com address, so a
+// message claiming to be from our domain aligns on neither SPF nor
+// DKIM. Receivers that care — and the ones our readers actually use
+// care a great deal — read that as an unauthenticated claim.
+//
+// `host` is host:port. `user`/`password` are the relay's submission
+// credentials, which are NOT required to look like an address.
+func NewRelaySender(host, user, password, from string) (*SMTPSender, error) {
+	if host == "" || user == "" || password == "" || from == "" {
+		return nil, fmt.Errorf(
+			"email: SMTP_HOST, SMTP_USER, SMTP_PASSWORD and MAIL_FROM are all required")
+	}
+	serverName, _, err := net.SplitHostPort(host)
+	if err != nil {
+		// A bare hostname with no port is the likeliest typo, and it
+		// would otherwise fail much later inside PlainAuth with a
+		// message that names neither the variable nor the value.
+		return nil, fmt.Errorf("email: SMTP_HOST must be host:port, got %q: %w", host, err)
+	}
+	if !strings.Contains(from, "@") {
+		return nil, fmt.Errorf("email: MAIL_FROM must be an email address, got %q", from)
+	}
+	return &SMTPSender{
+		host:       host,
+		serverName: serverName,
+		user:       user,
+		// Not whitespace-stripped, unlike a Gmail App Password: that
+		// strip exists for Gmail's four-group display form. An API key
+		// is opaque and stripping it could silently corrupt one.
+		password:     password,
+		envelopeFrom: from,
+		fromHeader:   fmt.Sprintf("AnimeGo <%s>", from),
+		sendFn:       smtp.SendMail,
 	}, nil
 }
 
@@ -112,8 +195,11 @@ func (s *SMTPSender) SendPasswordReset(ctx context.Context, to, resetURL string)
 	body := BuildResetEmailHTML(resetURL)
 	msg := buildRFC822Message(s.fromHeader, to, resetSubject, body)
 
-	auth := smtp.PlainAuth("", s.user, s.appPassword, gmailSMTPServer)
-	if err := s.sendFn(s.host, auth, s.user, []string{to}, msg); err != nil {
+	// envelopeFrom, not user: on a relay whose AUTH username is not an
+	// address, passing user here puts garbage in `MAIL FROM` and the
+	// message is rejected before SPF is even consulted.
+	auth := smtp.PlainAuth("", s.user, s.password, s.serverName)
+	if err := s.sendFn(s.host, auth, s.envelopeFrom, []string{to}, msg); err != nil {
 		return fmt.Errorf("email: SendMail: %w", err)
 	}
 	return nil

--- a/go-api/internal/email/email_test.go
+++ b/go-api/internal/email/email_test.go
@@ -43,7 +43,7 @@ func TestNewSMTPSender_HappyPath(t *testing.T) {
 	require.NotNil(t, s)
 	assert.Equal(t, "smtp.gmail.com:587", s.host)
 	assert.Equal(t, "u@example.com", s.user)
-	assert.Equal(t, "abcd1234efgh5678", s.appPassword)
+	assert.Equal(t, "abcd1234efgh5678", s.password)
 	assert.Equal(t, "AnimeGo <u@example.com>", s.fromHeader)
 	assert.NotNil(t, s.sendFn, "sendFn should default to smtp.SendMail")
 }
@@ -56,7 +56,7 @@ func TestNewSMTPSender_AppPasswordWhitespace_Stripped(t *testing.T) {
 	// "abcd efgh ijkl mnop" or "abcdefghijklmnop" works.
 	s, err := NewSMTPSender("u@example.com", "abcd efgh ijkl mnop")
 	require.NoError(t, err)
-	assert.Equal(t, "abcdefghijklmnop", s.appPassword)
+	assert.Equal(t, "abcdefghijklmnop", s.password)
 }
 
 func TestNoopSender_SendPasswordReset_NoError(t *testing.T) {
@@ -244,4 +244,121 @@ func TestSenderInterface_Implementations(t *testing.T) {
 
 	var _ Sender = (*SMTPSender)(nil)
 	var _ Sender = NoopSender{}
+}
+
+// ─── NewRelaySender ─────────────────────────────────────────────────────────
+//
+// The relay path exists so mail can go out AS an address at a domain we
+// control, which is the only arrangement where SPF, DKIM and DMARC can all
+// align on it. Gmail cannot do that — it signs with gmail.com whatever the
+// From header says.
+//
+// The property worth pinning hardest is the one that is invisible on Gmail:
+// the ENVELOPE sender and the AUTH username are different things. Gmail
+// collapses them onto the account address, so reusing `user` for the envelope
+// looks correct right up until the relay's username is not an address at all
+// — Resend's is the literal string "resend". The failure is not a bad
+// alignment score, it is a rejected message, and nothing in this package
+// would report it: `SendPasswordReset`'s error is swallowed by the auth
+// handler on purpose, so the reader still sees 200.
+
+func TestNewRelaySender_RequiresEveryField(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct{ name, host, user, pass, from string }{
+		{"no host", "", "u", "p", "a@b.com"},
+		{"no user", "smtp.example.com:587", "", "p", "a@b.com"},
+		{"no password", "smtp.example.com:587", "u", "", "a@b.com"},
+		{"no from", "smtp.example.com:587", "u", "p", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := NewRelaySender(tc.host, tc.user, tc.pass, tc.from)
+			assert.Nil(t, s)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestNewRelaySender_HostMustCarryAPort(t *testing.T) {
+	t.Parallel()
+
+	// A bare hostname is the likeliest typo. Caught here rather than
+	// inside PlainAuth, where the error names neither the variable nor
+	// the value.
+	s, err := NewRelaySender("smtp.example.com", "u", "p", "a@b.com")
+	assert.Nil(t, s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SMTP_HOST")
+}
+
+func TestNewRelaySender_FromMustBeAnAddress(t *testing.T) {
+	t.Parallel()
+
+	// It lands in `MAIL FROM` verbatim; a non-address is rejected by the
+	// relay with a message that says nothing about our configuration.
+	s, err := NewRelaySender("smtp.example.com:587", "u", "p", "AnimeGo")
+	assert.Nil(t, s)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MAIL_FROM")
+}
+
+func TestNewRelaySender_PasswordIsNotWhitespaceStripped(t *testing.T) {
+	t.Parallel()
+
+	// The strip on the Gmail path exists for its four-group App Password
+	// display form. A relay credential is an opaque API key, and stripping
+	// one would corrupt it silently — the send would fail on auth with no
+	// hint that we had rewritten the secret.
+	s, err := NewRelaySender("smtp.example.com:587", "u", "re_ab cd", "a@b.com")
+	require.NoError(t, err)
+	assert.Equal(t, "re_ab cd", s.password)
+}
+
+func TestRelaySender_EnvelopeAndHeaderUseMailFromNotTheAuthUser(t *testing.T) {
+	t.Parallel()
+
+	// The whole point. `user` here is Resend's actual submission username:
+	// not an address, and useless as an envelope sender.
+	s, err := NewRelaySender(
+		"smtp.resend.com:587", "resend", "re_secret", "animegoanime@animegoclub.com")
+	require.NoError(t, err)
+
+	fs := &fakeSend{}
+	s.sendFn = fs.Send
+
+	require.NoError(t, s.SendPasswordReset(
+		context.Background(), "reader@qq.com", "https://animegoclub.com/reset-password/tok"))
+	require.True(t, fs.called)
+
+	assert.Equal(t, "smtp.resend.com:587", fs.addr)
+	assert.Equal(t, "animegoanime@animegoclub.com", fs.from,
+		"envelope sender must be MAIL_FROM — SPF is evaluated against it, and "+
+			"the AUTH username is not an address")
+	assert.NotEqual(t, "resend", fs.from,
+		"the AUTH username leaked into MAIL FROM")
+
+	msg := string(fs.msg)
+	assert.Contains(t, msg, "From: AnimeGo <animegoanime@animegoclub.com>\r\n",
+		"the From header is what DMARC alignment is judged on")
+	assert.NotContains(t, msg, "From: AnimeGo <resend>")
+	assert.Contains(t, msg, "To: reader@qq.com\r\n")
+}
+
+func TestRelaySender_AuthIsScopedToTheRelayHostNotGmail(t *testing.T) {
+	t.Parallel()
+
+	// PlainAuth refuses to hand credentials to a server whose name does
+	// not match the one it was constructed with, so a hard-coded
+	// "smtp.gmail.com" here would make every relay send fail closed. That
+	// is the good failure mode, but only because it fails — a test that
+	// asserted on nothing would let a wrong-host build ship and look fine
+	// until the first reset request.
+	s, err := NewRelaySender("smtp.resend.com:587", "resend", "re_secret", "a@animegoclub.com")
+	require.NoError(t, err)
+	assert.Equal(t, "smtp.resend.com", s.serverName)
+
+	g, err := NewSMTPSender("u@gmail.com", "app-password")
+	require.NoError(t, err)
+	assert.Equal(t, "smtp.gmail.com", g.serverName, "the Gmail path must be unchanged")
+	assert.Equal(t, "u@gmail.com", g.envelopeFrom)
 }

--- a/scripts/check-mail-dns.sh
+++ b/scripts/check-mail-dns.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Check that animegoclub.com is set up to SEND authenticated mail without
+# breaking the Cloudflare Email Routing that receives it.
+#
+# Why a script rather than a checklist: every failure this looks for is
+# silent. A second SPF record, a DKIM selector that never got published, an
+# MX row clobbered while adding sending records — none of them produce an
+# error anywhere. The mail simply stops arriving for the receivers that
+# check, which here is most of them: 78% of accounts are on qq.com and
+# another 10% on 163.com.
+#
+# Usage:
+#   ./scripts/check-mail-dns.sh                       # SPF/DMARC/MX only
+#   ./scripts/check-mail-dns.sh resend._domainkey     # also check a DKIM selector
+#
+# Exits non-zero if anything that would stop authenticated delivery is wrong.
+
+set -uo pipefail
+
+ZONE="${MAIL_DOMAIN:-animegoclub.com}"
+DKIM_SELECTOR="${1:-}"
+RESOLVER="${DNS_RESOLVER:-1.1.1.1}"
+fail=0
+
+q() { dig +short "$2" "$1" "@$RESOLVER" 2>/dev/null; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$1"; fail=1; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$1"; }
+
+echo "域名: $ZONE   (解析器 $RESOLVER)"
+
+# ── SPF ─────────────────────────────────────────────────────────────────────
+#
+# RFC 7208 §4.5: more than one SPF record is a permerror, and a permerror is
+# treated as "no SPF at all" by most receivers — so adding a second record to
+# "add" a sender silently removes authentication for every sender. This is
+# the single most common way this setup gets broken, which is why it is
+# checked before the contents.
+echo
+echo "SPF"
+# No arrays, no mapfile: this has to run on macOS's bash 3.2 as well as on
+# the VPS. The first draft used `mapfile`, which 3.2 does not have — and the
+# script printed "no errors" and exited 0 having never checked SPF at all.
+# That is the exact failure it exists to catch, so: plain strings, and a
+# verdict that refuses to pass when a check could not run.
+spf_all=$(q "$ZONE" TXT | tr -d '"' | grep -i '^v=spf1')
+if [ -z "$spf_all" ]; then
+  spf_n=0
+else
+  spf_n=$(printf '%s\n' "$spf_all" | wc -l | tr -d ' ')
+fi
+spf_one=$(printf '%s\n' "$spf_all" | head -1)
+
+case "$spf_n" in
+  0) bad "没有 SPF 记录 —— 发出去的信没有任何 IP 授权" ;;
+  1) ok "恰好一条: $spf_one" ;;
+  *) bad "有 $spf_n 条 SPF 记录 —— 这是 permerror,等于完全没有 SPF"
+     printf '      %s\n' "$spf_all"
+     bad "修法: 合并成一条,把每个发信方的 include 写进同一行" ;;
+esac
+
+if [ "$spf_n" -eq 1 ]; then
+  # Cloudflare Email Routing's include must survive: dropping it while adding
+  # a sending provider is how inbound forwarding quietly stops passing SPF.
+  case "$spf_one" in
+    *_spf.mx.cloudflare.net*) ok "保留了 Cloudflare Email Routing 的 include(收信不受影响)" ;;
+    *) warn "SPF 里没有 _spf.mx.cloudflare.net —— 如果收信仍走 CF Routing,这条被删掉了" ;;
+  esac
+  # A bare `include:_spf.mx.cloudflare.net` authorises forwarding only; no
+  # outbound provider is listed, so nothing can send as this domain yet.
+  if [ "$(printf '%s' "$spf_one" | grep -o 'include:' | wc -l | tr -d ' ')" -le 1 ]; then
+    warn "只有一个 include —— 还没有任何发信服务被授权,现在发信 SPF 不会通过"
+  fi
+  # §4.6.4: >10 DNS-querying mechanisms is also a permerror. Counted loosely
+  # (nested includes are not expanded) so this is a floor, not the true total.
+  n=$(printf '%s' "$spf_one" | grep -oE '(include|a|mx|ptr|exists|redirect)[:=]?' | wc -l | tr -d ' ')
+  [ "$n" -gt 8 ] && warn "顶层机制已有 $n 个,上限是 10(嵌套 include 也算,这里没展开)"
+  case "$spf_one" in
+    *" -all"*) ok "以 -all 结尾(严格)" ;;
+    *" ~all"*) ok "以 ~all 结尾(软失败;先跑一段时间再收紧到 -all)" ;;
+    *) warn "结尾既不是 ~all 也不是 -all" ;;
+  esac
+fi
+
+# ── DKIM ────────────────────────────────────────────────────────────────────
+#
+# The provider publishes this; it is the half of DMARC that survives
+# forwarding, and the half QQ/163 weigh most heavily.
+echo
+echo "DKIM"
+if [ -z "$DKIM_SELECTOR" ]; then
+  warn "没传 selector,跳过。装好发信服务后用它给的 selector 再跑一次:"
+  warn "  ./scripts/check-mail-dns.sh resend._domainkey"
+else
+  rec=$(q "${DKIM_SELECTOR}.${ZONE}" TXT; q "${DKIM_SELECTOR}.${ZONE}" CNAME)
+  if [ -z "$rec" ]; then
+    bad "${DKIM_SELECTOR}.${ZONE} 解析不到 —— 记录没发布,或者还没生效"
+  else
+    ok "${DKIM_SELECTOR}.${ZONE} 有记录"
+    printf '      %s\n' "$rec" | head -3
+  fi
+fi
+
+# ── DMARC ───────────────────────────────────────────────────────────────────
+echo
+echo "DMARC"
+dmarc=$(q "_dmarc.$ZONE" TXT | tr -d '"' | grep -i '^v=DMARC1' || true)
+if [ -z "$dmarc" ]; then
+  bad "没有 DMARC 记录"
+else
+  ok "$dmarc"
+  case "$dmarc" in
+    *p=none*)
+      # Correct while bringing a new sender up: p=none asks receivers to
+      # report rather than act, so a misconfiguration costs a report instead
+      # of a bounced password reset. It buys no enforcement, though.
+      warn "p=none —— 只监控不拦截。新发信方跑通、rua 报告连续几天全对齐之后再考虑 quarantine" ;;
+  esac
+  case "$dmarc" in
+    *rua=*) ok "配了 rua,对齐失败会有报告寄回来" ;;
+    *) warn "没有 rua —— 出问题时不会有任何报告,只能靠用户抱怨发现" ;;
+  esac
+fi
+
+# ── MX ──────────────────────────────────────────────────────────────────────
+#
+# Receiving and sending are independent. Nothing about adding a sender should
+# touch MX, so this is here to catch the accident rather than to verify intent.
+echo
+echo "MX(收信,应保持不变)"
+mx=$(q "$ZONE" MX)
+if [ -z "$mx" ]; then
+  bad "没有 MX —— 这个域名收不了信"
+else
+  case "$mx" in
+    *mx.cloudflare.net*) ok "仍指向 Cloudflare Email Routing" ;;
+    *) warn "MX 不是 Cloudflare Email Routing,确认是有意为之:"; printf '      %s\n' "$mx" ;;
+  esac
+fi
+
+echo
+# `set -u` turns an unset variable into a message on stderr, not an exit —
+# which is how the first draft reported success on a section that never ran.
+# Anything the script could not evaluate counts as a failure, not a pass.
+for v in spf_n dmarc mx; do
+  eval "[ -n \"\${$v+set}\" ]" || { bad "内部错误: 检查项 $v 没能运行,结论不可信"; }
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "结论: 没有会阻断认证投递的错误。"
+  echo "注意这只证明记录对,不证明信能进 QQ/163 的收件箱 —— 那必须真发一封去看。"
+else
+  echo "结论: 上面标 ✗ 的会让认证投递失败,先修那些。"
+fi
+exit "$fail"


### PR DESCRIPTION
Password-reset mail goes out through Gmail SMTP as a `gmail.com` address. It works — I verified the whole path on prod today, and the message arrived. It is also the reason we cannot tell whether it works for the readers who matter:

| domain | users | share |
|---|---|---|
| qq.com | 977 | 78.3% |
| 163.com | 122 | 9.8% |
| gmail.com | 63 | 5.1% |

The test that passed was Gmail → Gmail, which is 5% of accounts and the easiest path there is.

## Why not just change the From header

Because it makes things worse, not better. Gmail signs with `gmail.com` and its envelope sender is a `gmail.com` address whatever we put in `From:`. A message claiming to be from `animegoclub.com` would then align on neither SPF nor DKIM — an unauthenticated claim, which is exactly what the receivers in the table above are strict about. Today's mail at least aligns honestly on `gmail.com`.

The only arrangement that aligns is sending through a relay that signs for our domain. This adds that path.

## Envelope sender is not the From header

Invisible on Gmail because both collapse onto the account address, load-bearing everywhere else:

- the **envelope** sender (`MAIL FROM`) is what SPF is evaluated against;
- the **`From:` header** is what the reader sees, and what DMARC requires SPF or DKIM to be *aligned* with.

A relay's AUTH username is frequently not an address at all — Resend's is the literal string `resend` — so reusing it as the envelope sender the way the Gmail path does puts garbage in `MAIL FROM` and the message is rejected before any of this matters. They are separate fields on `SMTPSender` now, with a test asserting the envelope carries `MAIL_FROM` and not the username.

That failure would have been silent: `SendPasswordReset`'s error is swallowed by the forgot-password handler on purpose, so the reader sees 200 whether or not anything was sent.

## Ordering, and why Gmail stays

`SMTP_HOST`/`SMTP_USER`/`SMTP_PASSWORD` + `MAIL_FROM` take precedence; the Gmail pair remains the fallback. A host not yet given relay credentials keeps sending instead of going quietly dark — which matters precisely because the handler's 200 hides the difference. Boot logs which path was chosen and says plainly when the fallback means mail will not align.

**With `SMTP_*` unset this build behaves exactly as before.** No DNS or provider is configured yet.

## `scripts/check-mail-dns.sh`

Every failure it looks for is silent — a second SPF record (permerror, treated as *no* SPF), an unpublished DKIM selector, an MX row clobbered while adding sending records.

It demonstrated the point on itself: the first draft used `mapfile`, absent from macOS's bash 3.2, so the SPF section never ran and it printed "no errors" and exited 0. Rewritten without arrays, and the verdict now refuses to pass when a check could not be evaluated.

Current state per the script: exactly one SPF record, Cloudflare Email Routing's include intact, and only that one include — nothing is authorised to send as this domain yet.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./internal/email/ -race` — existing Gmail tests unchanged and passing, 6 new cases for the relay path
- [x] `scripts/check-mail-dns.sh` run against live DNS; reports the true current state
- [ ] End-to-end through a real relay — blocked on a provider account
- [ ] **Delivery to a qq.com address.** This is the only check that answers the original question, and no amount of correct DNS substitutes for it.