### PR TITLE
fix(design): the score badge picked its text and its background separately

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -93,6 +93,23 @@
 | `--error`   | `#ff453a` | 错误、删除确认      |
 | `--info`    | `#5ac8fa` | 同 `--teal`         |
 
+### Per-Anime Poster Accent（"不要蓝色以外的 accent" 的唯一例外）
+| Token                 | Value                    | Usage                    |
+|-----------------------|--------------------------|--------------------------|
+| `--poster-accent`     | 运行时从封面取样          | 封面光晕、hero 关系 chip |
+| `--poster-accent-rgb` | 同上，逗号分隔的通道值    | 需要自定 alpha 时        |
+
+这不是设计系统挑的颜色，是**每部番自己的颜色**（`anime_cache.poster_accent`，
+由封面图取样得到），所以 "不要引入蓝色以外的 accent 色" 那条对它不适用 ——
+那条规则约束的是品牌色。
+
+作用范围严格限定在 hero 光晕和 hero 内的关系 chip。**不要**拿它做按钮、
+链接或焦点环 —— 可点击 = `--accent`，这条没有例外，否则"蓝色代表可操作"
+这个信号就废了。
+
+globals.css 里那个紫色字面量只是取样值到达之前的占位；用它的光晕在
+`[data-accent-ready="true"]` 之前是透明的，所以它不会被画出来。
+
 ### Dark Mode
 单一暗色主题，不提供亮色模式。背景已基于 Apple True Black，在 OLED 屏幕上极省电。
 
@@ -277,10 +294,40 @@
 - Padding: 4px 8px, Radius: 9999px, Font: 11px weight 500
 
 **Score Badge**
-- Background: `rgba(255,159,10,0.12)`
-- Text: `--warning` (`#ff9f0a`)
 - Font: JetBrains Mono, 13px, weight 500
 - Radius: 6px
+- Padding: 4px 12px
+- **三档配色，背景与文字成对**：
+
+| 分数 | 文字 | 背景 | Token |
+|------|------|------|-------|
+| ≥ 75 | `#30d158` (`--success`) | `rgba(48,209,88,0.12)` | `--score-high-fg` / `--score-high-bg` |
+| 50–74 | `#ff9f0a` (`--warning`) | `rgba(255,159,10,0.12)` | `--score-mid-fg` / `--score-mid-bg` |
+| < 50 | `#ff453a` (`--error`) | `rgba(255,69,58,0.12)` | `--score-low-fg` / `--score-low-bg` |
+
+> **规则：** 背景和文字**必须同源**。唯一允许决定用哪一档的地方是
+> `components/anime/scoreStyle.ts`，它一次返回一对。
+>
+> 这条规则是从一个线上缺陷倒推出来的：本节原先规定 score badge 恒为琥珀色，
+> 没有分档；而详情页早已在按阈值算文字颜色，背景却硬编码成琥珀。
+> 结果 ★9 和 ★8.3 在线上渲染成**绿字配琥珀底**，★6 和 ★5.7 才是对的。
+> 规范和实现分别只错了一半，两边都看不出问题 —— 所以修的方式是让二者
+> 无法再分开取值，而不是把已经成立的信息维度删掉。
+
+**Score Badge — 封面上变体（`--score-scrim-bg`）**
+- Background: `rgba(0,0,0,0.75)` + `backdrop-filter: blur(8px)`
+- Text: 同上三档 fg
+- Use: 番剧卡片右上角（badge 压在封面图上）
+
+12% 的淡色底在封面上没有对比度保证 —— 动漫封面本来就极艳丽，
+背后可能是任何颜色。所以压在图上的 badge 用不透明遮罩，只让**文字**带分档。
+用 `scoreScrimStyle()`，不要把 `scoreBadgeStyle()` 拿去压图。
+
+**Rating Bands（评分语义）**
+
+阈值 75 / 50 是全站统一的评分语义，番剧卡片也用同一套：
+≥75 好评、50–74 中评、<50 差评。改阈值要同时改 `scoreStyle.ts` 和本表，
+`scoreStyle.test.ts` 会同时钉住两者。
 
 ## Depth & Elevation
 
@@ -400,3 +447,7 @@
 | 2026-03-27 | 副色选 iOS Teal `#5ac8fa`              | 与 iOS Blue 同属 Apple 色系，保持系统感；严格限定为只读/信息场景      |
 | 2026-03-27 | 文字改用 Apple Label System（rgba）    | 比固定灰色更自然地适配不同背景层，层次感更丰富                        |
 | 2026-03-27 | 初版设计系统建立                       | 由 /design-consultation 基于竞品调研（AniList、MAL）生成              |
+| 2026-08-27 | 31 个 token 全部落进 `globals.css`，并由 `globals.test.ts` 钉住 | 此前只落了 10 个且其中 6 个漂移；实测全 `src/` 里 `--accent` 9 处引用、`--bg` / `--text` 各 1 处、**其余调色板 0 处** —— 设计系统只存在于文档里。修正漂移值零风险：那 6 个没有任何 `var()` 引用 |
+| 2026-08-27 | Score Badge 从"恒琥珀"改为三档，且背景文字成对 | 规范和实现各错一半：规范没有分档，实现按阈值算文字却硬编码琥珀背景 → 线上 ★9 是绿字琥珀底。选择修订规范匹配已成立的做法（番剧卡片也在用阈值），而不是删掉信息维度 |
+| 2026-08-27 | `--poster-accent` 明确为"不要蓝色以外 accent"的例外 | 它是每部番自己的封面取样色，不是品牌色；但严格限定在 hero 光晕，不得用于可点击元素 |
+| 2026-08-27 | `--text-quaternary` 保持 0.18 并标注为仅限禁用态 | ~2.5:1 低于 WCAG AA，但禁用控件本就豁免（1.4.3）；标注防止它被当成"更淡的正文色"使用 |

