### PR TITLE
chore(security): the origin address does not belong in a public repo

### DIFF
--- a/scripts/rotate-mail-key.sh
+++ b/scripts/rotate-mail-key.sh
@@ -21,8 +21,16 @@
 
 set -euo pipefail
 
-VPS_HOST="${VPS_HOST:-45.145.228.171}"
-VPS_PORT="${VPS_PORT:-57777}"
+# No defaults for the host or the port, on purpose. This repo is public, and
+# the origin address is not decoration: the box only accepts 80/443 from
+# Cloudflare's ranges, and that rule is worth more when the address behind it
+# is not trivially greppable. A convenience default here would hand it over in
+# exchange for saving one export.
+#
+# Put them in your shell profile or an ssh_config Host alias instead:
+#   export VPS_HOST=… VPS_PORT=…
+VPS_HOST="${VPS_HOST:?需要 VPS_HOST(不写死在这里 —— 仓库是公开的)}"
+VPS_PORT="${VPS_PORT:?需要 VPS_PORT}"
 APP_DIR="${APP_DIR:-/opt/animego}"
 MAIL_FROM="${MAIL_FROM:-animegoanime@animegoclub.com}"
 ENV_FILE="$APP_DIR/.env.production"


### PR DESCRIPTION
`rotate-mail-key.sh` (merged in #116) shipped with the production IP and SSH port as convenience defaults. **This repo is public.**

The address is not decoration. The box accepts 80/443 only from Cloudflare's ranges, enforced in the `DOCKER-USER` chain — and that rule is worth more when the address behind it is not trivially greppable from the current tree. Trading that for saving one `export` was a bad trade, and I made it.

Both are now required from the environment with no fallback:

```bash
VPS_HOST="${VPS_HOST:?…}"
VPS_PORT="${VPS_PORT:?…}"
```

## What this does not undo

The same address is reachable through `git log -S` from commits that predate this one — including the ones an earlier scrub (`0f7ad45 chore(security): scrub VPS IPs + SSH details from tracked files`) removed it from. Removing a value from tracked files does not remove it from history.

So the honest position is that **the origin address should be treated as already public**, and the firewall rule has to carry the weight on its own rather than being helped by obscurity. It does — that is why it lives in the `DOCKER-USER` chain rather than UFW, which Docker bypasses.

This commit stops making it easier, which is worth doing regardless. It does not restore a secret.

Worth deciding separately, and not in this PR: whether to rotate the origin IP. That is the only action that actually re-establishes the assumption, and it costs a DNS change plus firewall re-pinning.

## Test plan

- [x] `grep -rn` for the address and port across `scripts/` — clean
- [x] Syntax check
- [ ] The script's next real run will confirm the `:?` guards read correctly from the environment