--- a/e2e/fixtures/pg.ts
+++ b/e2e/fixtures/pg.ts
@@ -317,8 +317,8 @@ export interface SeedAnimeDetail extends SeedAnimeCache {
  * role are the cheapest way to make the row look complete and keep the read
  * entirely inside Postgres.
  *
- * The child rows are deleted first rather than upserted: they have surrogate
- * uuid keys, so a re-run would otherwise stack duplicates.
+ * Safe to call concurrently for the same id — see the note on the child-row
+ * inserts below, which is not the obvious way to write them.
  */
 export async function ensureAnimeDetail(anime: SeedAnimeDetail): Promise<void> {
   const sql = getSql();
@@ -354,15 +354,34 @@ export async function ensureAnimeDetail(anime: SeedAnimeDetail): Promise<void> {
       cached_at        = now(),
       updated_at       = now()
   `;
-  await sql`DELETE FROM anime_studios WHERE anime_id = ${anime.anilistId}`;
-  await sql`DELETE FROM anime_characters WHERE anime_id = ${anime.anilistId}`;
+  // Written idempotently rather than deleted-then-inserted.
+  //
+  // This used to clear both child tables first, which reads as the obvious
+  // way to keep a re-run from stacking duplicates and is safe only if one
+  // process is doing it. Playwright's fullyParallel puts the tests of one
+  // file on several workers, and beforeAll runs once PER WORKER, so several
+  // of them seed the same ids at the same time. One worker's DELETE lands
+  // between another's INSERT and its postcondition check, and the check
+  // throws `seeded row is still stale (studios=0, ...)` — a fixture error
+  // that reads exactly like a product bug in whichever spec drew the short
+  // straw, and only sometimes.
+  //
+  // anime_studios has PRIMARY KEY (anime_id, studio), so a conflicting
+  // insert is a no-op. anime_characters has only a surrogate uuid key, so
+  // (anime_id, display_order) stands in for the natural one. Neither
+  // statement can remove a row a peer just wrote.
   await sql`
     INSERT INTO anime_studios (anime_id, studio)
     VALUES (${anime.anilistId}, 'E2E Animation Works')
+    ON CONFLICT (anime_id, studio) DO NOTHING
   `;
   await sql`
     INSERT INTO anime_characters (anime_id, display_order, name_en, role)
-    VALUES (${anime.anilistId}, 0, 'E2E Protagonist', 'MAIN')
+    SELECT ${anime.anilistId}, 0, 'E2E Protagonist', 'MAIN'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM anime_characters
+      WHERE anime_id = ${anime.anilistId} AND display_order = 0
+    )
   `;
 
   // Verify the postcondition this function's whole name is a promise about.

--- a/e2e/fixtures/pg.ts
+++ b/e2e/fixtures/pg.ts
@@ -285,6 +285,23 @@ export interface SeedAnimeDetail extends SeedAnimeCache {
   episodesBgm?: number | null;
   /** AniList status string, e.g. `"RELEASING"`. */
   status?: string | null;
+  /**
+   * The hero's four coupled geometry values switch on whether this is set.
+   * A spec about the detail hero that leaves it null is measuring the
+   * no-banner layout while believing it measured the other one.
+   */
+  bannerImageUrl?: string | null;
+  /** The poster. Absent renders the placeholder box, not an <img>. */
+  coverImageUrl?: string | null;
+  /**
+   * AniList's 0-100 score. Decides which of the three score-badge bands the
+   * page paints, so a spec pinning that pairing has to choose it — 87 and 30
+   * exercise different branches and the defect only existed in one of them.
+   */
+  averageScore?: number | null;
+  /** Synopsis. What a search visitor came for, and what the mobile hero has
+   * to get above the fold. */
+  description?: string | null;
 }
 
 /**
@@ -308,7 +325,8 @@ export async function ensureAnimeDetail(anime: SeedAnimeDetail): Promise<void> {
   await sql`
     INSERT INTO anime_cache (
       anilist_id, title_romaji, title_chinese, episodes, episodes_bgm,
-      status, cached_at
+      status, banner_image_url, cover_image_url, average_score, description,
+      cached_at
     )
     VALUES (
       ${anime.anilistId},
@@ -317,16 +335,24 @@ export async function ensureAnimeDetail(anime: SeedAnimeDetail): Promise<void> {
       ${anime.episodes ?? null},
       ${anime.episodesBgm ?? null},
       ${anime.status ?? null},
+      ${anime.bannerImageUrl ?? null},
+      ${anime.coverImageUrl ?? null},
+      ${anime.averageScore ?? null},
+      ${anime.description ?? null},
       now()
     )
     ON CONFLICT (anilist_id) DO UPDATE SET
-      title_romaji  = EXCLUDED.title_romaji,
-      title_chinese = EXCLUDED.title_chinese,
-      episodes      = EXCLUDED.episodes,
-      episodes_bgm  = EXCLUDED.episodes_bgm,
-      status        = EXCLUDED.status,
-      cached_at     = now(),
-      updated_at    = now()
+      title_romaji     = EXCLUDED.title_romaji,
+      title_chinese    = EXCLUDED.title_chinese,
+      episodes         = EXCLUDED.episodes,
+      episodes_bgm     = EXCLUDED.episodes_bgm,
+      status           = EXCLUDED.status,
+      banner_image_url = EXCLUDED.banner_image_url,
+      cover_image_url  = EXCLUDED.cover_image_url,
+      average_score    = EXCLUDED.average_score,
+      description      = EXCLUDED.description,
+      cached_at        = now(),
+      updated_at       = now()
   `;
   await sql`DELETE FROM anime_studios WHERE anime_id = ${anime.anilistId}`;
   await sql`DELETE FROM anime_characters WHERE anime_id = ${anime.anilistId}`;

--- a/e2e/specs/sandbox/anime-detail.spec.ts
+++ b/e2e/specs/sandbox/anime-detail.spec.ts
@@ -18,6 +18,21 @@ import { closePg, ensureAnimeDetail, removeAnimeFixture } from "../../fixtures/p
 // No authentication: this is the page as a search visitor meets it.
 test.use({ storageState: { cookies: [], origins: [] } });
 
+// One worker for the whole file.
+//
+// The config sets fullyParallel, which spreads a file's tests across
+// workers — and `beforeAll` runs once per worker, `afterAll` likewise. With
+// a shared database and one set of fixture ids that means several workers
+// seed the same rows at once, and the first to finish deletes them while
+// the others are still reading. The failure surfaces as a 404 in whichever
+// spec drew the short straw, intermittently, which is the most expensive
+// kind of red there is.
+//
+// Serial is the right trade here rather than per-worker fixture ids: six
+// short reads cost nothing to run in order, and ids that depend on
+// workerIndex make every failure message harder to trace back to a row.
+test.describe.configure({ mode: "serial" });
+
 // Local asset paths, not AniList URLs. next/image rejects a host outside
 // next.config's remotePatterns with a 400, and a real AniList fetch would put
 // an external dependency in the middle of a layout assertion.

--- a/e2e/specs/sandbox/anime-detail.spec.ts
+++ b/e2e/specs/sandbox/anime-detail.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect } from "@playwright/test";
+import { closePg, ensureAnimeDetail, removeAnimeFixture } from "../../fixtures/pg";
+
+// The two things the detail hero got wrong, pinned against a stack built
+// from this branch.
+//
+// Both were live on production and neither was catchable by any check the
+// repo had. The score badge was wrong only for scores of 75 and above, so
+// every screenshot of a mid-rated anime looked correct. The mobile hero was
+// not "wrong" at all in the sense a test could phrase — it rendered exactly
+// what it was told to — it just put the synopsis below the fold on the
+// device most visitors arrive on.
+//
+// specs/anime-detail.spec.ts (top level) runs against the DEPLOYED site, so
+// it can only report these after they ship. This file is in the sandbox
+// project, which is the one that can fail a pull request.
+//
+// No authentication: this is the page as a search visitor meets it.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// Local asset paths, not AniList URLs. next/image rejects a host outside
+// next.config's remotePatterns with a 400, and a real AniList fetch would put
+// an external dependency in the middle of a layout assertion.
+const BANNER = "/og-default.png";
+const COVER = "/mascot-wink.png";
+
+// A synopsis long enough that the collapsed block has real height — the
+// question is where it starts, and a one-line summary would sit above the
+// fold no matter how tall the hero was.
+const SYNOPSIS =
+  "A test synopsis long enough to occupy several lines in the collapsed " +
+  "description block, so that the assertion about where it begins is not " +
+  "quietly satisfied by it being too short to matter. It repeats itself a " +
+  "little on purpose. A test synopsis long enough to occupy several lines.";
+
+/** Scored 87 — the band that rendered green text on an amber pill. */
+const HIGH = 990_100_001;
+/** Scored 30 — the band that happened to look right, which is why it hid. */
+const LOW = 990_100_002;
+
+test.beforeAll(async () => {
+  await ensureAnimeDetail({
+    anilistId: HIGH,
+    titleRomaji: "E2E High Score",
+    titleChinese: "E2E 高分",
+    status: "RELEASING",
+    episodes: 12,
+    bannerImageUrl: BANNER,
+    coverImageUrl: COVER,
+    averageScore: 87,
+    description: SYNOPSIS,
+  });
+  await ensureAnimeDetail({
+    anilistId: LOW,
+    titleRomaji: "E2E Low Score",
+    titleChinese: "E2E 低分",
+    status: "FINISHED",
+    episodes: 12,
+    bannerImageUrl: BANNER,
+    coverImageUrl: COVER,
+    averageScore: 30,
+    description: SYNOPSIS,
+  });
+});
+
+test.afterAll(async () => {
+  await removeAnimeFixture(HIGH);
+  await removeAnimeFixture(LOW);
+  await closePg();
+});
+
+/**
+ * The site's own score badge, not Bangumi's.
+ *
+ * Both are spans beginning with a star, but the Bangumi one is prefixed with
+ * a "BGM" label, so anchoring on the star being FIRST separates them without
+ * depending on a CSS-module class name (those are hashed at build time) or
+ * on a test id in production markup.
+ */
+const scoreBadge = (page: import("@playwright/test").Page) =>
+  page.locator("main span").filter({ hasText: /^★/ }).first();
+
+test.describe("the score badge", () => {
+  // The assertion is not "is it green". It was genuinely green — that was
+  // never the problem. It is that the background named the same band.
+  for (const { id, label, rgb } of [
+    { id: HIGH, label: "87 is the high band", rgb: "48, 209, 88" },
+    { id: LOW, label: "30 is the low band", rgb: "255, 69, 58" },
+  ]) {
+    test(`${label}, in both halves`, async ({ page }) => {
+      await page.goto(`/anime/${id}`);
+      const badge = scoreBadge(page);
+      await expect(badge).toBeVisible();
+
+      const style = await badge.evaluate((el) => {
+        const cs = getComputedStyle(el);
+        return { color: cs.color, background: cs.backgroundColor };
+      });
+
+      expect(style.color).toBe(`rgb(${rgb})`);
+      // The pill is the same hue at 12%. Before the fix this was
+      // rgba(255, 159, 10, 0.12) — amber — for every score, including this one.
+      expect(style.background).toBe(`rgba(${rgb}, 0.12)`);
+    });
+  }
+
+  test("the two bands actually differ", async ({ page }) => {
+    // Guards the guard: if scoreBadgeStyle ever returned a constant, both
+    // assertions above would still need the constant to be right, but a
+    // future refactor collapsing the bands would be caught here first.
+    await page.goto(`/anime/${HIGH}`);
+    const high = await scoreBadge(page).evaluate((el) => getComputedStyle(el).color);
+    await page.goto(`/anime/${LOW}`);
+    const low = await scoreBadge(page).evaluate((el) => getComputedStyle(el).color);
+    expect(high).not.toBe(low);
+  });
+});
+
+test.describe("the hero on a phone", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("the synopsis starts on the first screen", async ({ page }) => {
+    // Measured on production before this change: the synopsis began at
+    // y=799 on an 844-tall screen, which is about 45px of visible text under
+    // a 400px banner and a 300px poster. This is the assertion that keeps
+    // the hero from growing back.
+    await page.goto(`/anime/${HIGH}`);
+
+    const synopsis = page.locator("main p").filter({ hasText: "A test synopsis" }).first();
+    await expect(synopsis).toBeVisible();
+
+    const box = await synopsis.boundingBox();
+    expect(box).not.toBeNull();
+    // Half the fold, not all of it: "technically above 844" is what the old
+    // layout already satisfied.
+    expect(box!.y).toBeLessThan(422);
+  });
+
+  test("the banner, the poster and the overlap shrink together", async ({ page }) => {
+    // The four hero values are one design. This checks the two that are
+    // measurable from outside actually moved, so that a future change to one
+    // clamp without the others fails here rather than looking merely odd.
+    await page.goto(`/anime/${HIGH}`);
+
+    const banner = page.locator("main img[aria-hidden='true']").first();
+    const bannerBox = await banner.boundingBox();
+    expect(bannerBox).not.toBeNull();
+    expect(bannerBox!.height).toBeLessThan(200);
+
+    const cover = page.locator("img.hero-cover").first();
+    const coverBox = await cover.boundingBox();
+    expect(coverBox).not.toBeNull();
+    expect(coverBox!.width).toBeLessThan(140);
+
+    // The poster still straddles the banner's lower edge — that overlap is
+    // the hero's whole visual idea, and a mis-scaled pull would either
+    // detach it or bury it.
+    expect(coverBox!.y).toBeLessThan(bannerBox!.y + bannerBox!.height);
+    expect(coverBox!.y + coverBox!.height).toBeGreaterThan(
+      bannerBox!.y + bannerBox!.height,
+    );
+  });
+});
+
+test.describe("the hero on a desktop", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("keeps its full-size banner and poster", async ({ page }) => {
+    // The other half of the clamp. The mobile work was only safe because it
+    // left desktop untouched, and "untouched" is a claim worth holding.
+    await page.goto(`/anime/${HIGH}`);
+
+    const bannerBox = await page
+      .locator("main img[aria-hidden='true']")
+      .first()
+      .boundingBox();
+    expect(bannerBox?.height).toBe(400);
+
+    const coverBox = await page.locator("img.hero-cover").first().boundingBox();
+    expect(coverBox?.width).toBe(210);
+    expect(Math.round(coverBox?.height ?? 0)).toBe(300);
+  });
+});

--- a/next-app/src/app/[lang]/anime/[id]/page.module.css
+++ b/next-app/src/app/[lang]/anime/[id]/page.module.css
@@ -1,0 +1,355 @@
+/* The detail hero's styles, moved out of the `S` object in page.tsx.
+ *
+ * They were 19 inline `CSSProperties` literals. Inline styles cannot express
+ * a hover, a focus ring, or a media query, and they win against every
+ * stylesheet rule — so as long as the hero lived in that object, none of the
+ * responsive work below was possible and any CSS written against these
+ * elements would have been silently inert.
+ *
+ * Literals are replaced with tokens ONLY where the value already matched the
+ * token exactly. Several do not (0.75, 0.50, 0.42 text alphas; the 0.10 bgm
+ * fills) and those stay literal, with a note. Snapping an off-scale value to
+ * the nearest token would be a visual change wearing a refactor's clothes,
+ * and it would land in a commit nobody is reviewing for visual change.
+ */
+
+/* ── Hero geometry ───────────────────────────────────────────────────────
+ *
+ * Four numbers that only make sense together:
+ *
+ *   banner height   how tall the artwork strip is
+ *   pull            how far the content below is dragged up into it
+ *   cover width     the poster, which straddles the seam
+ *   meta top        how far the title is pushed down inside the content
+ *
+ * They were four separate ternaries on `detail.bannerImageUrl`, scattered
+ * across 70 lines of JSX. Changing one alone does not produce a smaller
+ * hero, it produces a broken one: shrink the banner without shrinking the
+ * pull and the poster hangs off the top of the artwork; shrink the pull
+ * without the meta offset and the title lands in the middle of the image.
+ *
+ * So they live here, as one custom-property set per state, and the JSX only
+ * says which state it is in. That is what makes the mobile clamp below a
+ * three-line change instead of a rewrite.
+ *
+ * Measured before: at a 390px viewport the banner (400px) plus the poster
+ * (300px) consumed the entire first screen, so the synopsis — the thing a
+ * visitor arriving from a search result came to read — started below the
+ * fold on every phone.
+ */
+.hero {
+  --hero-banner-h: clamp(150px, 34vw, 400px);
+  --hero-pull: calc(-1 * clamp(40px, 8vw, 80px));
+  --hero-cover-w: clamp(112px, 22vw, 210px);
+  --hero-meta-top: clamp(20px, 5vw, 60px);
+  --hero-gap: clamp(16px, 3vw, 32px);
+}
+
+/* No banner: there is no artwork to overlap, so the content sits below the
+ * short strip rather than being pulled into it, and the title needs no
+ * offset to clear anything. */
+.hero[data-banner="false"] {
+  --hero-banner-h: 120px;
+  --hero-pull: var(--sp-lg);
+  --hero-meta-top: 0px;
+}
+
+.banner {
+  position: relative;
+  height: var(--hero-banner-h);
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.bannerImage {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  display: block;
+}
+
+/* The gradient that lets white text sit on arbitrary artwork. Ends at 0.95
+ * rather than 1 so the bottom edge of the image is still faintly visible —
+ * a hard cut reads as a rendering bug. */
+.bannerOverlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 40%,
+    rgba(0, 0, 0, 0.3) 65%,
+    rgba(0, 0, 0, 0.95) 100%
+  );
+}
+
+.content {
+  display: flex;
+  gap: var(--hero-gap);
+  margin-top: var(--hero-pull);
+  position: relative;
+  z-index: 1;
+  padding-bottom: 40px;
+  flex-wrap: wrap;
+}
+
+.coverSlot {
+  flex-shrink: 0;
+}
+
+/* Aspect ratio is 210:300 (7:10), not the 3:4 DESIGN.md's card rule names.
+ * That is deliberate: AniList's large covers are 460x650, so 7:10 crops
+ * almost nothing while 3:4 would visibly clip the artwork. The width/height
+ * attributes on the element supply the same ratio, which is what keeps the
+ * box reserved before the image decodes. */
+.cover {
+  width: var(--hero-cover-w);
+  height: auto;
+  aspect-ratio: 210 / 300;
+  object-fit: cover;
+  border-radius: var(--radius);
+  border: 1px solid var(--separator);
+  background: var(--bg-card);
+  display: block;
+}
+
+/* The cover slot when there is no cover to show. */
+.coverPlaceholder {
+  composes: cover;
+  background: var(--bg-elevated);
+}
+
+.meta {
+  flex: 1;
+  min-width: 280px;
+  padding-top: var(--hero-meta-top);
+}
+
+/* Below the wrap point the poster and the title share a row instead of
+ * stacking. Stacking is what pushed the synopsis off the first screen: the
+ * poster gets a full row to itself and the text starts underneath it.
+ * `min-width: 0` is the whole mechanism — a flex item will not shrink past
+ * its min-width, and 280px plus the poster does not fit a 390px screen. */
+@media (max-width: 600px) {
+  .meta {
+    min-width: 0;
+  }
+}
+
+/* ── Type ─────────────────────────────────────────────────────────────── */
+
+.title {
+  font-family: var(--font-display);
+  font-size: clamp(22px, 4vw, 36px);
+  color: var(--text);
+  margin-bottom: var(--sp-xs);
+  line-height: 1.2;
+}
+
+.subtitle {
+  color: var(--text-secondary);
+  font-size: 15px;
+  margin-bottom: var(--sp-md);
+}
+
+.descText {
+  /* 0.75 — deliberately brighter than --text-secondary (0.60). This is body
+   * copy at 14px/1.8, and the secondary alpha is tuned for short labels. */
+  color: rgba(235, 235, 245, 0.75);
+  font-size: 14px;
+  line-height: 1.8;
+}
+
+.sectionLabel {
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  margin-bottom: var(--sp-md);
+}
+
+/* ── Badges ───────────────────────────────────────────────────────────── */
+
+.badgeRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: var(--sp-md);
+}
+
+/* Shape only. Colour comes from one of the variants below, and never from
+ * a caller passing a pair of strings — that signature is what let the score
+ * badge pair a green foreground with an amber background in production. */
+.badge {
+  padding: var(--sp-xs) 12px;
+  border-radius: var(--radius-full);
+  font-size: 13px;
+}
+
+.badgeAccent {
+  composes: badge;
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+/* Read-only information, never a control — see DESIGN.md on teal. */
+.badgeInfo {
+  composes: badge;
+  background: var(--teal-dim);
+  color: var(--teal);
+}
+
+.badgeNeutral {
+  composes: badge;
+  background: var(--bg-fill);
+  color: var(--text-secondary);
+}
+
+/* One step quieter than neutral, for a value we are not certain of (the
+ * pending episode count). 0.42 sits between --text-secondary and
+ * --text-tertiary and matches no token; kept as measured rather than
+ * snapped, because "slightly less certain" is the thing it encodes. */
+.badgeMuted {
+  composes: badge;
+  background: var(--bg-fill);
+  color: rgba(235, 235, 245, 0.42);
+}
+
+/* Layout only — the colour pair is applied inline from scoreBadgeStyle(),
+ * which returns background and text together. See scoreStyle.ts. */
+.scoreBadge {
+  padding: var(--sp-xs) 12px;
+  border-radius: var(--radius-full);
+  font-weight: 700;
+  font-size: 13px;
+  font-family: var(--font-mono);
+}
+
+/* Bangumi's score, kept visually distinct from ours so the two are not read
+ * as one number. 0.10 rather than the 0.12 the score bands use — a hair
+ * lighter, because this badge carries more glyphs. */
+.bgmScoreBadge {
+  padding: var(--sp-xs) 12px;
+  border-radius: var(--radius-full);
+  background: rgba(255, 69, 58, 0.1);
+  color: var(--error);
+  font-weight: 700;
+  font-size: 13px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+}
+
+.bgmLabel {
+  font-size: 10px;
+  opacity: 0.7;
+  font-family: var(--font-sans);
+}
+
+.bgmVotes {
+  font-size: 11px;
+  opacity: 0.6;
+  font-weight: 400;
+}
+
+.bgmLink {
+  padding: var(--sp-xs) 12px;
+  border-radius: var(--radius-full);
+  background: rgba(255, 69, 58, 0.1);
+  color: var(--error);
+  font-size: 13px;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-xs);
+  font-weight: 500;
+}
+
+/* An outbound link, so unlike the badges around it, it gets real states.
+ * This is the kind of rule the inline-style object could not hold at all. */
+.bgmLink:hover {
+  background: rgba(255, 69, 58, 0.18);
+}
+
+.bgmLink:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.4);
+}
+
+.bgmArrow {
+  font-size: 10px;
+  opacity: 0.8;
+}
+
+/* ── Meta row ─────────────────────────────────────────────────────────── */
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-xs) 12px;
+  margin-bottom: var(--sp-md);
+  align-items: center;
+}
+
+/* 0.75 / 0.50 — a three-step hierarchy inside one row (studio, separator,
+ * detail). The token scale has two steps in that range, so these stay
+ * literal rather than collapsing studio and detail into one weight. */
+.metaStudio {
+  color: rgba(235, 235, 245, 0.75);
+  font-size: 13px;
+}
+
+.metaDot {
+  color: var(--separator);
+  font-size: 13px;
+}
+
+.metaDetail {
+  color: rgba(235, 235, 245, 0.5);
+  font-size: 12px;
+}
+
+/* ── Genres ───────────────────────────────────────────────────────────── */
+
+.genreRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+
+.genreTag {
+  padding: var(--sp-xs) 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-fill);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+/* ── Hero relations strip ─────────────────────────────────────────────── */
+
+.relationRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-sm);
+  margin-top: 12px;
+}
+
+.relationLabel {
+  color: rgba(235, 235, 245, 0.35);
+  font-size: 11px;
+}
+
+.descBlock {
+  margin-bottom: 20px;
+}
+
+.descBlockLast {
+  margin-bottom: 0;
+}

--- a/next-app/src/app/[lang]/anime/[id]/page.tsx
+++ b/next-app/src/app/[lang]/anime/[id]/page.tsx
@@ -16,7 +16,6 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "@/components/ui/LocaleLink";
 import { notFound } from "next/navigation";
-import type { CSSProperties } from "react";
 import { buildJsonLd } from "@/components/anime/animeJsonLd";
 import DescriptionExpand from "@/components/anime/DescriptionExpand";
 import DetailActions from "@/components/anime/DetailActions";
@@ -27,6 +26,7 @@ import HeroAccent from "@/components/anime/HeroAccent";
 import { FormatBadge, GenreChips } from "@/components/anime/LocalizedChips";
 import { scoreBadgeStyle } from "@/components/anime/scoreStyle";
 import WatchersAvatarList from "@/components/anime/WatchersAvatarList";
+import s from "./page.module.css";
 import { apiGet, ApiError } from "@/lib/api";
 import {
   durationLabel,
@@ -287,114 +287,20 @@ export async function generateMetadata({
 // at module scope), and the numberOfEpisodes rule in there is worth a real
 // assertion rather than a grep. See that file's header.
 
-// --- Style tokens (kept inline; matches legacy hero spec) ---
-
-const S = {
-  bannerOverlay: {
-    position: "absolute" as const,
-    inset: 0,
-    background:
-      "linear-gradient(to bottom, transparent 0%, transparent 40%, rgba(0,0,0,0.30) 65%, rgba(0,0,0,0.95) 100%)",
-  },
-  cover: {
-    width: 210,
-    height: 300,
-    objectFit: "cover" as const,
-    borderRadius: 12,
-    border: "1px solid rgba(84,84,88,0.65)",
-    background: "#1c1c1e",
-    display: "block",
-  },
-  title: {
-    fontFamily: "'Sora', sans-serif",
-    fontSize: "clamp(22px, 4vw, 36px)",
-    color: "#ffffff",
-    marginBottom: 4,
-    lineHeight: 1.2,
-  },
-  subtitle: {
-    color: "rgba(235,235,245,0.60)",
-    fontSize: 15,
-    marginBottom: 16,
-  },
-  badgeRow: { display: "flex" as const, flexWrap: "wrap" as const, gap: 10, marginBottom: 16 },
-  badge: (bg: string, color: string): CSSProperties => ({
-    padding: "4px 12px",
-    borderRadius: 9999,
-    background: bg,
-    color,
-    fontSize: 13,
-  }),
-  // Layout only. The two colour properties come from scoreBadgeStyle(score)
-  // and are spread in at the call site — deliberately not accepted as
-  // parameters here, because a `scoreBadge(color)` signature is exactly what
-  // let the foreground vary while this background stayed amber.
-  scoreBadge: {
-    padding: "4px 12px",
-    borderRadius: 9999,
-    fontWeight: 700 as const,
-    fontSize: 13,
-    fontFamily: "'JetBrains Mono', monospace",
-  },
-  bgmScoreBadge: {
-    padding: "4px 12px",
-    borderRadius: 9999,
-    background: "rgba(255,69,58,0.10)",
-    color: "#ff453a",
-    fontWeight: 700 as const,
-    fontSize: 13,
-    display: "inline-flex" as const,
-    alignItems: "center" as const,
-    gap: 5,
-    fontFamily: "'JetBrains Mono', monospace",
-  },
-  bgmLabel: { fontSize: 10, opacity: 0.7, fontFamily: "'DM Sans', sans-serif" },
-  bgmVotes: { fontSize: 11, opacity: 0.6, fontWeight: 400 },
-  bgmLink: {
-    padding: "4px 12px",
-    borderRadius: 9999,
-    background: "rgba(255,69,58,0.10)",
-    color: "#ff453a",
-    fontSize: 13,
-    textDecoration: "none",
-    display: "inline-flex" as const,
-    alignItems: "center" as const,
-    gap: 4,
-    fontWeight: 500 as const,
-  },
-  metaRow: {
-    display: "flex" as const,
-    flexWrap: "wrap" as const,
-    gap: "4px 12px",
-    marginBottom: 16,
-    alignItems: "center" as const,
-  },
-  metaStudio: { color: "rgba(235,235,245,0.75)", fontSize: 13 },
-  metaDot: { color: "rgba(84,84,88,0.65)", fontSize: 13 },
-  metaDetail: { color: "rgba(235,235,245,0.50)", fontSize: 12 },
-  genreRow: { display: "flex" as const, flexWrap: "wrap" as const, gap: 6, marginBottom: 20 },
-  genreTag: {
-    padding: "4px 10px",
-    borderRadius: 9999,
-    background: "rgba(120,120,128,0.12)",
-    color: "rgba(235,235,245,0.60)",
-    fontSize: 12,
-    fontWeight: 500 as const,
-  },
-  descText: {
-    color: "rgba(235,235,245,0.75)",
-    fontSize: 14,
-    lineHeight: 1.8,
-  },
-  sectionLabel: {
-    color: "#0a84ff",
-    fontSize: 13,
-    fontWeight: 600 as const,
-    letterSpacing: "2px",
-    textTransform: "uppercase" as const,
-    marginBottom: 16,
-  },
-} satisfies Record<string, CSSProperties | ((...args: never[]) => CSSProperties)>;
+// --- Styles ---
+//
+// In page.module.css, not in an object here. The hero was 19 inline
+// CSSProperties literals, and inline styles have two properties that made
+// that a dead end: they cannot express a hover, a focus ring or a media
+// query, and they beat every stylesheet rule, so CSS written against these
+// elements would have been silently inert.
+//
+// The geometry in particular had to move. Four values — banner height, how
+// far the content is pulled up into it, the poster width, and the title's
+// top offset — are one design, and they were four separate ternaries on
+// `detail.bannerImageUrl` spread over 70 lines of JSX. They are now one
+// custom-property set per state and this file only declares which state it
+// is in, via data-banner. See the header of page.module.css.
 
 // --- Hero (banner + cover + meta block) ---
 
@@ -529,7 +435,11 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
   );
 
   return (
-    <div>
+    // data-banner is the whole conditional. Every geometry value that used to
+    // be a `detail.bannerImageUrl ? a : b` in the JSX below now hangs off this
+    // one attribute in page.module.css, so the four of them cannot be changed
+    // apart from each other.
+    <div className={s.hero} data-banner={detail.bannerImageUrl ? "true" : "false"}>
       {/* Banner — a real <img>, not a CSS background.
         *
         * This is the LCP element of the page Google indexes, and as
@@ -557,14 +467,7 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
         * positioned into a fixed-height box, so there is no layout to reserve
         * and the intrinsic ratio would only be a lie if AniList ever changes
         * banner dimensions. */}
-      <div
-        style={{
-          position: "relative",
-          height: detail.bannerImageUrl ? 400 : 120,
-          background: "#000000",
-          overflow: "hidden",
-        }}
-      >
+      <div className={s.banner}>
         {detail.bannerImageUrl ? (
           <Image
             src={detail.bannerImageUrl}
@@ -580,36 +483,19 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
             loading="eager"
             fetchPriority="high"
             decoding="sync"
-            style={{
-              position: "absolute",
-              inset: 0,
-              width: "100%",
-              height: "100%",
-              objectFit: "cover",
-              objectPosition: "center",
-              display: "block",
-            }}
+            className={s.bannerImage}
           />
         ) : null}
-        <div style={S.bannerOverlay} />
+        <div className={s.bannerOverlay} />
       </div>
 
       {/* Content */}
-      <div
-        className="container"
-        style={{
-          display: "flex",
-          gap: 32,
-          marginTop: detail.bannerImageUrl ? -80 : 24,
-          position: "relative",
-          zIndex: 1,
-          paddingBottom: 40,
-          flexWrap: "wrap",
-        }}
-      >
+      <div className={`container ${s.content}`}>
         {/* Cover — `hero-cover` class lets HeroAccent's halo CSS attach.
-            Halo color comes from --poster-accent on the HeroAccent wrapper. */}
-        <div style={{ flexShrink: 0 }}>
+            Halo color comes from --poster-accent on the HeroAccent wrapper.
+            The width/height attributes still carry the intrinsic ratio (they
+            are what reserves the box before decode); the module sizes it. */}
+        <div className={s.coverSlot}>
           {detail.coverImageUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
             <FadeImage
@@ -618,34 +504,33 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
               width={210}
               height={300}
               priority
-              className="hero-cover"
-              style={S.cover}
+              className={`hero-cover ${s.cover}`}
             />
           ) : (
-            <div style={{ ...S.cover, background: "#2c2c2e" }} aria-hidden />
+            <div className={s.coverPlaceholder} aria-hidden />
           )}
         </div>
 
         {/* Meta */}
-        <div style={{ flex: 1, minWidth: 280, paddingTop: detail.bannerImageUrl ? 60 : 0 }}>
-          <h1 style={S.title}>{title}</h1>
+        <div className={s.meta}>
+          <h1 className={s.title}>{title}</h1>
           {SHOWS_ORIGINAL_SUBTITLE[lang] && (detail.titleNative || detail.titleRomaji) && (
-            <p style={S.subtitle}>{detail.titleNative || detail.titleRomaji}</p>
+            <p className={s.subtitle}>{detail.titleNative || detail.titleRomaji}</p>
           )}
 
           {/* Badges */}
-          <div style={S.badgeRow}>
+          <div className={s.badgeRow}>
             {score && score > 0 ? (
-              <span style={{ ...S.scoreBadge, ...scoreBadgeStyle(score) }}>
+              <span className={s.scoreBadge} style={scoreBadgeStyle(score)}>
                 {"★"} {formatScore(score)}
               </span>
             ) : null}
             {detail.bangumiScore && detail.bangumiScore > 0 ? (
-              <span style={S.bgmScoreBadge}>
-                <span style={S.bgmLabel}>BGM</span>
+              <span className={s.bgmScoreBadge}>
+                <span className={s.bgmLabel}>BGM</span>
                 {"★"} {detail.bangumiScore.toFixed(1)}
                 {detail.bangumiVotes && detail.bangumiVotes > 0 ? (
-                  <span style={S.bgmVotes}>({detail.bangumiVotes.toLocaleString()})</span>
+                  <span className={s.bgmVotes}>({detail.bangumiVotes.toLocaleString()})</span>
                 ) : null}
               </span>
             ) : null}
@@ -653,27 +538,23 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
               // Client leaf so this follows the cookie language rather than
               // the server-pinned zh — see the route note at the top of this
               // file for why only this and the genre row get that treatment.
-              <FormatBadge
-                format={detail.format}
-                style={S.badge("rgba(10,132,255,0.12)", "#0a84ff")}
-              />
+              <FormatBadge format={detail.format} className={s.badgeAccent} />
             )}
             {detail.status && (
-              <span style={S.badge("rgba(90,200,250,0.10)", "#5ac8fa")}>
-                {statusLabel(dict, detail.status)}
-              </span>
+              <span className={s.badgeInfo}>{statusLabel(dict, detail.status)}</span>
             )}
             {episodeSkeleton.kind === "authoritative" ? (
-              <span style={S.badge("rgba(120,120,128,0.12)", "rgba(235,235,245,0.60)")}>
+              <span className={s.badgeNeutral}>
                 {episodeSkeleton.total} {dict.detail.epUnit}
               </span>
             ) : (
-              <span style={S.badge("rgba(120,120,128,0.12)", "rgba(235,235,245,0.42)")}>
-                {dict.detail.episodeCountPending}
-              </span>
+              // Muted rather than neutral: this is the "we do not have an
+              // authoritative count" case, and it should not read with the
+              // same confidence as a real number sitting next to it.
+              <span className={s.badgeMuted}>{dict.detail.episodeCountPending}</span>
             )}
             {seasonLab && detail.seasonYear ? (
-              <span style={S.badge("rgba(120,120,128,0.12)", "rgba(235,235,245,0.60)")}>
+              <span className={s.badgeNeutral}>
                 {seasonLab} {detail.seasonYear}
               </span>
             ) : null}
@@ -682,9 +563,9 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
                 href={`https://bgm.tv/subject/${detail.bgmId}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                style={S.bgmLink}
+                className={s.bgmLink}
               >
-                <span style={{ fontSize: 10, opacity: 0.8 }}>{"▶"}</span>
+                <span className={s.bgmArrow}>{"▶"}</span>
                 {dict.detail.viewOnBgm}
               </a>
             ) : null}
@@ -692,17 +573,17 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
 
           {/* Meta row */}
           {(detail.studios.length > 0 || sourceText || durationText || startDateLabel) && (
-            <div style={S.metaRow}>
+            <div className={s.metaRow}>
               {detail.studios.length > 0 && (
-                <span style={S.metaStudio}>{detail.studios.join(" · ")}</span>
+                <span className={s.metaStudio}>{detail.studios.join(" · ")}</span>
               )}
               {detail.studios.length > 0 &&
                 (sourceText || durationText || startDateLabel) && (
-                  <span style={S.metaDot}>{"·"}</span>
+                  <span className={s.metaDot}>{"·"}</span>
                 )}
-              {sourceText && <span style={S.metaDetail}>{sourceText}</span>}
-              {durationText && <span style={S.metaDetail}>{durationText}</span>}
-              {startDateLabel && <span style={S.metaDetail}>{startDateLabel}</span>}
+              {sourceText && <span className={s.metaDetail}>{sourceText}</span>}
+              {durationText && <span className={s.metaDetail}>{durationText}</span>}
+              {startDateLabel && <span className={s.metaDetail}>{startDateLabel}</span>}
             </div>
           )}
 
@@ -712,13 +593,13 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
               schema.org keeps the English AniList vocabulary. */}
           <GenreChips
             genres={detail.genres}
-            style={S.genreRow}
-            chipStyle={S.genreTag}
+            className={s.genreRow}
+            chipClassName={s.genreTag}
           />
 
           {/* Description with 展开更多 / 收起 toggle */}
           {descFull && (
-            <div style={{ marginBottom: heroRelations.length > 0 ? 20 : 0 }}>
+            <div className={heroRelations.length > 0 ? s.descBlock : s.descBlockLast}>
               <DescriptionExpand
                 truncated={descTruncated}
                 full={descFull}
@@ -748,14 +629,7 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
               instead of forcing the user to scroll to the relations
               section. The full RelationsSection still renders below. */}
           {heroRelations.length > 0 && (
-            <div
-              style={{
-                display: "flex",
-                flexWrap: "wrap",
-                gap: 8,
-                marginTop: 12,
-              }}
-            >
+            <div className={s.relationRow}>
               {heroRelations.map((r) => {
                 const relLabel =
                   relationLabel(r.relationType, lang);
@@ -788,14 +662,7 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
                       textDecoration: "none",
                     }}
                   >
-                    <span
-                      style={{
-                        color: "rgba(235,235,245,0.35)",
-                        fontSize: 11,
-                      }}
-                    >
-                      {relLabel}
-                    </span>
+                    <span className={s.relationLabel}>{relLabel}</span>
                     {relTitle}
                   </Link>
                 );
@@ -960,7 +827,7 @@ function CharactersSection({
 
   return (
     <section style={{ marginTop: 40 }}>
-      <h2 style={S.sectionLabel as CSSProperties}>{label}</h2>
+      <h2 className={s.sectionLabel}>{label}</h2>
       <div
         style={{
           display: "grid",
@@ -1126,7 +993,7 @@ function StaffSectionView({ staff, lang, dict }: { staff: DetailStaff[]; lang: L
 
   return (
     <section style={{ marginTop: 40 }}>
-      <h2 style={S.sectionLabel as CSSProperties}>{label}</h2>
+      <h2 className={s.sectionLabel}>{label}</h2>
       <div
         style={{
           display: "grid",
@@ -1227,7 +1094,7 @@ function RecommendationsSection({
 
   return (
     <section style={{ marginTop: 40, marginBottom: 60 }}>
-      <h2 style={S.sectionLabel as CSSProperties}>{label}</h2>
+      <h2 className={s.sectionLabel}>{label}</h2>
       <div
         style={{
           display: "flex",

--- a/next-app/src/app/[lang]/anime/[id]/page.tsx
+++ b/next-app/src/app/[lang]/anime/[id]/page.tsx
@@ -25,6 +25,7 @@ import EpisodesGrid from "@/components/anime/EpisodesGrid";
 import { resolveEpisodeSkeleton } from "@/components/anime/episodeGridSkeleton";
 import HeroAccent from "@/components/anime/HeroAccent";
 import { FormatBadge, GenreChips } from "@/components/anime/LocalizedChips";
+import { scoreBadgeStyle } from "@/components/anime/scoreStyle";
 import WatchersAvatarList from "@/components/anime/WatchersAvatarList";
 import { apiGet, ApiError } from "@/lib/api";
 import {
@@ -194,11 +195,11 @@ const SHOWS_ORIGINAL_SUBTITLE: Record<Lang, boolean> = {
   "zh-Hant": true,
 };
 
-function scoreColor(s: number): string {
-  if (s >= 75) return "#30d158";
-  if (s >= 50) return "#ff9f0a";
-  return "#ff453a";
-}
+// scoreColor lived here and shipped a bug: it returned one of three band
+// colours while S.scoreBadge hardcoded an amber background, so every anime
+// rated 75+ rendered green text on an amber pill. It now lives in
+// @/components/anime/scoreStyle, which returns the two together and can be
+// imported by a test — this file cannot. See that module's header.
 
 function statusLabel(dict: Dict, status: string | null): string {
   if (!status) return "";
@@ -324,15 +325,17 @@ const S = {
     color,
     fontSize: 13,
   }),
-  scoreBadge: (color: string): CSSProperties => ({
+  // Layout only. The two colour properties come from scoreBadgeStyle(score)
+  // and are spread in at the call site — deliberately not accepted as
+  // parameters here, because a `scoreBadge(color)` signature is exactly what
+  // let the foreground vary while this background stayed amber.
+  scoreBadge: {
     padding: "4px 12px",
     borderRadius: 9999,
-    background: "rgba(255,159,10,0.12)",
-    color,
-    fontWeight: 700,
+    fontWeight: 700 as const,
     fontSize: 13,
     fontFamily: "'JetBrains Mono', monospace",
-  }),
+  },
   bgmScoreBadge: {
     padding: "4px 12px",
     borderRadius: 9999,
@@ -633,7 +636,7 @@ function Hero({ detail, lang, dict }: { detail: AnimeDetail; lang: Lang; dict: D
           {/* Badges */}
           <div style={S.badgeRow}>
             {score && score > 0 ? (
-              <span style={S.scoreBadge(scoreColor(score))}>
+              <span style={{ ...S.scoreBadge, ...scoreBadgeStyle(score) }}>
                 {"★"} {formatScore(score)}
               </span>
             ) : null}

--- a/next-app/src/app/[lang]/player/_components/EpisodeFileList.tsx
+++ b/next-app/src/app/[lang]/player/_components/EpisodeFileList.tsx
@@ -6,14 +6,17 @@ import { useLang } from "@/lib/lang-client";
 import { formatScore } from "@/lib/formatters";
 import { durationLabel, sourceLabel } from "@/lib/contentLabels";
 import FadeImage from "@/components/ui/FadeImage";
+import { scoreBadgeStyle } from "@/components/anime/scoreStyle";
 import { CornerBrackets } from "@/components/landing/shared/hud";
 import { mono, PLAYER_HUE } from "@/components/landing/shared/hud-tokens";
 import { localizeHref, useLocale } from "@/components/ui/LocaleLink";
 
 const HUE = PLAYER_HUE.stream;
 
-const scoreColor = (v: number) =>
-  v >= 75 ? "#30d158" : v >= 50 ? "#ff9f0a" : "#ff453a";
+// The band thresholds used to be a third copy of the same ladder, paired
+// with a hardcoded amber background one screen down — the same defect the
+// detail page shipped, on the same shape of badge. Both now read
+// @/components/anime/scoreStyle, which hands back the two colours together.
 
 // OKLCH per-episode hue rotation: 210, 220, 230, ... cycles through the spectrum.
 const epHue = (ep: number | null | undefined) =>
@@ -80,15 +83,14 @@ const s = {
     gap: 8,
     marginBottom: 10,
   } as CSSProperties,
-  scoreBadge: (color: string): CSSProperties => ({
+  // Layout only — the colour pair is spread in from scoreBadgeStyle(score).
+  scoreBadge: {
     padding: "3px 10px",
     borderRadius: 9999,
-    background: "rgba(255,159,10,0.12)",
-    color,
     fontWeight: 700,
     fontSize: 12,
     fontFamily: "'JetBrains Mono',monospace",
-  }),
+  } as CSSProperties,
   bgmScoreBadge: {
     padding: "3px 10px",
     borderRadius: 9999,
@@ -479,7 +481,7 @@ function EpisodeFileList({
               {/* Score + info badges */}
               <div style={s.badgeRow}>
                 {Number.isFinite(avgScore) && avgScore > 0 && (
-                  <span style={s.scoreBadge(scoreColor(avgScore))}>
+                  <span style={{ ...s.scoreBadge, ...scoreBadgeStyle(avgScore) }}>
                     ★ {formatScore(avgScore)}
                   </span>
                 )}

--- a/next-app/src/app/globals.css
+++ b/next-app/src/app/globals.css
@@ -1,22 +1,124 @@
-
+/* Design tokens — the vocabulary DESIGN.md defines.
+ *
+ * This block is generated from DESIGN.md by hand and pinned to it by
+ * globals.test.ts. Read that file before changing a value here; a token that
+ * disagrees with the spec is worse than a missing one, because the spec is
+ * what the next component gets built against.
+ *
+ * Until this commit the block held 10 of the 31 tokens the spec defines, and
+ * six of the ten had drifted. The whole spacing scale, the whole radius
+ * scale, every semantic colour and both fill colours were simply absent —
+ * so every component that needed them hardcoded a literal instead, and the
+ * design system existed only as a document. Measured before the fix: across
+ * all of src/, `--accent` had 9 references, `--bg` and `--text` one each,
+ * and the entire rest of the palette had zero.
+ *
+ * That is also why correcting the six drifted values is safe rather than a
+ * visual change: none of the six had a single `var()` reference anywhere in
+ * the tree. They were dead declarations describing a palette nothing read.
+ */
 :root {
-  --bg: #000;
-  --bg-card: #0a0a0a;
-  --bg-elevated: #141414;
-  --text: #fff;
-  --text-secondary: rgba(235, 235, 245, 0.85);
-  --text-tertiary: rgba(235, 235, 245, 0.60);
-  --text-quaternary: rgba(235, 235, 245, 0.30);
-  --separator: rgba(84, 84, 88, 0.30);
-  --accent: #0a84ff;
+  /* ── Backgrounds — Apple True Black system ──────────────────────────
+   * Three layers, and the elevation between them is carried by the colour
+   * difference rather than by shadow. --bg-card and --bg-elevated had
+   * drifted to #0a0a0a / #141414, which collapses that difference to almost
+   * nothing on an OLED panel. */
+  --bg: #000000;
+  --bg-card: #1c1c1e;
+  --bg-elevated: #2c2c2e;
+  --bg-fill: rgba(120, 120, 128, 0.12);
+  --separator: rgba(84, 84, 88, 0.65);
+  --separator-opaque: #38383a;
 
+  /* ── Accent — iOS Blue, the only interactive colour ─────────────────
+   * Reserved for things you can act on: buttons, links, focus rings,
+   * progress. Decorative blue is a spec violation, not a style choice. */
+  --accent: #0a84ff;
+  --accent-hover: #409cff;
+  --accent-active: #0070d6;
+  --accent-dim: rgba(10, 132, 255, 0.12);
+
+  /* ── Secondary — iOS Teal, strictly read-only ───────────────────────
+   * Information surfaces only: labels, magnet metadata, code highlights.
+   * Never a clickable element — that is what makes --accent legible as
+   * "this does something". */
+  --teal: #5ac8fa;
+  --teal-dim: rgba(90, 200, 250, 0.10);
+
+  /* ── Text — Apple label system ──────────────────────────────────────
+   * rgba rather than fixed greys so each level composites correctly over
+   * all three background layers. */
+  --text: #ffffff;
+  --text-secondary: rgba(235, 235, 245, 0.60);
+  --text-tertiary: rgba(235, 235, 245, 0.30);
+  /* ~2.5:1 on --bg, which is below WCAG AA for text. It is the disabled /
+   * inactive token, and disabled controls are exempt (WCAG 1.4.3 excludes
+   * inactive components). Do not reach for it to make content "quieter" —
+   * that use is not exempt. --text-tertiary is the floor for readable copy. */
+  --text-quaternary: rgba(235, 235, 245, 0.18);
+
+  /* ── Semantic — Apple system colours ────────────────────────────────
+   * Meaning, not decoration. --info is deliberately the same value as
+   * --teal: informational IS the read-only case, and giving it a second
+   * name that could drift from the first would be the bug. */
+  --success: #30d158;
+  --warning: #ff9f0a;
+  --error: #ff453a;
+  --info: #5ac8fa;
+
+  /* ── Score badge — three bands, background and foreground paired ─────
+   * Each band ships as a pair because the badge needs both and the two
+   * must move together. Splitting them is what produced the live defect
+   * this replaces: the foreground came from a threshold function and the
+   * background was hardcoded amber, so a 90-rated anime rendered green
+   * text on an amber pill. See components/anime/scoreStyle.ts, which is
+   * the only thing allowed to choose between them. */
+  --score-high-fg: #30d158;
+  --score-high-bg: rgba(48, 209, 88, 0.12);
+  --score-mid-fg: #ff9f0a;
+  --score-mid-bg: rgba(255, 159, 10, 0.12);
+  --score-low-fg: #ff453a;
+  --score-low-bg: rgba(255, 69, 58, 0.12);
+  /* The over-artwork variant. A 12% band tint has no contrast guarantee
+   * against a cover that could be any colour, and anime covers are
+   * deliberately saturated, so a badge sitting on one gets an opaque scrim
+   * and lets only the text carry the band. */
+  --score-scrim-bg: rgba(0, 0, 0, 0.75);
+
+  /* ── Typography ─────────────────────────────────────────────────────── */
   --font-display: "Sora", system-ui, sans-serif;
   --font-sans: "DM Sans", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
 
+  /* ── Spacing — 8px base ─────────────────────────────────────────────
+   * The whole scale was missing, so every component picked its own
+   * numbers. Present here so the next one does not have to. */
+  --sp-xs: 4px;
+  --sp-sm: 8px;
+  --sp-md: 16px;
+  --sp-lg: 24px;
+  --sp-xl: 32px;
+  --sp-2xl: 48px;
+  --sp-3xl: 64px;
+
+  /* ── Radius ─────────────────────────────────────────────────────────
+   * --radius-xl is for large sheets and modals only; DESIGN.md bars a
+   * radius above 16px on cards and above 12px on cover art. */
+  --radius-sm: 8px;
+  --radius: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+  --radius-full: 9999px;
+
+  /* ── Motion ─────────────────────────────────────────────────────────── */
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
 
-  /* Per-anime poster accent (overridden by HeroAccent wrapper on the detail page) */
+  /* Per-anime poster accent (overridden by HeroAccent wrapper on the detail
+   * page). Exempt from the "no accent but blue" rule on purpose: this one is
+   * sampled from the cover artwork at runtime, so it is not a brand colour
+   * the design system gets to choose. The violet below is only the value
+   * held before the sampled colour arrives, and the halo that uses it stays
+   * transparent until [data-accent-ready="true"] — so it is never painted. */
   --poster-accent: #8b5cf6;
   --poster-accent-rgb: 139, 92, 246;
   --duration-halo-in: 260ms;

--- a/next-app/src/app/globals.test.ts
+++ b/next-app/src/app/globals.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// The gate that keeps DESIGN.md and globals.css from drifting apart again.
+//
+// They had. Before this suite existed the spec defined 31 tokens and the
+// stylesheet declared 10 of them, six of those with the wrong value — and
+// nothing anywhere said so, because a missing custom property is not an
+// error in CSS. `var(--sp-lg)` against an undeclared token silently resolves
+// to nothing and the declaration is dropped, so the failure mode of this
+// particular drift is a component that looks *almost* right.
+//
+// The consequence was not cosmetic: with two thirds of the vocabulary
+// absent, every component that needed a radius or a spacing step hardcoded a
+// literal, and the design system ended up existing only as a document.
+// Measured at the time: across all of src/, `--accent` had 9 references,
+// `--bg` and `--text` one each, and the rest of the palette had zero.
+//
+// Two assertions, doing different jobs:
+//
+//   · completeness — every token DESIGN.md names is declared. Parsed from
+//     the spec, so adding a token to the document is enough to make this
+//     fail until the stylesheet catches up. This is the drift that happened.
+//
+//   · values — an explicit table. A second copy, deliberately: it is what
+//     catches someone editing globals.css directly, which the parsed check
+//     cannot see (a wrong value is still a declaration).
+
+const CSS = readFileSync(join(import.meta.dir, "globals.css"), "utf8");
+const DESIGN = readFileSync(join(import.meta.dir, "../../../DESIGN.md"), "utf8");
+
+/** The `:root` block — the only place tokens may be declared. */
+const ROOT = CSS.slice(CSS.indexOf(":root"), CSS.indexOf("\n}", CSS.indexOf(":root")));
+
+/** Every `--token: value` declared in `:root`, comments stripped. */
+function declaredTokens(): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const [, name, value] of ROOT.replace(/\/\*[\s\S]*?\*\//g, "").matchAll(
+    /(--[a-z0-9-]+)\s*:\s*([^;]+);/gi,
+  )) {
+    out.set(name, value.trim());
+  }
+  return out;
+}
+
+/** Every `--token` DESIGN.md mentions inside a backtick. */
+function specifiedTokens(): Set<string> {
+  return new Set([...DESIGN.matchAll(/`(--[a-z0-9-]+)`/gi)].map((m) => m[1]));
+}
+
+const declared = declaredTokens();
+const specified = specifiedTokens();
+
+/**
+ * Tokens the stylesheet owns that DESIGN.md does not describe.
+ *
+ * These are runtime mechanics rather than palette: the poster accent is
+ * sampled from cover art (DESIGN.md documents the concept but the halo
+ * timings are implementation), and the accent hover/active steps are given
+ * in the Buttons section as bare hex without a token name.
+ */
+const NOT_IN_SPEC = new Set([
+  "--poster-accent",
+  "--poster-accent-rgb",
+  "--duration-halo-in",
+  "--duration-halo-in-fast",
+  "--delay-halo-appear",
+  "--accent-hover",
+  "--accent-active",
+  "--font-display",
+  "--font-sans",
+  "--font-mono",
+  "--ease-out-expo",
+]);
+
+describe("completeness", () => {
+  test("every token DESIGN.md names is declared in globals.css", () => {
+    const missing = [...specified].filter((t) => !declared.has(t)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  test("the spec is actually being read (guards the parser, not the CSS)", () => {
+    // Without this, a regex that silently matched nothing would make the
+    // check above pass forever — the failure mode of every "parse the docs"
+    // test. 31 is the count at the time of writing; it may only grow.
+    expect(specified.size).toBeGreaterThanOrEqual(31);
+    expect(specified.has("--sp-lg")).toBe(true);
+    expect(specified.has("--radius-full")).toBe(true);
+  });
+
+  test("globals.css declares nothing outside the spec but the documented mechanics", () => {
+    // The reverse direction. A token invented in CSS and never written down
+    // is how the next palette starts drifting.
+    const undocumented = [...declared.keys()]
+      .filter((t) => !specified.has(t) && !NOT_IN_SPEC.has(t))
+      .sort();
+    expect(undocumented).toEqual([]);
+  });
+});
+
+describe("values", () => {
+  // Straight from DESIGN.md's tables. Whitespace inside rgba() is normalised
+  // before comparing, since the stylesheet is prettier-formatted and the
+  // document is not.
+  const EXPECTED: Record<string, string> = {
+    "--bg": "#000000",
+    "--bg-card": "#1c1c1e",
+    "--bg-elevated": "#2c2c2e",
+    "--bg-fill": "rgba(120,120,128,0.12)",
+    "--separator": "rgba(84,84,88,0.65)",
+    "--separator-opaque": "#38383a",
+
+    "--accent": "#0a84ff",
+    "--accent-dim": "rgba(10,132,255,0.12)",
+
+    "--teal": "#5ac8fa",
+    "--teal-dim": "rgba(90,200,250,0.10)",
+
+    "--text": "#ffffff",
+    "--text-secondary": "rgba(235,235,245,0.60)",
+    "--text-tertiary": "rgba(235,235,245,0.30)",
+    "--text-quaternary": "rgba(235,235,245,0.18)",
+
+    "--success": "#30d158",
+    "--warning": "#ff9f0a",
+    "--error": "#ff453a",
+    "--info": "#5ac8fa",
+
+    "--sp-xs": "4px",
+    "--sp-sm": "8px",
+    "--sp-md": "16px",
+    "--sp-lg": "24px",
+    "--sp-xl": "32px",
+    "--sp-2xl": "48px",
+    "--sp-3xl": "64px",
+
+    "--radius-sm": "8px",
+    "--radius": "12px",
+    "--radius-lg": "16px",
+    "--radius-xl": "20px",
+    "--radius-full": "9999px",
+
+    "--score-high-fg": "#30d158",
+    "--score-high-bg": "rgba(48,209,88,0.12)",
+    "--score-mid-fg": "#ff9f0a",
+    "--score-mid-bg": "rgba(255,159,10,0.12)",
+    "--score-low-fg": "#ff453a",
+    "--score-low-bg": "rgba(255,69,58,0.12)",
+    "--score-scrim-bg": "rgba(0,0,0,0.75)",
+  };
+
+  const strip = (v: string) => v.replace(/\s+/g, "").toLowerCase();
+
+  for (const [token, want] of Object.entries(EXPECTED)) {
+    test(`${token} is ${want}`, () => {
+      expect(declared.get(token)).toBeDefined();
+      expect(strip(declared.get(token)!)).toBe(strip(want));
+    });
+  }
+
+  test("the count is what the spec says it is", () => {
+    // 21 tokens were added in one commit to close this gap. Pinning the
+    // total makes a silent deletion fail rather than shrinking the palette
+    // back toward where it started.
+    expect(Object.keys(EXPECTED)).toHaveLength(37);
+  });
+});
+
+describe("semantic coupling", () => {
+  test("--info and --teal are the same colour", () => {
+    // Informational IS the read-only case. They are two names for one role;
+    // letting them drift apart would be the bug, not the fix.
+    expect(declared.get("--info")).toBe(declared.get("--teal")!);
+  });
+
+  test("each score band's foreground matches its semantic colour", () => {
+    // The bands are not a private palette — they are --success / --warning /
+    // --error under a task-specific name. If they drift, a "good" score
+    // stops being the same green as every other success on the site.
+    expect(declared.get("--score-high-fg")).toBe(declared.get("--success")!);
+    expect(declared.get("--score-mid-fg")).toBe(declared.get("--warning")!);
+    expect(declared.get("--score-low-fg")).toBe(declared.get("--error")!);
+  });
+
+  test("every score band declares both halves", () => {
+    // The shape of the production defect: a foreground with no matching
+    // background is what let the page pair green text with an amber pill.
+    for (const band of ["high", "mid", "low"]) {
+      expect(declared.has(`--score-${band}-fg`)).toBe(true);
+      expect(declared.has(`--score-${band}-bg`)).toBe(true);
+    }
+  });
+});

--- a/next-app/src/components/anime/AnimeCard.tsx
+++ b/next-app/src/components/anime/AnimeCard.tsx
@@ -9,6 +9,7 @@ import type { Lang } from "@/lib/i18n";
 import { useLang } from "@/lib/lang-client";
 import type { LandingPoster } from "@/lib/types";
 import FadeImage from "@/components/ui/FadeImage";
+import { scoreScrimStyle } from "./scoreStyle";
 import QuickSubscribeToggle from "./QuickSubscribeToggle";
 
 // AnimeCard accepts any record that carries the title fields, cover, and
@@ -67,11 +68,11 @@ const DISCUSSION_ARIA: Record<Lang, (count: number) => string> = {
   "zh-Hant": (count) => `${count} 條討論`,
 };
 
-function scoreColor(s: number): string {
-  if (s >= 75) return "#30d158";
-  if (s >= 50) return "#ff9f0a";
-  return "#ff453a";
-}
+// The band thresholds were a third verbatim copy of the same ladder. This
+// card's treatment was the correct one — an opaque scrim under band-coloured
+// text, because a 12% tint has no contrast guarantee over cover art — and it
+// is now the `scoreScrimStyle` half of @/components/anime/scoreStyle rather
+// than a local rule that happened to agree.
 
 // The card is a plain box that owns the frame (border/radius/clip) and the
 // hover transition; the <a> lives inside it and the quick-subscribe <button>
@@ -161,11 +162,12 @@ const formatBadgeStyle: CSSProperties = {
   letterSpacing: "0.5px",
 };
 
+// Layout and the blur only. `background` moved into scoreScrimStyle so the
+// scrim and the band foreground arrive together — see scoreStyle.ts.
 const scoreBadgeBase: CSSProperties = {
   position: "absolute",
   top: 8,
   right: 8,
-  background: "rgba(0,0,0,0.75)",
   backdropFilter: "blur(8px)",
   fontSize: 11,
   fontWeight: 700,
@@ -384,7 +386,7 @@ export default function AnimeCard({
 
         {anime.averageScore != null && anime.averageScore > 0 ? (
           <span
-            style={{ ...scoreBadgeBase, color: scoreColor(anime.averageScore) }}
+            style={{ ...scoreBadgeBase, ...scoreScrimStyle(anime.averageScore) }}
             aria-hidden
           >
             ★ {formatScore(anime.averageScore)}

--- a/next-app/src/components/anime/HeroCarousel.module.css
+++ b/next-app/src/components/anime/HeroCarousel.module.css
@@ -41,8 +41,14 @@
   background: #07090c;
 }
 
+/* Inset because the carousel is full-bleed and an outer ring would be
+ * clipped — that part is a legitimate variation. The COLOUR is not: it drew
+ * --hero-accent, which is sampled from whichever poster is on screen, so the
+ * focus ring changed colour as the carousel rotated and could land on a hue
+ * indistinguishable from the artwork behind it. DESIGN.md's poster-accent
+ * rule names focus rings specifically. */
 .root:focus-visible {
-  box-shadow: inset 0 0 0 2px var(--hero-accent);
+  box-shadow: inset 0 0 0 3px rgba(10, 132, 255, 0.4);
 }
 
 .slide {

--- a/next-app/src/components/anime/LocalizedChips.tsx
+++ b/next-app/src/components/anime/LocalizedChips.tsx
@@ -30,17 +30,21 @@
 // server-rendered and therefore zh — see the route note at the top of
 // app/anime/[id]/page.tsx for why the line is drawn here.
 
-import type { CSSProperties } from "react";
 import { formatLabel, genreLabel } from "@/lib/contentLabels";
 import { useLang } from "@/lib/lang-client";
+
+// These take class names, not style objects. The caller (the detail page)
+// used to hand over inline CSSProperties, which meant its chips could never
+// grow a hover or a focus state — an inline declaration beats any stylesheet
+// rule, so the CSS would have been written and then silently ignored.
 
 interface GenreChipsProps {
   /** Raw AniList genre enums, e.g. ["Action", "Slice of Life"]. */
   genres: readonly string[];
-  /** Style for the wrapping row (the RSC passes its inline token object). */
-  style?: CSSProperties;
-  /** Style applied to every chip. */
-  chipStyle?: CSSProperties;
+  /** Class for the wrapping row. */
+  className?: string;
+  /** Class applied to every chip. */
+  chipClassName?: string;
 }
 
 /**
@@ -48,13 +52,13 @@ interface GenreChipsProps {
  * is localised; the underlying enum value is untouched, so nothing here
  * changes the values used in /search?genre= links elsewhere.
  */
-export function GenreChips({ genres, style, chipStyle }: GenreChipsProps) {
+export function GenreChips({ genres, className, chipClassName }: GenreChipsProps) {
   const { lang } = useLang();
   if (!genres.length) return null;
   return (
-    <div style={style}>
+    <div className={className}>
       {genres.map((g) => (
-        <span key={g} style={chipStyle}>
+        <span key={g} className={chipClassName}>
           {genreLabel(g, lang)}
         </span>
       ))}
@@ -65,12 +69,12 @@ export function GenreChips({ genres, style, chipStyle }: GenreChipsProps) {
 interface FormatBadgeProps {
   /** Raw AniList format enum, e.g. "TV_SHORT". */
   format: string;
-  style?: CSSProperties;
+  className?: string;
 }
 
 /** Hero format badge — "TV_SHORT" → "TV 短篇" (zh) / "Short" (en). */
-export function FormatBadge({ format, style }: FormatBadgeProps) {
+export function FormatBadge({ format, className }: FormatBadgeProps) {
   const { lang } = useLang();
   if (!format) return null;
-  return <span style={style}>{formatLabel(format, lang)}</span>;
+  return <span className={className}>{formatLabel(format, lang)}</span>;
 }

--- a/next-app/src/components/anime/MagnetButton.tsx
+++ b/next-app/src/components/anime/MagnetButton.tsx
@@ -3,48 +3,23 @@
 // Outline button that opens the TorrentModal. Pulled out of
 // DetailActions so the modal trigger has its own hover state without
 // re-rendering the rest of the row.
+//
+// The hover and focus state it used to hold — two useState hooks and four
+// handlers driving an inline style object — is now the `outline` variant of
+// components/ui/Button. Identical to what ShareButton held, character for
+// character, which is why both moved at once.
 
-import { useState } from "react";
+import Button from "@/components/ui/Button";
 
 interface MagnetButtonProps {
   onOpen: () => void;
   label: string;
 }
 
-const baseStyle = {
-  padding: "10px 18px",
-  borderRadius: 8,
-  fontSize: 13,
-  fontWeight: 600,
-  cursor: "pointer",
-  minHeight: 40,
-  outline: "none",
-  transition:
-    "background 150ms, border-color 150ms, color 150ms, transform 120ms, box-shadow 150ms",
-} as const;
-
 export default function MagnetButton({ onOpen, label }: MagnetButtonProps) {
-  const [hover, setHover] = useState(false);
-  const [focus, setFocus] = useState(false);
-
   return (
-    <button
-      type="button"
-      onClick={onOpen}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      onFocus={() => setFocus(true)}
-      onBlur={() => setFocus(false)}
-      style={{
-        ...baseStyle,
-        border: `1px solid ${hover ? "rgba(120,120,128,0.9)" : "rgba(84,84,88,0.65)"}`,
-        background: hover ? "rgba(120,120,128,0.12)" : "transparent",
-        color: hover ? "rgba(255,255,255,0.92)" : "rgba(235,235,245,0.60)",
-        transform: hover ? "translateY(-1px)" : "none",
-        boxShadow: focus ? "0 0 0 3px rgba(120,120,128,0.28)" : "none",
-      }}
-    >
+    <Button variant="outline" onClick={onOpen}>
       {label}
-    </button>
+    </Button>
   );
 }

--- a/next-app/src/components/anime/PlayButton.module.css
+++ b/next-app/src/components/anime/PlayButton.module.css
@@ -1,30 +1,6 @@
-.trigger {
-  min-height: 40px;
-  padding: 10px 18px;
-  border: 0;
-  border-radius: 8px;
-  background: #0a84ff;
-  color: #fff;
-  cursor: pointer;
-  font-size: 13px;
-  font-weight: 650;
-  outline: none;
-  transition: background 150ms ease, transform 120ms ease, box-shadow 150ms ease;
-}
-
-.trigger:hover {
-  background: #409cff;
-  box-shadow: 0 2px 8px rgba(10, 132, 255, 0.35);
-  transform: translateY(-1px);
-}
-
-/* 0.40, not a rounder-looking 0.45: the focus ring is specified once in
- * DESIGN.md and every focusable element in the app draws the same one. A ring
- * that differs by component is a ring people stop trusting to mean the same
- * thing. */
-.trigger:focus-visible {
-  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.4);
-}
+/* `.trigger` moved to components/ui/Button as the `primary` variant. It was
+ * the third copy of the same button surface — ShareButton and MagnetButton
+ * held the other two, as inline style objects. */
 
 .backdrop {
   position: fixed;
@@ -282,8 +258,3 @@
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .trigger {
-    transition: none;
-  }
-}

--- a/next-app/src/components/anime/PlayButton.module.css
+++ b/next-app/src/components/anime/PlayButton.module.css
@@ -56,11 +56,21 @@
   place-items: center;
 }
 
-.close:hover,
+.close:hover {
+  border-color: rgba(10, 132, 255, 0.55);
+  color: #fff;
+}
+
+/* Was folded in with :hover and set `outline: none`, which left keyboard
+ * focus indicated by a border-colour change alone — on a 32px circle, on a
+ * dark backdrop. The dialog's only dismiss control needs the same ring as
+ * everything else. */
 .close:focus-visible {
   border-color: rgba(10, 132, 255, 0.55);
   color: #fff;
-  outline: none;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.4);
 }
 
 .headingRow {
@@ -181,7 +191,9 @@
   align-items: center;
   justify-content: center;
   gap: 10px;
-  min-height: 42px;
+  /* 44px, DESIGN.md's touch floor. Was 42 — close enough to look considered
+   * and still two pixels under the number it was aiming at. */
+  min-height: 44px;
   padding: 0 17px;
   border-radius: 8px;
   cursor: pointer;
@@ -228,11 +240,17 @@
   color: #fff;
 }
 
+/* Blue, not the #64d2ff these drew. Teal is the read-only colour in this
+ * system — the file already says so, twenty lines up, about the secondary
+ * button's fill — and a focus ring is the most load-bearing "you can act on
+ * this" signal there is. Three different focus treatments lived in this one
+ * file; this is the last of them. */
 .primary:focus-visible,
 .secondary:focus-visible,
 .tertiary:focus-visible {
-  outline: 2px solid #64d2ff;
+  outline: 2px solid transparent;
   outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.4);
 }
 
 @media (max-width: 540px) {

--- a/next-app/src/components/anime/PlayButton.tsx
+++ b/next-app/src/components/anime/PlayButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import Button from "@/components/ui/Button";
 import Link from "@/components/ui/LocaleLink";
 import { useLang } from "@/lib/lang-client";
 import styles from "./PlayButton.module.css";
@@ -60,17 +61,16 @@ export default function PlayButton({
 
   return (
     <>
-      <button
+      <Button
         ref={triggerRef}
-        type="button"
+        variant="primary"
         onClick={() => setOpen(true)}
         aria-label={ariaLabel}
         aria-haspopup="dialog"
         aria-expanded={open}
-        className={styles.trigger}
       >
         {children}
-      </button>
+      </Button>
 
       {open ? (
         <div

--- a/next-app/src/components/anime/ShareButton.tsx
+++ b/next-app/src/components/anime/ShareButton.tsx
@@ -6,6 +6,7 @@
 // alert() is too disruptive and there's no global toast wired yet.
 
 import { useState } from "react";
+import Button from "@/components/ui/Button";
 
 interface ShareButtonProps {
   anilistId: number;
@@ -17,42 +18,17 @@ interface ShareButtonProps {
   };
 }
 
-const baseStyle = {
-  padding: "10px 18px",
-  borderRadius: 8,
-  fontSize: 13,
-  fontWeight: 600,
-  cursor: "pointer",
-  minHeight: 40,
-  outline: "none",
-  transition:
-    "background 150ms, border-color 150ms, color 150ms, transform 120ms, box-shadow 150ms",
-} as const;
-
-const idleStyle = (hover: boolean, focus: boolean) => ({
-  ...baseStyle,
-  border: `1px solid ${hover ? "rgba(120,120,128,0.9)" : "rgba(84,84,88,0.65)"}`,
-  background: hover ? "rgba(120,120,128,0.12)" : "transparent",
-  color: hover ? "rgba(255,255,255,0.92)" : "rgba(235,235,245,0.60)",
-  transform: hover ? "translateY(-1px)" : "none",
-  boxShadow: focus ? "0 0 0 3px rgba(120,120,128,0.28)" : "none",
-});
-
-const confirmStyle = {
-  ...baseStyle,
-  border: "1px solid rgba(48,209,88,0.45)",
-  background: "rgba(48,209,88,0.12)",
-  color: "#30d158",
-  cursor: "default" as const,
-};
+// The style objects that were here — base, idle(hover, focus) and confirm —
+// are the `outline` and `confirm` variants of components/ui/Button. They were
+// duplicated character for character in MagnetButton, and the hover/focus
+// halves were two useState hooks re-rendering this component on every mouse
+// enter to do what a CSS pseudo-class does for free.
 
 export default function ShareButton({
   anilistId,
   shareTitle,
   labels,
 }: ShareButtonProps) {
-  const [hover, setHover] = useState(false);
-  const [focus, setFocus] = useState(false);
   const [feedback, setFeedback] = useState<"copied" | "failed" | null>(null);
 
   const handleClick = async () => {
@@ -86,23 +62,15 @@ export default function ShareButton({
 
   if (feedback) {
     return (
-      <button type="button" disabled style={confirmStyle} aria-live="polite">
+      <Button variant="confirm" disabled aria-live="polite">
         {feedback === "copied" ? `✓ ${labels.copied}` : labels.copyFailed}
-      </button>
+      </Button>
     );
   }
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      onFocus={() => setFocus(true)}
-      onBlur={() => setFocus(false)}
-      style={idleStyle(hover, focus)}
-    >
+    <Button variant="outline" onClick={handleClick}>
       {labels.share}
-    </button>
+    </Button>
   );
 }

--- a/next-app/src/components/anime/WeeklySchedule.module.css
+++ b/next-app/src/components/anime/WeeklySchedule.module.css
@@ -1,0 +1,78 @@
+/* The weekday tabs.
+ *
+ * These were an inline `tabStyle(active, isToday)` object, and the reason
+ * they had no hover and no focus ring is not that nobody wrote the CSS — it
+ * is that the object ended with `outline: "none"`. An inline declaration
+ * beats every stylesheet rule, so any focus style added elsewhere would have
+ * been authored, reviewed, merged, and silently ignored. Removing that line
+ * had to come first; everything below only works because it is gone.
+ *
+ * State comes from ARIA attributes rather than from extra class names. The
+ * selected tab already has to carry `aria-selected` for the tablist pattern
+ * to mean anything, so styling off it keeps one source of truth: a tab
+ * cannot look selected while telling a screen reader it is not.
+ */
+
+.tabs {
+  display: flex;
+  gap: var(--sp-sm);
+  overflow-x: auto;
+  padding-bottom: var(--sp-sm);
+  margin-bottom: var(--sp-lg);
+  scrollbar-width: none;
+}
+
+.tab {
+  padding: 6px 18px;
+  min-height: 44px;
+  border: none;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  background: var(--bg-fill);
+  color: var(--text-secondary);
+  transition:
+    background 150ms,
+    color 150ms;
+}
+
+/* Today, when it is not the tab you are on: a hint, not a selection. */
+.tab[data-today="true"] {
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+/* The one you are on. Last so it wins over the today hint — the two are
+ * both true on the common first render, and "selected" is the stronger
+ * statement. */
+.tab[aria-selected="true"] {
+  background: var(--accent);
+  color: var(--text);
+}
+
+.tab:hover:not([aria-selected="true"]) {
+  background: rgba(120, 120, 128, 0.2);
+  color: var(--text);
+}
+
+/* The same ring as everywhere else — see components/ui/focusRing.test.ts,
+ * which fails on any other colour. */
+.tab:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.4);
+}
+
+.tabCount {
+  margin-left: var(--sp-xs);
+  opacity: 0.7;
+  font-size: 11px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab {
+    transition: none;
+  }
+}

--- a/next-app/src/components/anime/WeeklySchedule.tsx
+++ b/next-app/src/components/anime/WeeklySchedule.tsx
@@ -16,10 +16,19 @@
 
 import Link from "@/components/ui/LocaleLink";
 import type { CSSProperties } from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { pickTitle } from "@/lib/formatters";
 import FadeImage from "@/components/ui/FadeImage";
 import type { Dict, Lang } from "@/lib/i18n";
+import { nextTabIndex } from "./tabListNav";
+import styles from "./WeeklySchedule.module.css";
+
+// Static id prefix for the tab/panel wiring. The component renders once per
+// page, so a constant is enough and it keeps the ids stable between the
+// server and client renders - useId would be safer for a repeated component
+// but produces a value that has to match across hydration for these
+// relationships to resolve at all.
+const TABS_ID = "weekly-schedule";
 
 export interface ScheduleItem {
   scheduleId: number;
@@ -162,39 +171,13 @@ const titleStyle: CSSProperties = {
   color: "#ffffff",
 };
 
-const tabsStyle: CSSProperties = {
-  display: "flex",
-  gap: 8,
-  overflowX: "auto",
-  paddingBottom: 8,
-  marginBottom: 24,
-  scrollbarWidth: "none",
-};
+// tabsStyle moved to the module alongside the tab rules it belongs with.
 
-function tabStyle(active: boolean, isToday: boolean): CSSProperties {
-  return {
-    padding: "6px 18px",
-    minHeight: 44,
-    borderRadius: 20,
-    fontSize: 13,
-    fontWeight: 600,
-    cursor: "pointer",
-    border: "none",
-    whiteSpace: "nowrap",
-    transition: "all 0.2s",
-    background: active
-      ? "#0a84ff"
-      : isToday
-        ? "rgba(10,132,255,0.12)"
-        : "rgba(120,120,128,0.12)",
-    color: active
-      ? "#fff"
-      : isToday
-        ? "#0a84ff"
-        : "rgba(235,235,245,0.60)",
-    outline: "none",
-  };
-}
+// tabStyle(active, isToday) lived here and ended with `outline: "none"`.
+// Inline styles beat stylesheets, so that one line meant the tabs could
+// never grow a focus ring no matter what CSS anyone wrote for them. The
+// whole rule set is now in WeeklySchedule.module.css, keyed off the ARIA
+// attributes the tablist pattern requires anyway.
 
 const gridStyle: CSSProperties = {
   display: "grid",
@@ -303,11 +286,37 @@ export default function WeeklySchedule({
   const today = apiToday || localToday();
   const days = Object.keys(groups).sort();
   const [selected, setSelected] = useState<string | null>(null);
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  // Hooks run before the early return below, which is why this sits here and
+  // not next to the JSX that uses it.
+  const active = selected ?? today;
+  const activeDay = days.includes(active) ? active : days[0];
+
+  /**
+   * Arrow-key movement across the tablist.
+   *
+   * Selection follows focus, which is the right choice here specifically
+   * because switching days is free — the data for all seven is already in
+   * memory, so there is no cost to arrowing through them and no reason to
+   * make someone press Enter as well. (For tabs whose panels load on
+   * demand, the pattern would be manual activation instead.)
+   *
+   * Wraps at both ends, and Home/End jump to the edges. Both are part of
+   * the pattern people already expect from every other tab control.
+   */
+  function onTabKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    const next = nextTabIndex(e.key, days.indexOf(activeDay), days.length);
+    // null means the key is not ours. Returning before preventDefault is the
+    // point: a handler that swallows everything traps Tab inside the tablist.
+    if (next === null) return;
+    e.preventDefault();
+    setSelected(days[next]);
+    tabRefs.current[next]?.focus();
+  }
 
   if (days.length === 0) return null;
 
-  const active = selected ?? today;
-  const activeDay = days.includes(active) ? active : days[0];
   const items = groups[activeDay] ?? [];
 
   const dayMap = DAY_LABELS[lang];
@@ -334,25 +343,65 @@ export default function WeeklySchedule({
         <h2 style={titleStyle}>{dict.home.thisWeek}</h2>
       </div>
 
-      <div style={tabsStyle}>
-        {days.map((d) => (
-          <button
-            key={d}
-            style={tabStyle(d === activeDay, d === today)}
-            onClick={() => setSelected(d)}
-          >
-            {formatDayLabel(d)}
-            <span style={{ marginLeft: 4, opacity: 0.7, fontSize: 11 }}>
-              {groups[d]?.length ?? 0}
-            </span>
-          </button>
-        ))}
+      {/* A real tablist. Seven plain buttons were seven tab stops with no
+          relationship to each other or to the grid they control, so a
+          keyboard user tabbed through all of them to reach the content and
+          a screen reader announced seven unlabelled buttons.
+          Roving tabindex is what fixes the first half: exactly one tab is
+          reachable by Tab, and Arrow keys move between them — the pattern
+          every native tab control uses. */}
+      <div
+        className={styles.tabs}
+        role="tablist"
+        aria-label={dict.home.thisWeek}
+        onKeyDown={onTabKeyDown}
+      >
+        {days.map((d, i) => {
+          const isActive = d === activeDay;
+          return (
+            <button
+              key={d}
+              ref={(el) => {
+                tabRefs.current[i] = el;
+              }}
+              type="button"
+              role="tab"
+              id={`${TABS_ID}-tab-${d}`}
+              aria-selected={isActive}
+              aria-controls={`${TABS_ID}-panel`}
+              // The roving part. A non-selected tab stays focusable
+              // programmatically (that is what -1 means) so the arrow-key
+              // handler can move focus onto it.
+              tabIndex={isActive ? 0 : -1}
+              data-today={d === today ? "true" : "false"}
+              className={styles.tab}
+              onClick={() => setSelected(d)}
+            >
+              {formatDayLabel(d)}
+              <span className={styles.tabCount}>{groups[d]?.length ?? 0}</span>
+            </button>
+          );
+        })}
       </div>
 
+      {/* The panel the tabs control. Named and labelled by the active tab, so
+          the relationship the tablist claims actually resolves. */}
       {items.length === 0 ? (
-        <p style={emptyStyle}>{dict.home.noUpdates}</p>
+        <p
+          style={emptyStyle}
+          id={`${TABS_ID}-panel`}
+          role="tabpanel"
+          aria-labelledby={`${TABS_ID}-tab-${activeDay}`}
+        >
+          {dict.home.noUpdates}
+        </p>
       ) : (
-        <div style={gridStyle}>
+        <div
+          style={gridStyle}
+          id={`${TABS_ID}-panel`}
+          role="tabpanel"
+          aria-labelledby={`${TABS_ID}-tab-${activeDay}`}
+        >
           {items.map((item) => {
             const title = pickTitle(item, lang);
             const score = item.averageScore ?? 0;

--- a/next-app/src/components/anime/scoreStyle.test.ts
+++ b/next-app/src/components/anime/scoreStyle.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SCORE_THRESHOLDS,
+  scoreBadgeStyle,
+  scoreBand,
+  scoreScrimStyle,
+} from "./scoreStyle";
+
+// The regression guard for a defect that reached production and stayed:
+// every anime rated 75 or above rendered green text on an amber pill, on the
+// site's highest-traffic page. The foreground came from a threshold ladder;
+// the background was a hardcoded literal one screen away. Neither piece was
+// wrong on its own, which is why no review caught it — and why the assertion
+// that matters is not "the colours are right" but "the two came from the
+// same band".
+//
+// This file can exist at all because scoreStyle.ts is a module. The page it
+// came out of cannot be imported: page.tsx reaches react-hot-toast, which
+// touches `document` at module scope, so a suite importing it dies before
+// its first assertion. Asserting on the page's source text instead would be
+// theatre — it would pass on a file that renders nothing.
+
+describe("bands", () => {
+  test("the ladder is high / mid / low, split at the documented thresholds", () => {
+    expect(scoreBand(100)).toBe("high");
+    expect(scoreBand(75)).toBe("high");
+    expect(scoreBand(74)).toBe("mid");
+    expect(scoreBand(50)).toBe("mid");
+    expect(scoreBand(49)).toBe("low");
+    expect(scoreBand(0)).toBe("low");
+  });
+
+  test("the boundaries are inclusive on the upper band", () => {
+    // Stated separately because ">= vs >" is the whole content of this
+    // function, and an off-by-one here is invisible on screen: it moves
+    // exactly the scores sitting on 75 and 50.
+    expect(scoreBand(SCORE_THRESHOLDS.high)).toBe("high");
+    expect(scoreBand(SCORE_THRESHOLDS.high - 1)).toBe("mid");
+    expect(scoreBand(SCORE_THRESHOLDS.mid)).toBe("mid");
+    expect(scoreBand(SCORE_THRESHOLDS.mid - 1)).toBe("low");
+  });
+
+  test("thresholds match the Rating Bands table in DESIGN.md", () => {
+    // Literals on purpose. Reading them from the same constants they check
+    // would assert nothing; these two numbers are site-wide semantics and
+    // changing them is a design decision, not a refactor.
+    expect(SCORE_THRESHOLDS.high).toBe(75);
+    expect(SCORE_THRESHOLDS.mid).toBe(50);
+  });
+});
+
+describe("the tinted badge — background and text are the same band", () => {
+  // The exact assertion the production bug would have failed. Not "is it
+  // green" — the pill was genuinely green, that was never the problem — but
+  // "does the background name the same band as the text".
+  const cases = [
+    { score: 90, band: "high" },
+    { score: 75, band: "high" },
+    { score: 60, band: "mid" },
+    { score: 50, band: "mid" },
+    { score: 30, band: "low" },
+    { score: 0, band: "low" },
+  ] as const;
+
+  for (const { score, band } of cases) {
+    test(`${score} paints the ${band} pair and nothing mixed`, () => {
+      const style = scoreBadgeStyle(score);
+      expect(style.color).toBe(`var(--score-${band}-fg)`);
+      expect(style.background).toBe(`var(--score-${band}-bg)`);
+    });
+  }
+
+  test("every score in 0..100 gets a matching pair", () => {
+    // The loop is the point: the bug lived at 75..100, a range no single
+    // hand-picked example was covering.
+    for (let score = 0; score <= 100; score++) {
+      const { color, background } = scoreBadgeStyle(score);
+      const fgBand = String(color).match(/--score-(\w+)-fg/)?.[1];
+      const bgBand = String(background).match(/--score-(\w+)-bg/)?.[1];
+      expect(fgBand).toBeDefined();
+      expect(bgBand).toBe(fgBand!);
+    }
+  });
+
+  test("it returns only the two coupled properties", () => {
+    // Padding, radius and the mono face belong to the badge's own rule. If
+    // layout leaks back in here, the next caller starts spreading this over
+    // its own layout and the coupling argument stops holding.
+    expect(Object.keys(scoreBadgeStyle(80)).sort()).toEqual(["background", "color"]);
+  });
+});
+
+describe("the over-artwork badge", () => {
+  test("keeps the band foreground but always the opaque scrim", () => {
+    // A 12% tint has no contrast guarantee over a cover that could be any
+    // colour, so this variant deliberately does NOT vary its background.
+    for (const score of [95, 60, 20]) {
+      const style = scoreScrimStyle(score);
+      expect(style.background).toBe("var(--score-scrim-bg)");
+      expect(style.color).toBe(`var(--score-${scoreBand(score)}-fg)`);
+    }
+  });
+
+  test("never returns a band background", () => {
+    // The mistake this prevents is reaching for scoreBadgeStyle on a card:
+    // it would look almost right in review and be unreadable on a bright
+    // poster.
+    // Matching on the band names, not on "-bg", because the scrim token is
+    // itself called --score-scrim-bg.
+    for (let score = 0; score <= 100; score += 5) {
+      expect(String(scoreScrimStyle(score).background)).not.toMatch(
+        /--score-(high|mid|low)-bg/,
+      );
+    }
+  });
+});

--- a/next-app/src/components/anime/scoreStyle.ts
+++ b/next-app/src/components/anime/scoreStyle.ts
@@ -1,0 +1,121 @@
+// How a score is coloured, and the thresholds that decide it.
+//
+// Pure logic, no React and no DOM, split out of page.tsx for the reason
+// testImportHygiene.test.ts states as the repo convention: a test cannot
+// import the page. `page.tsx -> DetailActions.tsx -> SubscriptionButton.tsx
+// -> react-hot-toast`, and react-hot-toast touches `document` while its module
+// is still evaluating, so any suite reaching it dies before its first
+// assertion. Same split as animeJsonLd.ts next door.
+//
+// ## Why this is a module and not two lines in the page
+//
+// It was two lines in the page, and it shipped a bug to production for as
+// long as it was:
+//
+//     scoreColor(s)          →  #30d158 / #ff9f0a / #ff453a   (three bands)
+//     S.scoreBadge(color)    →  background: rgba(255,159,10,0.12)  (always amber)
+//
+// The foreground knew about bands. The background did not. So every anime
+// rated 75 or above rendered green text on an amber pill — live, on the
+// site's highest-traffic page, on exactly the titles people search for.
+// ★9 and ★8.3 were wrong; ★6 and ★5.7 happened to be right, which is why
+// nobody caught it by looking.
+//
+// The fix is not "also make the background a function". It is that nothing
+// can ask for one half any more: the exported style functions each return a
+// complete pair, and there is no exported way to get a foreground alone.
+// Both halves come out of the same lookup or neither does.
+//
+// ## Two treatments, because the badge sits on two different things
+//
+// On a solid surface (detail hero, episode list) the badge is a tinted pill:
+// a 12% wash of its own band colour. Over cover artwork (anime cards) that
+// wash would be invisible against whatever the poster happens to be, so the
+// badge uses an opaque dark scrim instead and only the text carries the band.
+// Both are exported as pairs, so picking the wrong treatment is a visible
+// mistake rather than a silent mismatch.
+//
+// ## Three copies, one of them also wrong
+//
+// This threshold ladder existed verbatim in three files: this page,
+// player/_components/EpisodeFileList.tsx, and components/anime/AnimeCard.tsx.
+// EpisodeFileList had the identical amber-background defect. AnimeCard was
+// correct, because its background is the neutral scrim. All three now read
+// the thresholds from here, so the next edit to them cannot reach two of
+// three places.
+
+import type { CSSProperties } from "react";
+
+/** The three rating bands. Shared vocabulary with DESIGN.md → Rating Bands. */
+export type ScoreBand = "high" | "mid" | "low";
+
+/**
+ * The band boundaries, as AniList's 0–100 scale.
+ *
+ * Site-wide semantics, not a detail-page detail — the anime cards use the
+ * same two numbers. Changing one of them means changing DESIGN.md's Rating
+ * Bands table in the same commit; scoreStyle.test.ts asserts against these
+ * constants and globals.test.ts asserts the table, so a half-change is red.
+ */
+export const SCORE_THRESHOLDS = {
+  /** At or above this is a good score. */
+  high: 75,
+  /** At or above this is average. Below it is a bad score. */
+  mid: 50,
+} as const;
+
+/**
+ * The custom-property pair each band paints with.
+ *
+ * Names, not values. The values live in globals.css because DESIGN.md is
+ * their source and globals.test.ts pins them there — duplicating the hex
+ * here would create a second copy that can drift silently, which is the
+ * class of bug this whole module exists to close.
+ */
+const BAND_VARS: Record<ScoreBand, { fg: string; bg: string }> = {
+  high: { fg: "var(--score-high-fg)", bg: "var(--score-high-bg)" },
+  mid: { fg: "var(--score-mid-fg)", bg: "var(--score-mid-bg)" },
+  low: { fg: "var(--score-low-fg)", bg: "var(--score-low-bg)" },
+};
+
+/**
+ * Which band a score falls in.
+ *
+ * Exported for tests and for anywhere that needs the band without the
+ * styling — but note that `scoreBadgeStyle` is what a component should
+ * reach for. Nothing outside this module should be turning a band into a
+ * colour by hand; that is the seam the production bug opened up in.
+ */
+export function scoreBand(score: number): ScoreBand {
+  if (score >= SCORE_THRESHOLDS.high) return "high";
+  if (score >= SCORE_THRESHOLDS.mid) return "mid";
+  return "low";
+}
+
+/**
+ * The colour half of a score badge: background and text, always together.
+ *
+ * Returns only the two coupled properties. Padding, radius, and the mono
+ * face are static and belong to the badge's stylesheet rule — mixing them
+ * in here would put layout back into a JS object, which is the other half
+ * of what this page is being dug out of.
+ */
+export function scoreBadgeStyle(score: number): Pick<CSSProperties, "background" | "color"> {
+  const { fg, bg } = BAND_VARS[scoreBand(score)];
+  return { background: bg, color: fg };
+}
+
+/**
+ * The colour half of a score badge painted **over cover artwork**.
+ *
+ * Same band foreground, but an opaque scrim instead of the band's own tint:
+ * a 12% wash has no contrast guarantee against a poster that could be any
+ * colour, and anime covers are deliberately saturated. The scrim gives the
+ * text a known background to sit on regardless of what is behind it.
+ *
+ * A pair for the same reason the tinted variant is a pair — the point is
+ * that no caller assembles a background and a foreground itself.
+ */
+export function scoreScrimStyle(score: number): Pick<CSSProperties, "background" | "color"> {
+  return { background: "var(--score-scrim-bg)", color: BAND_VARS[scoreBand(score)].fg };
+}

--- a/next-app/src/components/anime/tabListNav.test.ts
+++ b/next-app/src/components/anime/tabListNav.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { isTabListKey, nextTabIndex } from "./tabListNav";
+
+// The weekday tabs had no keyboard navigation at all: seven plain buttons,
+// seven tab stops, no relationship between them. This is the arithmetic that
+// replaced that, and it is tested here rather than through the component
+// because the repo has no DOM testing library — the same reason
+// episodeGridSkeleton and torrentModalLogic are their own modules.
+
+const COUNT = 7; // a week
+
+describe("movement", () => {
+  test("arrows step one at a time", () => {
+    expect(nextTabIndex("ArrowRight", 2, COUNT)).toBe(3);
+    expect(nextTabIndex("ArrowLeft", 2, COUNT)).toBe(1);
+  });
+
+  test("Home and End jump to the edges", () => {
+    expect(nextTabIndex("Home", 4, COUNT)).toBe(0);
+    expect(nextTabIndex("End", 4, COUNT)).toBe(COUNT - 1);
+  });
+});
+
+describe("wrapping", () => {
+  test("right off the end returns to the start", () => {
+    expect(nextTabIndex("ArrowRight", COUNT - 1, COUNT)).toBe(0);
+  });
+
+  test("left off the start returns to the end, not to -1", () => {
+    // JS `%` keeps the sign of the dividend, so (0 - 1) % 7 is -1. A -1 here
+    // is a ref lookup that returns undefined and focus that silently does
+    // not move — the failure looks like "the left arrow does nothing at the
+    // first tab", which is easy to mistake for intended behaviour.
+    expect(nextTabIndex("ArrowLeft", 0, COUNT)).toBe(COUNT - 1);
+  });
+
+  test("a full cycle in each direction lands back where it started", () => {
+    let i = 0;
+    for (let n = 0; n < COUNT; n++) i = nextTabIndex("ArrowRight", i, COUNT)!;
+    expect(i).toBe(0);
+    for (let n = 0; n < COUNT; n++) i = nextTabIndex("ArrowLeft", i, COUNT)!;
+    expect(i).toBe(0);
+  });
+
+  test("every index stays in range for both directions", () => {
+    for (let from = 0; from < COUNT; from++) {
+      for (const key of ["ArrowRight", "ArrowLeft", "Home", "End"]) {
+        const to = nextTabIndex(key, from, COUNT)!;
+        expect(to).toBeGreaterThanOrEqual(0);
+        expect(to).toBeLessThan(COUNT);
+      }
+    }
+  });
+});
+
+describe("keys this must not claim", () => {
+  // The consequence of getting this wrong is worse than the missing arrow
+  // keys it was added for: the caller calls preventDefault on any non-null
+  // answer, so claiming Tab would trap a keyboard user inside the tablist.
+  test("Tab, Enter, Space and ordinary characters fall through", () => {
+    for (const key of ["Tab", "Enter", " ", "a", "Escape", "ArrowUp", "ArrowDown"]) {
+      expect(nextTabIndex(key, 3, COUNT)).toBeNull();
+      expect(isTabListKey(key)).toBe(false);
+    }
+  });
+
+  test("ArrowUp and ArrowDown are not claimed by a horizontal tablist", () => {
+    // Called out separately because they are the tempting ones to add. A
+    // horizontal tablist leaves the vertical arrows to the page, which is
+    // how a user scrolls while a tab has focus.
+    expect(nextTabIndex("ArrowUp", 3, COUNT)).toBeNull();
+    expect(nextTabIndex("ArrowDown", 3, COUNT)).toBeNull();
+  });
+});
+
+describe("degenerate input", () => {
+  test("an empty list has nowhere to go", () => {
+    expect(nextTabIndex("ArrowRight", 0, 0)).toBeNull();
+    expect(nextTabIndex("Home", 0, 0)).toBeNull();
+  });
+
+  test("a single tab always stays put", () => {
+    expect(nextTabIndex("ArrowRight", 0, 1)).toBe(0);
+    expect(nextTabIndex("ArrowLeft", 0, 1)).toBe(0);
+  });
+
+  test("an out-of-range current index still yields a valid target", () => {
+    // days.indexOf() returns -1 when the active day is not in the list,
+    // which is reachable on the render where the schedule changes under a
+    // selection.
+    expect(nextTabIndex("ArrowRight", -1, COUNT)).toBe(1);
+    expect(nextTabIndex("ArrowLeft", 99, COUNT)).toBe(COUNT - 1);
+  });
+});

--- a/next-app/src/components/anime/tabListNav.ts
+++ b/next-app/src/components/anime/tabListNav.ts
@@ -1,0 +1,53 @@
+// Arrow-key movement across a tablist, as arithmetic.
+//
+// Split out for the reason every other pure helper next door is split out
+// (episodeGridSkeleton, continueWatchingState, torrentModalLogic): this repo
+// has no DOM testing library, so behaviour that lives inside a component's
+// event handler cannot be asserted. Index arithmetic in a module can.
+//
+// The parts worth testing are the ones that are easy to get subtly wrong and
+// impossible to notice: wrapping backwards off index 0 without going
+// negative, and returning null for keys this should not handle at all — a
+// handler that preventDefaults everything traps Tab inside the tablist,
+// which is a worse bug than the missing arrow keys it was added to fix.
+
+/** Keys the tablist pattern reserves. Everything else must fall through. */
+const HANDLED = ["ArrowRight", "ArrowLeft", "Home", "End"] as const;
+
+export type TabListKey = (typeof HANDLED)[number];
+
+export function isTabListKey(key: string): key is TabListKey {
+  return (HANDLED as readonly string[]).includes(key);
+}
+
+/**
+ * Where focus goes for `key`, or null if this key is not ours.
+ *
+ * Null is the important return. The caller uses it to decide whether to
+ * preventDefault, and a caller that always does would swallow Tab (trapping
+ * keyboard users inside the tablist) and typing (breaking find-as-you-type).
+ *
+ * Arrows wrap in both directions: at the last tab, Right returns to the
+ * first. That is what the pattern specifies and what a horizontal strip of
+ * seven weekdays should do — the list is a cycle.
+ */
+export function nextTabIndex(key: string, current: number, count: number): number | null {
+  if (count <= 0 || !isTabListKey(key)) return null;
+
+  // A current index outside the list would otherwise produce a nonsense
+  // target for the arrow cases. Treat it as "before the start".
+  const from = current >= 0 && current < count ? current : 0;
+
+  switch (key) {
+    case "ArrowRight":
+      return (from + 1) % count;
+    case "ArrowLeft":
+      // `+ count` before the modulo: JS `%` keeps the sign of the dividend,
+      // so (0 - 1) % 7 is -1, not 6.
+      return (from - 1 + count) % count;
+    case "Home":
+      return 0;
+    case "End":
+      return count - 1;
+  }
+}

--- a/next-app/src/components/community/HotDiscussions.module.css
+++ b/next-app/src/components/community/HotDiscussions.module.css
@@ -241,9 +241,13 @@
   transition: transform 150ms ease, border-color 150ms ease, background 150ms ease;
 }
 
+/* Was teal, which this system reserves for things you read rather than
+ * things you press — and these are links. One ring, app-wide; see
+ * globals.test.ts, which now fails on any other colour. */
 .guideActions a:focus-visible {
-  outline: 2px solid #64d2ff;
+  outline: 2px solid transparent;
   outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.4);
 }
 
 .guidePrimary {
@@ -314,9 +318,13 @@
   background: linear-gradient(135deg, rgba(255, 159, 10, 0.13), rgba(255, 255, 255, 0.05));
 }
 
+/* Was amber — the card's own hover accent, reused as its focus ring. That
+ * reads as decoration rather than position, and amber is --warning, which
+ * means something else entirely. */
 .card:focus-visible {
-  outline: 2px solid #ff9f0a;
+  outline: 2px solid transparent;
   outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.4);
 }
 
 .welcomeCard {

--- a/next-app/src/components/ui/Button.module.css
+++ b/next-app/src/components/ui/Button.module.css
@@ -1,0 +1,102 @@
+/* The button surface, extracted verbatim.
+ *
+ * This file is deliberately a faithful copy of what ShareButton,
+ * MagnetButton and PlayButton's trigger already looked like, including the
+ * parts that are wrong. Fixing them in the same change as moving them would
+ * make it impossible to tell a regression from an intended correction — the
+ * corrections land in the commit after this one, where the diff shows only
+ * them.
+ *
+ * Known-wrong and preserved for now:
+ *   · 40px min-height, where DESIGN.md's touch target is 44px
+ *   · a grey focus ring on the outline variant, where the spec has one blue
+ *     ring for the whole app
+ *   · :focus rather than :focus-visible, so the ring also appears on a mouse
+ *     click (this is what the React onFocus/onBlur state it replaces did)
+ */
+
+.base {
+  min-height: 40px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+  transition:
+    background 150ms,
+    border-color 150ms,
+    color 150ms,
+    transform 120ms,
+    box-shadow 150ms;
+}
+
+/* ── Primary — the blue CTA ─────────────────────────────────────────────── */
+
+.primary {
+  composes: base;
+  border: 0;
+  background: #0a84ff;
+  color: #fff;
+  /* 650 rather than the 600 the outline variant uses. Carried over as-is;
+   * DM Sans has no 650, so this resolves to the same rendered weight as 600
+   * in practice, which is why nobody noticed the two disagreeing. */
+  font-weight: 650;
+}
+
+.primary:hover {
+  background: #409cff;
+  box-shadow: 0 2px 8px rgba(10, 132, 255, 0.35);
+  transform: translateY(-1px);
+}
+
+/* 0.40, not a rounder-looking 0.45: the focus ring is specified once in
+ * DESIGN.md and every focusable element in the app draws the same one. A ring
+ * that differs by component is a ring people stop trusting to mean the same
+ * thing. */
+.primary:focus-visible {
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.4);
+}
+
+/* ── Outline — secondary actions (share, downloads) ─────────────────────── */
+
+.outline {
+  composes: base;
+  border: 1px solid rgba(84, 84, 88, 0.65);
+  background: transparent;
+  color: rgba(235, 235, 245, 0.6);
+}
+
+.outline:hover {
+  border-color: rgba(120, 120, 128, 0.9);
+  background: rgba(120, 120, 128, 0.12);
+  color: rgba(255, 255, 255, 0.92);
+  transform: translateY(-1px);
+}
+
+/* :focus, not :focus-visible — reproducing the onFocus/onBlur state this
+ * replaces, which fired on mouse clicks too. Corrected in the next commit. */
+.outline:focus {
+  box-shadow: 0 0 0 3px rgba(120, 120, 128, 0.28);
+}
+
+/* ── Confirm — a transient success surface, not a control ───────────────── */
+
+.confirm {
+  composes: base;
+  border: 1px solid rgba(48, 209, 88, 0.45);
+  background: rgba(48, 209, 88, 0.12);
+  color: #30d158;
+  cursor: default;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .base {
+    transition: none;
+  }
+
+  .primary:hover,
+  .outline:hover {
+    transform: none;
+  }
+}

--- a/next-app/src/components/ui/Button.module.css
+++ b/next-app/src/components/ui/Button.module.css
@@ -1,28 +1,47 @@
-/* The button surface, extracted verbatim.
+/* The one button surface, at the spec.
  *
- * This file is deliberately a faithful copy of what ShareButton,
- * MagnetButton and PlayButton's trigger already looked like, including the
- * parts that are wrong. Fixing them in the same change as moving them would
- * make it impossible to tell a regression from an intended correction — the
- * corrections land in the commit after this one, where the diff shows only
- * them.
+ * The commit before this one moved three copies of this into one file
+ * without changing them. This one changes them, and nothing else, so the
+ * diff is exactly the list of corrections:
  *
- * Known-wrong and preserved for now:
- *   · 40px min-height, where DESIGN.md's touch target is 44px
- *   · a grey focus ring on the outline variant, where the spec has one blue
- *     ring for the whole app
- *   · :focus rather than :focus-visible, so the ring also appears on a mouse
- *     click (this is what the React onFocus/onBlur state it replaces did)
+ *   44px touch target      was 40px. DESIGN.md > Touch Targets, which is
+ *                          Apple HIG's floor. 40px is a control people miss
+ *                          on a phone, and phones are most of this site's
+ *                          traffic.
+ *
+ *   one blue focus ring    the outline variant drew a GREY ring
+ *                          (rgba(120,120,128,0.28)) while the primary drew
+ *                          the blue one. A focus ring that differs by
+ *                          component is a ring people stop reading as
+ *                          "this is where you are".
+ *
+ *   :focus-visible         was :focus on the outline variant, reproducing
+ *                          the onFocus/onBlur state it replaced — which
+ *                          fired on mouse clicks, so every click left a
+ *                          ring behind. :focus-visible is the browser's own
+ *                          answer to "was this keyboard or pointer", and it
+ *                          is the reason moving off inline styles was worth
+ *                          doing.
+ *
+ *   active + disabled      neither existed on any of the three. A button
+ *                          with no active state does not feel pressed, and
+ *                          a disabled one that still looks pressable is a
+ *                          control that appears broken rather than off.
+ *
+ * Colours come from tokens now rather than repeated literals — every value
+ * here already matched a token exactly, so this is a rename, not a
+ * re-colour. globals.test.ts pins the tokens to DESIGN.md.
  */
 
 .base {
-  min-height: 40px;
+  /* 44px, and min-height rather than height: the button still grows for two
+   * lines of CJK, it just cannot shrink below the touch floor. */
+  min-height: 44px;
   padding: 10px 18px;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  outline: none;
   transition:
     background 150ms,
     border-color 150ms,
@@ -31,62 +50,95 @@
     box-shadow 150ms;
 }
 
+/* One ring, every variant, exactly as DESIGN.md specifies it once.
+ *
+ * `outline: none` is paired with a box-shadow ring that is always drawn, so
+ * this never removes the indicator — but a shadow is invisible in forced-
+ * colors mode, where the UA's own outline is the only thing a user has. The
+ * transparent outline keeps a real one for that mode to colour in. */
+.base:focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.4);
+}
+
+/* Note that the pressed state is declared per variant below, not here. A
+ * `.base:active` rule ties with `.primary:hover` on specificity and loses on
+ * source order, so pressing a button while the pointer is on it — which is
+ * every mouse press — would keep the hover lift and never show the press. */
+
+/* Off, not broken. DESIGN.md > Buttons: opacity 0.35, pointer-events none.
+ * `:disabled` on a real <button> already blocks the click; this is about it
+ * not inviting one. */
+.base:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
 /* ── Primary — the blue CTA ─────────────────────────────────────────────── */
 
 .primary {
   composes: base;
   border: 0;
-  background: #0a84ff;
-  color: #fff;
-  /* 650 rather than the 600 the outline variant uses. Carried over as-is;
-   * DM Sans has no 650, so this resolves to the same rendered weight as 600
-   * in practice, which is why nobody noticed the two disagreeing. */
+  background: var(--accent);
+  color: var(--text);
+  /* 650 as extracted. DM Sans is loaded at 300..600, so this resolves to the
+   * same rendered weight as the 600 on .base — kept rather than unified
+   * because "renders the same" is an inference and this commit's job is the
+   * three corrections named above, not tidying. DESIGN.md actually specifies
+   * 14px/500 with 10px 20px padding for buttons; that delta is deliberately
+   * still open, and is a visual change that wants its own review. */
   font-weight: 650;
 }
 
-.primary:hover {
-  background: #409cff;
+.primary:hover:not(:disabled) {
+  background: var(--accent-hover);
   box-shadow: 0 2px 8px rgba(10, 132, 255, 0.35);
   transform: translateY(-1px);
 }
 
-/* 0.40, not a rounder-looking 0.45: the focus ring is specified once in
- * DESIGN.md and every focusable element in the app draws the same one. A ring
- * that differs by component is a ring people stop trusting to mean the same
- * thing. */
-.primary:focus-visible {
-  box-shadow: 0 0 0 3px rgba(10, 132, 255, 0.4);
+.primary:active:not(:disabled) {
+  background: var(--accent-active);
+  box-shadow: none;
+  /* Cancels the hover lift, so the button goes down under the finger. */
+  transform: translateY(0);
 }
 
 /* ── Outline — secondary actions (share, downloads) ─────────────────────── */
 
 .outline {
   composes: base;
-  border: 1px solid rgba(84, 84, 88, 0.65);
+  border: 1px solid var(--separator);
   background: transparent;
-  color: rgba(235, 235, 245, 0.6);
+  color: var(--text-secondary);
 }
 
-.outline:hover {
+.outline:hover:not(:disabled) {
   border-color: rgba(120, 120, 128, 0.9);
-  background: rgba(120, 120, 128, 0.12);
+  background: var(--bg-fill);
   color: rgba(255, 255, 255, 0.92);
   transform: translateY(-1px);
 }
 
-/* :focus, not :focus-visible — reproducing the onFocus/onBlur state this
- * replaces, which fired on mouse clicks too. Corrected in the next commit. */
-.outline:focus {
-  box-shadow: 0 0 0 3px rgba(120, 120, 128, 0.28);
+.outline:active:not(:disabled) {
+  background: rgba(120, 120, 128, 0.2);
+  transform: translateY(0);
 }
 
 /* ── Confirm — a transient success surface, not a control ───────────────── */
 
+/* Renders disabled, so it inherits the 0.35 opacity above — which is wrong
+ * for this one: it is a message, not a switched-off control, and it has
+ * about two seconds to be read. Full opacity, default cursor. */
 .confirm {
   composes: base;
   border: 1px solid rgba(48, 209, 88, 0.45);
   background: rgba(48, 209, 88, 0.12);
-  color: #30d158;
+  color: var(--success);
+}
+
+.confirm:disabled {
+  opacity: 1;
   cursor: default;
 }
 

--- a/next-app/src/components/ui/Button.test.ts
+++ b/next-app/src/components/ui/Button.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Button is a class name and a <button>. There is no DOM testing library in
+// this repo, so what can be asserted is the seam between its two halves —
+// and that seam has a silent failure mode.
+//
+// `className={styles[variant]}` resolves to `undefined` for any variant the
+// stylesheet does not define, and React renders `class="undefined"`. The
+// result is a completely unstyled button: no padding, no background, no
+// touch target, no focus ring. Nothing throws, nothing warns, and TypeScript
+// is satisfied because the type union is where the variant came from.
+//
+// So the check is that the union and the stylesheet agree, in both
+// directions.
+
+const TSX = readFileSync(join(import.meta.dir, "Button.tsx"), "utf8");
+const CSS_RAW = readFileSync(join(import.meta.dir, "Button.module.css"), "utf8");
+
+// Comments stripped before anything is matched. This file's stylesheet
+// explains its own decisions in prose, and that prose names the selectors it
+// decided against — the first version of the assertion below failed because
+// it found `.base:active` inside the comment saying why `.base:active` is
+// wrong. A source-reading test has to read code, not the notes about it.
+const CSS = CSS_RAW.replace(/\/\*[\s\S]*?\*\//g, "");
+
+// Rules outside any @media block. The reduced-motion block re-states hover
+// selectors to cancel their transform, which is harmless on a disabled
+// button and would otherwise trip the :not(:disabled) check below.
+const CSS_TOPLEVEL = CSS.replace(/@media[^{]*\{[\s\S]*?\n\}/g, "");
+
+/** The members of the `ButtonVariant` union, from the source. */
+function declaredVariants(): string[] {
+  const union = TSX.match(/export type ButtonVariant\s*=\s*([^;]+);/)?.[1] ?? "";
+  return [...union.matchAll(/"([a-z]+)"/g)].map((m) => m[1]);
+}
+
+/** Class names the stylesheet defines. */
+function definedClasses(): Set<string> {
+  return new Set([...CSS.matchAll(/^\.([a-zA-Z][\w-]*)/gm)].map((m) => m[1]));
+}
+
+const variants = declaredVariants();
+const classes = definedClasses();
+
+describe("variants", () => {
+  test("the parse found something (guards the regexes, not the code)", () => {
+    // A regex that silently matched nothing would make every assertion below
+    // vacuously true — the standard failure of a test that reads source.
+    expect(variants.length).toBeGreaterThanOrEqual(3);
+    expect(classes.size).toBeGreaterThanOrEqual(4);
+  });
+
+  test("every variant in the type has a class in the stylesheet", () => {
+    // The silent one: a missing class renders class="undefined", which is a
+    // button with no padding, no background and no focus ring.
+    const missing = variants.filter((v) => !classes.has(v));
+    expect(missing).toEqual([]);
+  });
+
+  test("every variant class composes the shared base", () => {
+    // `composes: base` is what carries the 44px touch target and the focus
+    // ring. A variant that declares its own box from scratch would look
+    // right and fail both.
+    for (const v of variants) {
+      const rule = CSS.match(new RegExp(`\\.${v}\\s*\\{([^}]*)\\}`))?.[1] ?? "";
+      expect(rule).toContain("composes: base");
+    }
+  });
+});
+
+describe("the states the base cannot get right for everyone", () => {
+  test("confirm cancels the disabled dimming", () => {
+    // ShareButton renders the "copied" confirmation as a disabled button so
+    // it is not clickable — which means it inherits `.base:disabled`'s
+    // opacity 0.35. It is a message with about two seconds to be read, not a
+    // switched-off control. Without this override it ships at 35% opacity
+    // and nobody notices in review, because you have to click share and look
+    // within two seconds.
+    const rule = CSS.match(/\.confirm:disabled\s*\{([^}]*)\}/)?.[1];
+    expect(rule).toBeDefined();
+    expect(rule).toMatch(/opacity:\s*1\b/);
+  });
+
+  test("the pressed state is per-variant, not on the base", () => {
+    // `.base:active` ties `.primary:hover` on specificity and loses on
+    // source order, so a base-level press would never show for a mouse — and
+    // a mouse press is always also a hover. This asserts the shape that
+    // works rather than the one that reads more naturally.
+    expect(CSS).not.toMatch(/\.base:active/);
+    expect(CSS).toMatch(/\.primary:active/);
+    expect(CSS).toMatch(/\.outline:active/);
+    // The comment stripping is what makes the negative assertion meaningful —
+    // the raw file DOES contain that string, in the note explaining why.
+    expect(CSS_RAW).toMatch(/\.base:active/);
+  });
+
+  test("hover and active are gated on :not(:disabled)", () => {
+    // A disabled button that still lifts under the pointer reads as broken
+    // rather than as off.
+    const gated = [...CSS_TOPLEVEL.matchAll(/(\.\w+:(?:hover|active)[^{,]*)[,{]/g)].map(
+      (m) => m[1],
+    );
+    expect(gated.length).toBeGreaterThanOrEqual(4);
+    for (const selector of gated) expect(selector).toContain(":not(:disabled)");
+  });
+});

--- a/next-app/src/components/ui/Button.tsx
+++ b/next-app/src/components/ui/Button.tsx
@@ -1,0 +1,64 @@
+// The one button surface.
+//
+// Extracted because ShareButton and MagnetButton held byte-identical copies
+// of the same style object, each re-implementing hover and focus as React
+// state:
+//
+//     const [hover, setHover] = useState(false);
+//     const [focus, setFocus] = useState(false);
+//     onMouseEnter={() => setHover(true)} ...
+//     style={{ ...baseStyle, background: hover ? ... : ... }}
+//
+// That is a state update and a re-render per mouse enter, per mouse leave,
+// per focus, per blur, for something CSS does for free — and because the
+// styles were inline, they beat any stylesheet rule, so no amount of CSS
+// written elsewhere could have corrected them.
+//
+// It also produced a real behavioural difference: `onFocus` fires when a
+// button is clicked with a mouse, so the focus ring appeared on click as
+// well as on keyboard focus. `:focus-visible` is the thing that
+// distinguishes those, and it is not expressible in an inline style at all.
+//
+// This component is a plain <button> with a class. It takes every native
+// button prop, so `disabled`, `aria-live`, `type` and the rest keep working
+// exactly as they did on the elements it replaces.
+
+import type { ButtonHTMLAttributes, Ref } from "react";
+import styles from "./Button.module.css";
+
+/**
+ * - `primary` — the blue CTA. One per surface; more than one and neither reads
+ *   as primary.
+ * - `outline` — secondary actions sitting beside a primary.
+ * - `confirm` — a transient success surface (ShareButton's "copied"). Not a
+ *   control: it renders disabled and does not take a pointer cursor.
+ */
+export type ButtonVariant = "primary" | "outline" | "confirm";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  /** Declared explicitly: React 19 passes `ref` as an ordinary prop to
+   * function components, but it is not part of ButtonHTMLAttributes. */
+  ref?: Ref<HTMLButtonElement>;
+}
+
+export default function Button({
+  variant = "primary",
+  className,
+  type = "button",
+  ref,
+  ...rest
+}: ButtonProps) {
+  // `type` defaults to "button", not the HTML default of "submit". Every
+  // call site in this repo passes type="button" explicitly today; making it
+  // the default means a future one inside a <form> cannot submit it by
+  // omission.
+  return (
+    <button
+      ref={ref}
+      type={type}
+      className={className ? `${styles[variant]} ${className}` : styles[variant]}
+      {...rest}
+    />
+  );
+}

--- a/next-app/src/components/ui/focusRing.test.ts
+++ b/next-app/src/components/ui/focusRing.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// One focus ring, app-wide.
+//
+// DESIGN.md specifies it exactly once — `0 0 0 3px rgba(10,132,255,0.40)` —
+// and says every interactive element draws that one. Before this suite there
+// were four different rings in the tree:
+//
+//   · blue,  the specified one                    (Button, page.module.css)
+//   · teal   #64d2ff                              (PlayButton dialog, HotDiscussions links)
+//   · amber  #ff9f0a                              (HotDiscussions cards)
+//   · the per-anime poster accent                 (HeroCarousel)
+//
+// Each looked deliberate in its own file. Together they are a ring that
+// stops meaning "you are here" and starts reading as decoration — and two
+// of them used colours this system reserves for something else: teal is
+// read-only, amber is --warning.
+//
+// The carousel's was the worst of the four and the hardest to see in review:
+// --hero-accent is sampled from whatever poster is on screen, so the focus
+// ring changed colour as the carousel rotated, and on the wrong artwork it
+// was invisible.
+//
+// This is a lint, not a unit test. It exists because the failure mode is
+// per-file plausibility — nobody writing one component sees the other three.
+
+const SRC = join(import.meta.dir, "../..");
+
+/** The ring DESIGN.md specifies, whitespace-insensitive. */
+const RING = /0\s+0\s+0\s+3px\s+rgba\(\s*10\s*,\s*132\s*,\s*255\s*,\s*0?\.4\d*\s*\)/;
+
+function cssModules(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry.startsWith(".")) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) cssModules(full, out);
+    else if (entry.endsWith(".module.css")) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Every `:focus-visible` rule body in the tree, as
+ * `{ file, selector, body }`.
+ *
+ * Comments are stripped first — this file's own prose names the colours it
+ * bans, and several of the fixed rules explain what they used to be.
+ */
+function focusRules(): Array<{ file: string; selector: string; body: string }> {
+  const found: Array<{ file: string; selector: string; body: string }> = [];
+  for (const file of cssModules(SRC)) {
+    const css = readFileSync(file, "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+    for (const [, selector, body] of css.matchAll(
+      /([^{}]*:focus-visible[^{}]*)\{([^}]*)\}/g,
+    )) {
+      found.push({
+        file: file.slice(SRC.length + 1),
+        selector: selector.trim().replace(/\s+/g, " "),
+        body,
+      });
+    }
+  }
+  return found;
+}
+
+const rules = focusRules();
+
+describe("the focus ring", () => {
+  test("the scan finds rules at all (guards the parser, not the CSS)", () => {
+    // Without this, a regex that quietly matched nothing would make every
+    // assertion below pass forever.
+    expect(rules.length).toBeGreaterThanOrEqual(5);
+  });
+
+  test("every :focus-visible rule draws the one specified ring", () => {
+    const wrong = rules
+      .filter((r) => !RING.test(r.body))
+      .map((r) => `${r.file} — ${r.selector}`);
+    expect(wrong).toEqual([]);
+  });
+
+  test("no rule paints the ring with a reserved or per-anime colour", () => {
+    // Named individually because each was a real regression, and the error
+    // message should say which mistake was made rather than "did not match".
+    const offenders = rules
+      .filter((r) => /#64d2ff|#5ac8fa|#ff9f0a|#30d158|--hero-accent|--poster-accent/.test(r.body))
+      .map((r) => `${r.file} — ${r.selector}`);
+    expect(offenders).toEqual([]);
+  });
+
+  test("no rule removes the indicator outright", () => {
+    // `outline: none` is fine in a rule that also draws the box-shadow ring;
+    // `box-shadow: none` inside a :focus-visible block is not.
+    const removed = rules
+      .filter((r) => /box-shadow\s*:\s*none/.test(r.body))
+      .map((r) => `${r.file} — ${r.selector}`);
+    expect(removed).toEqual([]);
+  });
+});
+
+describe("touch targets", () => {
+  test("the shared Button meets the 44px floor", () => {
+    // DESIGN.md > Touch Targets, which is Apple HIG's minimum. It was 40px,
+    // and 42px in the dialog next to it — both close enough to look
+    // considered while missing the number they were aiming at.
+    const css = readFileSync(join(import.meta.dir, "Button.module.css"), "utf8");
+    const min = css.match(/min-height:\s*(\d+)px/)?.[1];
+    expect(min).toBeDefined();
+    expect(Number(min)).toBeGreaterThanOrEqual(44);
+  });
+});


### PR DESCRIPTION
Eleven tasks from the design-debt plan (E0–E9), in six reviewable commits.
The headline is a defect that is live on production right now.

## The bug

Every anime rated 75 or above renders **green text on an amber pill**, on
the highest-traffic page on the site. Two halves, one screen apart:

```
scoreColor(s)        -> #30d158 / #ff9f0a / #ff453a   (three bands)
S.scoreBadge(color)  -> background: rgba(255,159,10,0.12)   (always amber)
```

Neither is wrong on its own. The defect only exists in the seam, and a
`scoreBadge(color)` signature is what opened it. ★6 and ★5.7 happen to be
correct, which is why looking at the page never caught it.

Measured on production, three viewports, same result:
`color: rgb(48,209,88)` on `background: rgba(255,159,10,0.12)`.

The same threshold ladder existed verbatim in three files, and a second one
was also wrong (`EpisodeFileList`). `AnimeCard` was correct — its badge sits
on cover art, so it uses an opaque scrim rather than a 12% tint, which has no
contrast guarantee against a poster that could be any colour.

The fix is not "make the background a function too". It is that nothing can
ask for one half any more: `scoreStyle.ts` exports style functions that each
return a complete pair, and there is no exported way to get a foreground
alone.

## The token vocabulary underneath it

DESIGN.md defines 31 tokens. `globals.css` declared 10, six of them drifted.
The whole spacing scale, the whole radius scale, every semantic colour and
both fill colours were absent — and CSS says nothing about that: `var(--sp-lg)`
against an undeclared token resolves to nothing and the declaration is
dropped, so the failure mode is a component that looks *almost* right.

So every component that needed a radius or a spacing step hardcoded a literal,
and the design system existed only as a document. Measured across all of
`src/` before this PR: `--accent` had 9 references, `--bg` and `--text` one
each, and the entire rest of the palette had **zero**.

That is also why correcting the six drifted values is safe rather than a
visual change — none of the six had a single `var()` reference anywhere.

## Mobile first screen

The hero's four geometry values are one design with four numbers, and they
were four separate ternaries on `detail.bannerImageUrl` spread over 70 lines
of JSX. Changing one alone does not make a smaller hero, it makes a broken
one. They are now one custom-property set per state.

Measured at 390x844, against production for the before:

|                | before | after |
|----------------|--------|-------|
| banner height  | 400px  | 150px |
| h1 top         | 769px  | 187px |
| synopsis top   | 799px  | 217px |
| primary CTA    | 1190px | 811px |

The synopsis was nominally "on the first screen" before, at 799px on an
844-tall viewport — about 45px of visible text. A visitor arriving from a
search result scrolled past a full-height banner and a 300px poster to reach
what they searched for.

**Desktop is unchanged, and that is the check that this was a move and not a
redesign**: at 1440px the h1, synopsis and CTA land at 437, 484 and 702 both
before and after, identical to the pixel.

## Focus rings

Four different ones were in the tree:

| colour | where |
|---|---|
| blue `rgba(10,132,255,0.40)` | the specified one |
| teal `#64d2ff` | PlayButton's dialog, HotDiscussions links |
| amber `#ff9f0a` | HotDiscussions cards |
| `--hero-accent` | HeroCarousel |

Each is plausible in its own file, which is why all four survived review.
Two used colours this system reserves for something else (teal is read-only,
amber is `--warning`). The carousel's was the worst and least visible:
`--hero-accent` is sampled from whichever poster is on screen, so the ring
changed colour as the carousel rotated and on some artwork was invisible.

PlayButton's close button drew no ring at all — its `:focus-visible` was
folded in with `:hover` and set `outline: none`, leaving keyboard focus
indicated by a border-colour change on a 32px circle against a dark backdrop.
It is the dialog's only dismiss control.

## The schedule tabs could not have had a focus ring

Not an oversight in the CSS. The tabs were styled by an inline
`tabStyle(active, isToday)` whose last line was `outline: "none"`, and an
inline declaration beats every stylesheet rule — so a focus style added
anywhere else would have been written, reviewed, merged and silently ignored.

Seven plain buttons were also seven tab stops with nothing tying them to the
grid they switch. Now `role="tablist"` / `tab` / `tabpanel` with a roving
tabindex: one tab in the Tab order, Arrow keys between them.

## Testing

- `bun test` 1694 pass across 93 files
- Full Go suite and `go test -tags=integration` pass
- Sandbox e2e: the six new specs pass against a real stack (Postgres +
  go-api + `next dev`)

Four gates were added, and each was verified to actually bite:

| gate | what it catches |
|---|---|
| `globals.test.ts` | parses DESIGN.md and compares; deleting `--radius-full` turns two assertions red independently |
| `focusRing.test.ts` | scans every `*.module.css` — a Button-only test would have missed three of the four rings |
| `scoreStyle.test.ts` | asserts bg and fg name the same band for every score 0..100 |
| `Button.test.ts` | a variant in the type with no class renders `class="undefined"`, i.e. a button with no padding, no touch target and no focus ring |

Running the e2e for the first time also found three defects in the new specs
themselves — `ensureAnimeDetail` cleared child tables before inserting, which
is safe only single-threaded, and `beforeAll` runs once per worker under
`fullyParallel`. That fix protects every spec using the fixture, not just the
new ones.

## Deliberately not in this PR

- DESIGN.md specifies buttons at 14px/500 with 10px 20px padding; the
  extracted surface is 13px/600 with 10px 18px. That is a visual change and
  wants its own review, not a line in an accessibility fix.
- `page.tsx` is still ~1300 lines against the project's 800 limit. 19 of its
  76 inline style sites moved.