### PR TITLE
fix(seo): the sitemap was built from an endpoint that answers a different question

### DIFF
--- a/e2e/specs/sandbox/sitemap-shards.spec.ts
+++ b/e2e/specs/sandbox/sitemap-shards.spec.ts
@@ -20,6 +20,13 @@ import { closePg, ensureAnimeCached, removeAnimeFixture } from "../../fixtures/p
 // session changes what the proxy does with them.
 test.use({ storageState: { cookies: [], origins: [] } });
 
+// One worker for the whole file. The config sets fullyParallel, which
+// spreads a file's tests across workers — and beforeAll/afterAll run once
+// per worker, so with one shared database and one set of fixture ids the
+// first worker to finish deletes the rows the others are still reading.
+// The result is an intermittent 404 in whichever spec drew the short straw.
+test.describe.configure({ mode: "serial" });
+
 // Ids picked for their remainder, not their meaning. `anilist_id % 4` is the
 // shard, so this pair is the smallest thing that proves the Go query and the
 // Next route agree about which file an anime belongs in — seed both, and each

--- a/e2e/specs/sandbox/sitemap-shards.spec.ts
+++ b/e2e/specs/sandbox/sitemap-shards.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "@playwright/test";
+import { closePg, ensureAnimeCached, removeAnimeFixture } from "../../fixtures/pg";
+
+// The anime sitemap, end to end: Postgres row → go-api → Next → XML.
+//
+// This is the project that can fail a pull request. The prod-facing
+// sitemap-robots.spec.ts runs against the deployed site, so it can only
+// report a broken sitemap after it is already broken in public.
+//
+// What it is really guarding is a URL. The shards are published at
+// /sitemaps/anime/sitemap/{id}.xml by Next's generateSitemaps convention,
+// and robots.txt names those paths from a separate constant. If the two ever
+// disagree — a rename, a shard-count change, a move under a different segment
+// — nothing throws: /sitemap.xml still validates, each shard still serves,
+// robots.txt still parses, and Google simply never reads the 17,603 anime
+// URLs. That silence is the whole reason the catalogue went unlisted long
+// enough to be discovered by reading the code rather than by anything failing.
+//
+// No authentication: these are the URLs a crawler fetches, and a signed-in
+// session changes what the proxy does with them.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// Ids picked for their remainder, not their meaning. `anilist_id % 4` is the
+// shard, so this pair is the smallest thing that proves the Go query and the
+// Next route agree about which file an anime belongs in — seed both, and each
+// must appear in exactly one shard, and not the other's.
+const IN_SHARD_0 = 990_000_000; // % 4 === 0
+const IN_SHARD_3 = 990_000_003; // % 4 === 3
+
+test.beforeAll(async () => {
+  // Seeded before the first request on purpose. The route caches its upstream
+  // fetch for an hour, so a shard read before its rows exist would answer
+  // empty for the rest of the run.
+  await ensureAnimeCached({ anilistId: IN_SHARD_0, titleRomaji: "Sitemap Shard Zero" });
+  await ensureAnimeCached({ anilistId: IN_SHARD_3, titleRomaji: "Sitemap Shard Three" });
+});
+
+test.afterAll(async () => {
+  await removeAnimeFixture(IN_SHARD_0);
+  await removeAnimeFixture(IN_SHARD_3);
+  await closePg();
+});
+
+test("each shard serves XML and carries only its own anime", async ({ page }) => {
+  const shard0 = await page.request.get("/sitemaps/anime/sitemap/0.xml");
+  expect(shard0.status(), "the shard URL must exist — robots.txt points at it").toBe(200);
+  expect(shard0.headers()["content-type"] || "").toMatch(/^(application|text)\/xml/);
+
+  const body0 = await shard0.text();
+  expect(body0).toContain(`/anime/${IN_SHARD_0}`);
+  expect(body0).not.toContain(`/anime/${IN_SHARD_3}`);
+
+  const shard3 = await page.request.get("/sitemaps/anime/sitemap/3.xml");
+  expect(shard3.status()).toBe(200);
+
+  const body3 = await shard3.text();
+  expect(body3).toContain(`/anime/${IN_SHARD_3}`);
+  expect(body3).not.toContain(`/anime/${IN_SHARD_0}`);
+});
+
+test("a shard row carries every locale and a real lastmod", async ({ page }) => {
+  const body = await (await page.request.get("/sitemaps/anime/sitemap/0.xml")).text();
+
+  // hreflang has to agree with what the detail pages claim about themselves;
+  // Google drops a reciprocal group whose two halves disagree.
+  for (const prefix of ["", "/en", "/zh-Hant"]) {
+    expect(body).toContain(`<loc>https://animegoclub.com${prefix}/anime/${IN_SHARD_0}</loc>`);
+  }
+
+  // A lastmod exists and is not the epoch — it comes from the row's
+  // updated_at. The version this replaced stamped the current time on every
+  // row of every fetch, which is a claim Google can disprove by crawling.
+  const lastmod = body.match(/<lastmod>([^<]+)<\/lastmod>/)?.[1];
+  expect(lastmod, "every url needs a lastmod").toBeTruthy();
+  expect(new Date(lastmod!).getFullYear()).toBeGreaterThan(2000);
+});
+
+test("robots.txt names every shard, and each name resolves", async ({ page }) => {
+  const robots = await (await page.request.get("/robots.txt")).text();
+
+  const listed = [...robots.matchAll(/^Sitemap:\s*(\S+)$/gim)].map((m) => m[1]);
+  expect(listed.length, "the static sitemap plus one line per shard").toBeGreaterThan(1);
+
+  // The assertion that matters: nothing robots.txt advertises is a 404. A
+  // stale entry here is invisible from every other angle.
+  for (const url of listed) {
+    const res = await page.request.get(new URL(url).pathname);
+    expect(res.status(), `${url} is advertised to crawlers`).toBe(200);
+  }
+});

--- a/e2e/specs/sitemap-robots.spec.ts
+++ b/e2e/specs/sitemap-robots.spec.ts
@@ -18,10 +18,15 @@ test("sitemap.xml serves application/xml with absolute https URLs", async ({ req
   expect(contentType).toMatch(/^(application|text)\/xml/);
 
   const body = await res.text();
-  // Sitemap must contain at least the homepage and at least one anime
-  // detail URL absolutized to the canonical host.
+  // The homepage and the current season, absolutized to the canonical host.
+  //
+  // Not the anime URLs: this document holds the static pages, and the
+  // catalogue moved to the sharded sitemaps under /sitemaps/anime/ when it
+  // outgrew Google's 50,000-URL cap. The shards are covered end to end by
+  // specs/sandbox/sitemap-shards.spec.ts, which runs against a stack built
+  // from the branch rather than against whatever is already deployed.
   expect(body).toContain("https://animegoclub.com/");
-  expect(body).toMatch(/https:\/\/animegoclub\.com\/(anime\/|seasonal\/)/);
+  expect(body).toMatch(/https:\/\/animegoclub\.com\/seasonal\//);
 });
 
 test("robots.txt serves text/plain with a User-agent directive", async ({ request }) => {
@@ -37,4 +42,24 @@ test("robots.txt serves text/plain with a User-agent directive", async ({ reques
   expect(body).toMatch(/^User-Agent:/im);
   // Sitemap reference must absolutize to the canonical host.
   expect(body).toMatch(/Sitemap:\s*https:\/\/animegoclub\.com\/sitemap\.xml/i);
+});
+
+test("every sitemap robots.txt advertises actually resolves", async ({ request }) => {
+  // Derived from robots.txt rather than hardcoded, which is what lets this
+  // run green both before and after the sharded sitemaps deploy — it checks
+  // whatever the live site currently claims, however many that is.
+  //
+  // The failure it catches is the one with no other symptom: robots.txt is
+  // the only thing that makes a sitemap discoverable (there is no index
+  // document), so a name that 404s costs the entire file's URLs and nothing
+  // anywhere reports it.
+  const robots = await (await request.get("/robots.txt")).text();
+  const listed = [...robots.matchAll(/^Sitemap:\s*(\S+)$/gim)].map((m) => m[1]);
+
+  expect(listed.length, "robots.txt must advertise at least one sitemap").toBeGreaterThan(0);
+
+  for (const url of listed) {
+    const res = await request.get(new URL(url).pathname);
+    expect(res.status(), `${url} is advertised to crawlers`).toBe(200);
+  }
 });

--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -755,6 +755,9 @@ func main() {
 		// A fixed segment, so it must be registered outside the /{anilistId}
 		// group to avoid being read as an id.
 		r.Get("/episode-offsets", anime.EpisodeOffsets(q))
+		// Catalogue enumeration for next-app's sitemap. Another fixed
+		// segment sharing the subtree with /{anilistId}.
+		r.Get("/sitemap", anime.SitemapShard(q))
 		r.Get("/{anilistId}/watchers", anime.Watchers(q))
 		// How many episodes precede this season in its franchise's
 		// continuous numbering.  Registered before the bare /{anilistId} for

--- a/go-api/internal/anime/handlers_test.go
+++ b/go-api/internal/anime/handlers_test.go
@@ -63,6 +63,7 @@ type fakeQuerier struct {
 	getWatchersFn           func(ctx context.Context, id int32, limit int32) ([]dbgen.GetWatchersRow, error)
 	countWatchersFn         func(ctx context.Context, id int32) (int64, error)
 	getTorrentQueryInputsFn func(ctx context.Context, anilistID int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error)
+	listSitemapShardFn      func(ctx context.Context, shardCount, shardIndex int32) ([]dbgen.ListSitemapShardRow, error)
 }
 
 func (f *fakeQuerier) GetCompletedGems(ctx context.Context, limit int32) ([]dbgen.GetCompletedGemsRow, error) {
@@ -112,6 +113,13 @@ func (f *fakeQuerier) CountWatchers(ctx context.Context, id int32) (int64, error
 		return 0, errors.New("fakeQuerier: CountWatchers not set")
 	}
 	return f.countWatchersFn(ctx, id)
+}
+
+func (f *fakeQuerier) ListSitemapShard(ctx context.Context, shardCount, shardIndex int32) ([]dbgen.ListSitemapShardRow, error) {
+	if f.listSitemapShardFn == nil {
+		return nil, errors.New("fakeQuerier: ListSitemapShard not set")
+	}
+	return f.listSitemapShardFn(ctx, shardCount, shardIndex)
 }
 
 func (f *fakeQuerier) GetTorrentQueryInputsByAnilistID(ctx context.Context, anilistID int32) (dbgen.GetTorrentQueryInputsByAnilistIDRow, error) {

--- a/go-api/internal/anime/sitemap.go
+++ b/go-api/internal/anime/sitemap.go
@@ -1,0 +1,96 @@
+package anime
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
+)
+
+// maxSitemapShards bounds the `shards` parameter.  Anything above this is
+// not a sitemap layout, it is a typo — and since each shard is a separate
+// full scan of anime_cache, an unbounded value turns one query string into
+// as many scans as the caller cares to name.
+const maxSitemapShards = 64
+
+// SitemapShard implements GET /api/anime/sitemap — every anime id in one
+// modulo shard of the catalogue, with the time its row last changed.
+//
+// It exists because next-app's sitemap was built out of
+// /api/anime/yearly-top, which answers a different question: the
+// top-rated titles of one year, capped at 20 by that handler.  The
+// sitemap asked for limit=100, parseLimit silently clamped it to 20, and
+// the site advertised 20 of its 17,603 anime to Google.  The other 99.9%
+// were reachable only by a crawler guessing ids.  Nothing was broken in
+// a way any test or log could show — the wrong endpoint answered
+// correctly.
+//
+// The caller owns the shard count.  next-app holds the constant and
+// passes it, so changing the sitemap layout is a one-line frontend edit
+// and this handler keeps no opinion about sizing.  See the
+// ListSitemapShard comment for why the slice is `id % n` rather than
+// LIMIT/OFFSET.
+//
+// Uncached on purpose.  next-app reads this behind its own revalidate
+// window, so real traffic is a few requests an hour regardless of how
+// many crawlers pull the XML.  A cache here would buy nothing and cost an
+// invalidation question.
+//
+// Query parameters:
+//
+//	shards  how many shards the catalogue is divided into, 1..64 (default 1)
+//	shard   which shard to return, 0..shards-1 (default 0)
+//
+// Response envelope:
+//
+//	{"data":[{"anilistId":1,"updatedAt":"2026-08-27T11:29:16.681137Z"}, ...]}
+func SitemapShard(q dbgen.Querier) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		ctx, cancel := context.WithTimeout(req.Context(), queryTimeout)
+		defer cancel()
+
+		qs := req.URL.Query()
+
+		// Rejecting bad input rather than clamping it, which is the
+		// opposite of what parseLimit does elsewhere in this package.
+		// The difference is what a silent correction costs: a clamped
+		// `limit` returns fewer rows, while a clamped `shard` returns
+		// somebody else's rows — two sitemap files would list the same
+		// URLs, and duplicate <loc> entries across a sitemap set is a
+		// defect Google attributes to the site instead of reporting
+		// back.  A 400 is visible; a wrong sitemap is not.
+		shards, err := parseShard(qs.Get("shards"), 1)
+		if err != nil || shards < 1 || shards > maxSitemapShards {
+			httpx.Fail(w, httpx.NewError(http.StatusBadRequest, httpx.CodeValidationError,
+				"shards must be an integer in 1.."+strconv.Itoa(maxSitemapShards)))
+			return
+		}
+
+		shard, err := parseShard(qs.Get("shard"), 0)
+		if err != nil || shard < 0 || shard >= shards {
+			httpx.Fail(w, httpx.NewError(http.StatusBadRequest, httpx.CodeValidationError,
+				"shard must be an integer in 0.."+strconv.Itoa(shards-1)))
+			return
+		}
+
+		rows, err := q.ListSitemapShard(ctx, int32(shards), int32(shard))
+		if err != nil {
+			httpx.Fail(w, httpx.WrapError(err, http.StatusInternalServerError, httpx.CodeServerError, "query failed"))
+			return
+		}
+
+		httpx.Data(w, http.StatusOK, rows)
+	}
+}
+
+// parseShard reads an optional non-negative integer query parameter.
+// Absent means def; anything present but unparseable is an error rather
+// than a fallback, for the reason given at the call site.
+func parseShard(s string, def int) (int, error) {
+	if s == "" {
+		return def, nil
+	}
+	return strconv.Atoi(s)
+}

--- a/go-api/internal/anime/sitemap_test.go
+++ b/go-api/internal/anime/sitemap_test.go
@@ -1,0 +1,174 @@
+package anime
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+// shardCall records the coordinates the handler forwarded to the querier,
+// which is the only thing about this endpoint that can be wrong in a way
+// the response body would still look fine.
+type shardCall struct {
+	count int32
+	index int32
+	made  bool
+}
+
+func sitemapQuerier(rows []dbgen.ListSitemapShardRow, call *shardCall) *fakeQuerier {
+	return &fakeQuerier{
+		listSitemapShardFn: func(_ context.Context, count, index int32) ([]dbgen.ListSitemapShardRow, error) {
+			call.count, call.index, call.made = count, index, true
+			return rows, nil
+		},
+	}
+}
+
+func TestSitemapShard_ForwardsShardCoordinates(t *testing.T) {
+	t.Parallel()
+
+	var call shardCall
+	q := sitemapQuerier(nil, &call)
+
+	rec := httptest.NewRecorder()
+	SitemapShard(q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/sitemap?shards=4&shard=3", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, int32(4), call.count)
+	assert.Equal(t, int32(3), call.index)
+}
+
+func TestSitemapShard_DefaultsToTheWholeCatalogue(t *testing.T) {
+	t.Parallel()
+
+	// No parameters means one shard containing everything — `id % 1 == 0`
+	// is true for every row.  A caller that forgets the parameters gets
+	// the complete catalogue rather than an arbitrary slice of it.
+	var call shardCall
+	q := sitemapQuerier(nil, &call)
+
+	rec := httptest.NewRecorder()
+	SitemapShard(q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/sitemap", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, int32(1), call.count)
+	assert.Equal(t, int32(0), call.index)
+}
+
+func TestSitemapShard_EmitsIDAndLastModified(t *testing.T) {
+	t.Parallel()
+
+	when := time.Date(2026, 8, 27, 11, 29, 16, 0, time.UTC)
+	var call shardCall
+	q := sitemapQuerier([]dbgen.ListSitemapShardRow{
+		{AnilistID: 1474, UpdatedAt: pgtype.Timestamptz{Time: when, Valid: true}},
+	}, &call)
+
+	rec := httptest.NewRecorder()
+	SitemapShard(q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/sitemap", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var parsed struct {
+		Data []struct {
+			AnilistID int32  `json:"anilistId"`
+			UpdatedAt string `json:"updatedAt"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &parsed))
+	require.Len(t, parsed.Data, 1)
+	assert.Equal(t, int32(1474), parsed.Data[0].AnilistID)
+
+	// The timestamp has to survive as something Date() can parse — this is
+	// the sitemap's <lastmod>, and pgtype.Timestamptz would serialise as a
+	// struct if it did not carry its own MarshalJSON.
+	got, err := time.Parse(time.RFC3339Nano, parsed.Data[0].UpdatedAt)
+	require.NoError(t, err, "updatedAt must be an RFC3339 string, got %q", parsed.Data[0].UpdatedAt)
+	assert.True(t, got.Equal(when))
+}
+
+// The four rejection cases below all share one stake: a request the
+// handler "fixes" instead of refusing produces a sitemap file full of
+// another shard's URLs, and duplicate <loc> entries across a sitemap set
+// is a defect that surfaces as lost rankings rather than as an error.
+// Every one of them must reach the database zero times.
+func TestSitemapShard_RejectsBadCoordinates(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"shard equal to the shard count", "?shards=4&shard=4"},
+		{"negative shard", "?shards=4&shard=-1"},
+		{"non-numeric shard count", "?shards=four&shard=0"},
+		// Zero is the one that would reach Postgres as `id % 0` and come
+		// back as a division-by-zero from the driver, i.e. a 500 blamed on
+		// the database for what is a bad query string.
+		{"zero shards", "?shards=0&shard=0"},
+		{"more shards than the cap", "?shards=65&shard=0"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var call shardCall
+			q := sitemapQuerier(nil, &call)
+
+			rec := httptest.NewRecorder()
+			SitemapShard(q).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/sitemap"+tc.query, nil))
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.False(t, call.made, "a rejected request must not reach the database")
+		})
+	}
+}
+
+func TestSitemapShard_RouteDoesNotCollideWithDetail(t *testing.T) {
+	t.Parallel()
+
+	// /sitemap is a literal segment sharing the /api/anime subtree with
+	// the /{anilistId} wildcard.  chi resolves static before parametric,
+	// so this passes by construction — the test is here because the
+	// consequence of it ever changing is the detail handler being asked
+	// for anime "sitemap" and the sitemap silently emptying out.
+	var detailHits []string
+	detail := func(w http.ResponseWriter, req *http.Request) {
+		detailHits = append(detailHits, chi.URLParam(req, "anilistId"))
+		w.WriteHeader(http.StatusOK)
+	}
+
+	var call shardCall
+	q := sitemapQuerier([]dbgen.ListSitemapShardRow{{AnilistID: 1}}, &call)
+
+	r := chi.NewRouter()
+	r.Route("/api/anime", func(r chi.Router) {
+		r.Get("/sitemap", SitemapShard(q))
+		r.Get("/{anilistId}", detail)
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/anime/sitemap", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, call.made, "SitemapShard is the handler that ran")
+	assert.Empty(t, detailHits, "the detail handler must not see /api/anime/sitemap")
+
+	// And the wildcard still answers for a real id.
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/api/anime/12345", nil))
+
+	require.Equal(t, http.StatusOK, rec2.Code)
+	assert.Equal(t, []string{"12345"}, detailHits)
+}

--- a/go-api/internal/db/gen/anime_cache.sql.go
+++ b/go-api/internal/db/gen/anime_cache.sql.go
@@ -2290,6 +2290,60 @@ func (q *Queries) ListEpisodesBgmCandidates(ctx context.Context, arg ListEpisode
 	return items, nil
 }
 
+const listSitemapShard = `-- name: ListSitemapShard :many
+SELECT
+    anilist_id,
+    updated_at
+FROM anime_cache
+WHERE anilist_id % $1::int = $2::int
+ORDER BY anilist_id
+`
+
+type ListSitemapShardRow struct {
+	AnilistID int32              `json:"anilistId"`
+	UpdatedAt pgtype.Timestamptz `json:"updatedAt"`
+}
+
+// One modulo slice of the whole catalogue, for /api/anime/sitemap.
+//
+// Deliberately unfiltered.  Every row in anime_cache renders a 200 at
+// /anime/{anilist_id} — the detail page reads GetAnimeMainByID and the
+// row existing IS the page existing — so any WHERE clause here would be
+// an editorial judgement about which real pages to hide from Google,
+// not a correctness constraint.  The previous sitemap made that
+// judgement by accident (it reused /yearly-top, which is one year's
+// top-rated) and published 20 of 17,603.
+//
+// Sharded by `anilist_id % $1` rather than LIMIT/OFFSET because a shard
+// has to stay stable as the catalogue grows: with offsets, one new row
+// shifts every anime after it into a different sitemap file, and a
+// crawler re-reading them sees the whole tail as churn.  Modulo keeps
+// each id in the same file for life, and the id space is dense enough
+// that the shards stay balanced without tuning (measured on prod:
+// 4129 / 4653 / 4061 / 4760 at $1 = 4).
+//
+// updated_at, not now(): Google discards lastmod it can prove wrong,
+// and "every URL changed this second, on every fetch" is provably wrong.
+func (q *Queries) ListSitemapShard(ctx context.Context, shardCount int32, shardIndex int32) ([]ListSitemapShardRow, error) {
+	rows, err := q.db.Query(ctx, listSitemapShard, shardCount, shardIndex)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListSitemapShardRow{}
+	for rows.Next() {
+		var i ListSitemapShardRow
+		if err := rows.Scan(&i.AnilistID, &i.UpdatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUnenrichedAnilistIDs = `-- name: ListUnenrichedAnilistIDs :many
 SELECT anilist_id
 FROM anime_cache

--- a/go-api/internal/db/gen/querier.go
+++ b/go-api/internal/db/gen/querier.go
@@ -984,6 +984,27 @@ type Querier interface {
 	ListProfileWatching(ctx context.Context, userID uuid.UUID) ([]ListProfileWatchingRow, error)
 	// Passing NULL report_status returns the entire moderation queue.
 	ListReports(ctx context.Context, reportStatus *string, pageOffset int32, pageLimit int32) ([]ListReportsRow, error)
+	// One modulo slice of the whole catalogue, for /api/anime/sitemap.
+	//
+	// Deliberately unfiltered.  Every row in anime_cache renders a 200 at
+	// /anime/{anilist_id} — the detail page reads GetAnimeMainByID and the
+	// row existing IS the page existing — so any WHERE clause here would be
+	// an editorial judgement about which real pages to hide from Google,
+	// not a correctness constraint.  The previous sitemap made that
+	// judgement by accident (it reused /yearly-top, which is one year's
+	// top-rated) and published 20 of 17,603.
+	//
+	// Sharded by `anilist_id % $1` rather than LIMIT/OFFSET because a shard
+	// has to stay stable as the catalogue grows: with offsets, one new row
+	// shifts every anime after it into a different sitemap file, and a
+	// crawler re-reading them sees the whole tail as churn.  Modulo keeps
+	// each id in the same file for life, and the id space is dense enough
+	// that the shards stay balanced without tuning (measured on prod:
+	// 4129 / 4653 / 4061 / 4760 at $1 = 4).
+	//
+	// updated_at, not now(): Google discards lastmod it can prove wrong,
+	// and "every URL changed this second, on every fetch" is provably wrong.
+	ListSitemapShard(ctx context.Context, shardCount int32, shardIndex int32) ([]ListSitemapShardRow, error)
 	// Explainable discovery ranking for the homepage.  Participation matters more
 	// than raw volume, reactions add a smaller signal, and a smooth age divisor
 	// lets a fresh smaller conversation outrank an old thread without making the

--- a/go-api/internal/db/queries/anime_cache.sql
+++ b/go-api/internal/db/queries/anime_cache.sql
@@ -222,6 +222,34 @@ SELECT count(*)::bigint AS total
 FROM subscriptions
 WHERE anilist_id = $1 AND status = 'watching';
 
+-- name: ListSitemapShard :many
+-- One modulo slice of the whole catalogue, for /api/anime/sitemap.
+--
+-- Deliberately unfiltered.  Every row in anime_cache renders a 200 at
+-- /anime/{anilist_id} — the detail page reads GetAnimeMainByID and the
+-- row existing IS the page existing — so any WHERE clause here would be
+-- an editorial judgement about which real pages to hide from Google,
+-- not a correctness constraint.  The previous sitemap made that
+-- judgement by accident (it reused /yearly-top, which is one year's
+-- top-rated) and published 20 of 17,603.
+--
+-- Sharded by `anilist_id % $1` rather than LIMIT/OFFSET because a shard
+-- has to stay stable as the catalogue grows: with offsets, one new row
+-- shifts every anime after it into a different sitemap file, and a
+-- crawler re-reading them sees the whole tail as churn.  Modulo keeps
+-- each id in the same file for life, and the id space is dense enough
+-- that the shards stay balanced without tuning (measured on prod:
+-- 4129 / 4653 / 4061 / 4760 at $1 = 4).
+--
+-- updated_at, not now(): Google discards lastmod it can prove wrong,
+-- and "every URL changed this second, on every fetch" is provably wrong.
+SELECT
+    anilist_id,
+    updated_at
+FROM anime_cache
+WHERE anilist_id % sqlc.arg(shard_count)::int = sqlc.arg(shard_index)::int
+ORDER BY anilist_id;
+
 -- name: UpsertAnimeCache :exec
 -- Upsert anime_cache main row from AniList sync.  Bangumi columns
 -- (title_chinese, bgm_id, bangumi_score, bangumi_votes, bangumi_version)

--- a/next-app/src/app/robots.test.ts
+++ b/next-app/src/app/robots.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import robots from "./robots";
+import { ANIME_SITEMAP_SHARDS, animeSitemapPath } from "@/lib/seo/animeSitemap";
+import { SITE_ORIGIN } from "@/lib/seo/alternates";
+
+// robots.txt is the only thing that makes the sharded anime sitemaps
+// discoverable. There is no sitemap index — Next's sitemap convention emits
+// <urlset> and cannot emit <sitemapindex> — so a shard missing from this
+// list is a shard Google never reads, and nothing about that failure is
+// visible: /sitemap.xml still validates, the shard still serves, the URLs
+// just never get crawled. That is the same shape as the defect this whole
+// change fixes, which is why it gets a test.
+
+const doc = robots();
+const sitemaps = Array.isArray(doc.sitemap) ? doc.sitemap : [doc.sitemap];
+
+describe("sitemap discovery", () => {
+  test("the static sitemap keeps the URL Search Console has on file", () => {
+    // Moving this would retire a submitted sitemap. The anime catalogue was
+    // sharded into new files specifically so this one could stay put.
+    expect(sitemaps).toContain(`${SITE_ORIGIN}/sitemap.xml`);
+  });
+
+  test("every anime shard is listed", () => {
+    for (let id = 0; id < ANIME_SITEMAP_SHARDS; id++) {
+      expect(sitemaps).toContain(`${SITE_ORIGIN}${animeSitemapPath(id)}`);
+    }
+  });
+
+  test("lists nothing beyond the static sitemap and the shards", () => {
+    // Catches the reverse mistake: a stale entry left behind after the
+    // shard count changes points a crawler at a file that no longer exists.
+    expect(sitemaps).toHaveLength(ANIME_SITEMAP_SHARDS + 1);
+  });
+
+  test("every sitemap url is absolute and on the canonical origin", () => {
+    for (const url of sitemaps) {
+      expect(url.startsWith(`${SITE_ORIGIN}/`)).toBe(true);
+    }
+  });
+});
+
+describe("crawl policy", () => {
+  test("nothing the sitemaps advertise is disallowed", () => {
+    // A sitemap listing URLs robots.txt blocks is a contradiction Search
+    // Console reports as an error against the whole document. /anime/ is
+    // the surface the shards enumerate, so it must stay crawlable.
+    const wildcard = doc.rules;
+    const rules = Array.isArray(wildcard) ? wildcard : [wildcard];
+    const forEveryone = rules.find((r) => r.userAgent === "*");
+    expect(forEveryone).toBeDefined();
+
+    const disallow = forEveryone?.disallow;
+    const blocked = Array.isArray(disallow) ? disallow : disallow ? [disallow] : [];
+    for (const path of blocked) {
+      expect("/anime/1".startsWith(path)).toBe(false);
+      expect("/sitemaps/anime/sitemap/0.xml".startsWith(path)).toBe(false);
+    }
+  });
+});

--- a/next-app/src/app/robots.ts
+++ b/next-app/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { animeSitemapUrls } from "@/lib/seo/animeSitemap";
 import { SITE_ORIGIN as SITE } from "@/lib/seo/alternates";
 
 /**
@@ -22,6 +23,15 @@ import { SITE_ORIGIN as SITE } from "@/lib/seo/alternates";
  * storm (267 of ~1,000 5xx in 17h) and brings no search or referral value,
  * so it is barred site-wide. It documents robots.txt compliance, so this
  * is effective, unlike the residential-proxy scrapers we can't name.
+ *
+ * The sitemap list is plural. /sitemap.xml holds the static pages and keeps
+ * the URL Search Console has on file; the anime catalogue is too large for
+ * one document (17,603 anime × 3 locales overflows Google's 50,000-URL cap)
+ * and is sharded under /sitemaps/anime/. robots.txt accepts any number of
+ * Sitemap directives and Google reads all of them, so naming the files here
+ * is what makes the shards discoverable — there is no index document,
+ * because Next's sitemap convention emits <urlset> and cannot emit
+ * <sitemapindex>.
  */
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -36,7 +46,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/library", "/player", "/api/", "/admin"],
       },
     ],
-    sitemap: `${SITE}/sitemap.xml`,
+    sitemap: [`${SITE}/sitemap.xml`, ...animeSitemapUrls()],
     host: SITE,
   };
 }

--- a/next-app/src/app/sitemap.ts
+++ b/next-app/src/app/sitemap.ts
@@ -1,26 +1,33 @@
 import type { MetadataRoute } from "next";
-import { apiGet } from "@/lib/api";
-import { DEFAULT_LOCALE, LOCALES, localizePath, type Locale } from "@/lib/i18n/locale";
-import { SITE_ORIGIN as SITE } from "@/lib/seo/alternates";
-import type { YearlyTopItem } from "@/lib/types";
+import { expandLocales, type SitemapEntry } from "@/lib/seo/sitemapEntry";
 
 // Stays at app/ rather than moving under app/[lang]/ with the route tree.
-// There is one sitemap for the site and it enumerates every locale itself; a
-// per-locale /en/sitemap.xml would be a second document making claims about
-// the same URLs.
+// This document enumerates every locale itself; a per-locale /en/sitemap.xml
+// would be a second document making claims about the same URLs.
+//
+// It also stays a plain sitemap.ts rather than growing generateSitemaps,
+// which would move it to /sitemap/0.xml and retire the one sitemap URL
+// Search Console has on file and robots.txt has always pointed at. The
+// anime catalogue is sharded at app/sitemaps/anime/ instead, and robots.txt
+// names every file.
+//
+// What used to be here: an /api/anime/yearly-top fetch asking for 100 rows
+// from a handler that caps at 20 — a silent clamp that published 20 of
+// 17,603 anime. It moved rather than being fixed in place, because the
+// endpoint was answering a different question (one year's top-rated titles)
+// and no limit would have made it enumerate a catalogue.
 
-// Number of anime detail pages to enumerate. Google's per-sitemap cap is
-// 50,000 URLs; 100 covers the SEO-relevant head without re-fetching the
-// whole catalog on every revalidate. Phase 4.4 can split via generateSitemaps
-// once /anime/* page yield justifies a larger surface.
-const YEARLY_TOP_LIMIT = 100;
-
-// Revalidate window for the upstream Go API fetch. One hour keeps the
-// sitemap reasonably fresh while letting the route stay cached between
-// crawler hits.
-const REVALIDATE_SECONDS = 3600;
-
-type Entry = Omit<MetadataRoute.Sitemap[number], "url"> & { path: string };
+/**
+ * Keep regenerating hourly now that nothing in here fetches.
+ *
+ * This used to be implicit: the route held an `apiGet` with a revalidate
+ * window, and that fetch was what kept the document from being frozen at
+ * build time. Moving the anime rows out took the fetch with it, which would
+ * have quietly pinned `currentSeasonPath(new Date())` to whenever the Docker
+ * image was built — reintroducing, by accident, the exact stale-season bug
+ * the function below exists to have fixed.
+ */
+export const revalidate = 3600;
 
 const SEASONS = ["winter", "spring", "summer", "fall"] as const;
 
@@ -38,48 +45,10 @@ function currentSeasonPath(now: Date): string {
   return `/seasonal/${SEASONS[Math.floor(now.getMonth() / 3)]}/${now.getFullYear()}`;
 }
 
-/**
- * Pages whose CONTENT exists only in the default locale.
- *
- * The legal pages are hardcoded Chinese JSX with no English body. Listing an
- * /en/ URL for them, or advertising one as an alternate, would tell Google
- * about an English page that serves Chinese — the exact defect this project
- * spent a commit removing from eight route files. They ship as a single
- * default-locale URL with no alternates until someone translates them.
- */
-const UNTRANSLATED_PATHS = new Set(["/terms", "/privacy", "/copyright"]);
-
-/**
- * One sitemap row per locale, cross-linked.
- *
- * Google reads sitemap `alternates.languages` the same way it reads the
- * `<link rel="alternate">` tags in the head, reciprocity requirement
- * included — so every row lists every locale, itself among them. Both
- * surfaces derive from LOCALES for that reason: a sitemap that disagrees
- * with the pages it lists is worse than one that says nothing.
- */
-function expand(entry: Entry): MetadataRoute.Sitemap {
-  const { path, ...rest } = entry;
-
-  if (UNTRANSLATED_PATHS.has(path)) {
-    return [{ ...rest, url: `${SITE}${localizePath(path, DEFAULT_LOCALE)}` }];
-  }
-
-  const languages = Object.fromEntries(
-    LOCALES.map((locale) => [locale, `${SITE}${localizePath(path, locale)}`]),
-  );
-
-  return LOCALES.map((locale: Locale) => ({
-    ...rest,
-    url: `${SITE}${localizePath(path, locale)}`,
-    alternates: { languages },
-  }));
-}
-
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
 
-  const staticEntries: Entry[] = [
+  const staticEntries: SitemapEntry[] = [
     { path: "/", lastModified: now, changeFrequency: "daily", priority: 1.0 },
     {
       path: currentSeasonPath(now),
@@ -106,25 +75,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { path: "/copyright", lastModified: now, changeFrequency: "yearly", priority: 0.2 },
   ];
 
-  let animeEntries: Entry[] = [];
-  try {
-    const items = await apiGet<YearlyTopItem[]>(
-      `/api/anime/yearly-top?limit=${YEARLY_TOP_LIMIT}`,
-      { revalidate: REVALIDATE_SECONDS },
-    );
-    animeEntries = items.map((a) => ({
-      path: `/anime/${a.anilistId}`,
-      lastModified: now,
-      changeFrequency: "weekly" as const,
-      priority: 0.8,
-    }));
-  } catch (err) {
-    // Graceful degradation: a sitemap that only lists the static URLs is
-    // still valid per the Sitemaps 0.9 protocol. We never want a Go API
-    // outage to turn /sitemap.xml into a 500, which would cause Googlebot
-    // to drop the entire sitemap from its crawl queue.
-    console.warn("[sitemap] yearly-top fetch failed:", err);
-  }
-
-  return [...staticEntries, ...animeEntries].flatMap(expand);
+  return staticEntries.flatMap(expandLocales);
 }

--- a/next-app/src/app/sitemaps/anime/sitemap.ts
+++ b/next-app/src/app/sitemaps/anime/sitemap.ts
@@ -1,0 +1,77 @@
+import type { MetadataRoute } from "next";
+import { apiGet } from "@/lib/api";
+import { ANIME_SITEMAP_SHARDS, animeSitemapRows } from "@/lib/seo/animeSitemap";
+import type { SitemapAnime } from "@/lib/types";
+
+// The anime catalogue, sharded.
+//
+// This is the half of the sitemap that was missing. /sitemap.xml built its
+// anime rows out of /api/anime/yearly-top, an endpoint that answers "the
+// top-rated titles of one year" and caps itself at 20 — so the site
+// advertised 20 of 17,603 anime to Google and the other 99.9% were
+// reachable only by a crawler guessing ids. The request asked for 100 and
+// the cap clamped it silently, which is why nothing ever looked broken.
+//
+// It lives at /sitemaps/anime/ rather than /anime/ because a route segment
+// at app/anime/ would be a static sibling of app/[lang]/, and static
+// segments win — /anime/{id}, the site's whole SEO surface, would start
+// resolving against a segment with no page to serve it.
+//
+// The proxy leaves these URLs alone: NON_PAGE_PATH in src/proxy.ts skips
+// anything ending in a file extension, so .xml is never rewritten under a
+// locale prefix. That guard exists because rewriting /sitemap.xml to
+// /zh-Hans/sitemap.xml 404s it.
+
+// Revalidate window for the upstream Go API fetch. One hour keeps the
+// sitemap reasonably fresh while letting the route stay cached between
+// crawler hits.
+const REVALIDATE_SECONDS = 3600;
+
+/**
+ * The shard list, from a constant rather than a count query.
+ *
+ * This runs at build time, and a build-time fetch is a build-time failure
+ * mode: a Go API that is unreachable while the image builds — which is the
+ * normal case, the API is not up during `docker build` — would return zero
+ * shards and bake a site with no anime sitemap at all. A constant cannot
+ * fail. The per-shard fetch below still degrades gracefully on its own.
+ */
+export function generateSitemaps(): Array<{ id: number }> {
+  return Array.from({ length: ANIME_SITEMAP_SHARDS }, (_, id) => ({ id }));
+}
+
+export default async function sitemap({
+  id,
+}: {
+  // Next 16 changed this: `id` is a promise resolving to a STRING, where
+  // earlier versions passed the number through directly. The framework's
+  // own example still does arithmetic on it and survives on JS coercion;
+  // parsing is the honest version, and it is what makes the range check
+  // below mean anything.
+  id: Promise<string>;
+}): Promise<MetadataRoute.Sitemap> {
+  const shard = Number(await id);
+
+  // A shard outside the declared set can only come from a hand-typed URL.
+  // Returning empty beats forwarding it: the Go endpoint would answer 400,
+  // the catch below would swallow it, and the difference would show up as
+  // a warning in a log nobody reads.
+  if (!Number.isInteger(shard) || shard < 0 || shard >= ANIME_SITEMAP_SHARDS) {
+    return [];
+  }
+
+  try {
+    const items = await apiGet<SitemapAnime[]>(
+      `/api/anime/sitemap?shards=${ANIME_SITEMAP_SHARDS}&shard=${shard}`,
+      { revalidate: REVALIDATE_SECONDS },
+    );
+    return animeSitemapRows(items);
+  } catch (err) {
+    // Graceful degradation, same contract as the static sitemap: an empty
+    // but well-formed <urlset> is valid per Sitemaps 0.9. A 500 here would
+    // make Googlebot drop the document from its crawl queue entirely,
+    // which costs more than one stale hour.
+    console.warn(`[sitemap] anime shard ${shard} fetch failed:`, err);
+    return [];
+  }
+}

--- a/next-app/src/lib/seo/animeSitemap.test.ts
+++ b/next-app/src/lib/seo/animeSitemap.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ANIME_SITEMAP_SHARDS,
+  animeSitemapPath,
+  animeSitemapRows,
+  animeSitemapUrls,
+} from "./animeSitemap";
+import { LOCALES, localizePath } from "@/lib/i18n/locale";
+import { SITE_ORIGIN } from "@/lib/seo/alternates";
+import type { SitemapAnime } from "@/lib/types";
+
+// Prod at the time of writing: 17,603 anime. Kept as a literal because the
+// point of the shard-count assertion is to fail when the catalogue outgrows
+// the layout, and a value read from the same constant it is checking would
+// never fail.
+const CATALOGUE_SIZE = 17_603;
+const GOOGLE_URLS_PER_SITEMAP = 50_000;
+
+const rows: SitemapAnime[] = [
+  { anilistId: 1474, updatedAt: "2026-08-27T11:29:16.681137Z" },
+  { anilistId: 21, updatedAt: "2026-05-01T00:00:00Z" },
+];
+
+describe("shard layout", () => {
+  test("the whole catalogue fits, in every locale", () => {
+    // The constraint that decides this number: Google caps a sitemap at
+    // 50,000 <url> entries, and the site publishes one URL per anime per
+    // locale. One document would overflow on the anime count alone.
+    const perShard = Math.ceil(CATALOGUE_SIZE / ANIME_SITEMAP_SHARDS) * LOCALES.length;
+    expect(perShard).toBeLessThan(GOOGLE_URLS_PER_SITEMAP);
+  });
+
+  test("paths follow the generateSitemaps convention and stay off /anime/", () => {
+    // Next publishes app/sitemaps/anime/sitemap.ts at <segment>/sitemap/<id>.xml.
+    expect(animeSitemapPath(0)).toBe("/sitemaps/anime/sitemap/0.xml");
+
+    // A segment at app/anime/ would be a static sibling of app/[lang]/, and
+    // static wins — /anime/{id} would resolve against a segment with no page.
+    for (let id = 0; id < ANIME_SITEMAP_SHARDS; id++) {
+      expect(animeSitemapPath(id).startsWith("/anime/")).toBe(false);
+    }
+  });
+
+  test("one absolute url per shard, no duplicates", () => {
+    const urls = animeSitemapUrls();
+    expect(urls).toHaveLength(ANIME_SITEMAP_SHARDS);
+    expect(new Set(urls).size).toBe(urls.length);
+    for (const url of urls) expect(url.startsWith(`${SITE_ORIGIN}/`)).toBe(true);
+  });
+});
+
+describe("row expansion", () => {
+  const expanded = animeSitemapRows(rows);
+
+  test("one url per anime per locale", () => {
+    expect(expanded).toHaveLength(rows.length * LOCALES.length);
+    for (const a of rows) {
+      for (const locale of LOCALES) {
+        expect(expanded.map((r) => r.url)).toContain(
+          `${SITE_ORIGIN}${localizePath(`/anime/${a.anilistId}`, locale)}`,
+        );
+      }
+    }
+  });
+
+  test("lastmod is the row's own updated_at, not the time of the fetch", () => {
+    // The sitemap this replaces stamped `new Date()` on every row, which
+    // claimed the entire catalogue changed on every crawl. Google's
+    // documented response to a lastmod it can disprove is to ignore lastmod
+    // for the whole site — so a regression here silently costs the signal
+    // for the static pages too.
+    for (const row of expanded) {
+      const source = rows.find((a) => row.url.endsWith(`/anime/${a.anilistId}`));
+      expect(source).toBeDefined();
+      expect(new Date(row.lastModified as Date).toISOString()).toBe(
+        new Date(source!.updatedAt).toISOString(),
+      );
+    }
+  });
+
+  test("the language map is reciprocal and self-referential", () => {
+    // Same rule the static sitemap is held to. Two documents now make
+    // hreflang claims about this site; Google drops a reciprocal group when
+    // they disagree, so both have to expand through the same function.
+    for (const row of expanded) {
+      const languages = row.alternates?.languages as Record<string, string>;
+      expect(Object.keys(languages).sort()).toEqual([...LOCALES].sort());
+      expect(Object.values(languages)).toContain(row.url);
+    }
+  });
+
+  test("no url is listed twice", () => {
+    const urls = expanded.map((r) => r.url);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+
+  test("an empty shard produces an empty list, not a broken row", () => {
+    // The fetch path returns [] on API failure, and Sitemaps 0.9 accepts an
+    // empty <urlset>. What it must not do is emit a row with no url.
+    expect(animeSitemapRows([])).toEqual([]);
+  });
+});

--- a/next-app/src/lib/seo/animeSitemap.ts
+++ b/next-app/src/lib/seo/animeSitemap.ts
@@ -1,0 +1,82 @@
+import type { MetadataRoute } from "next";
+import { SITE_ORIGIN as SITE } from "@/lib/seo/alternates";
+import { expandLocales } from "@/lib/seo/sitemapEntry";
+import type { SitemapAnime } from "@/lib/types";
+
+/**
+ * How many files the anime catalogue is split across.
+ *
+ * The site publishes one URL per anime per locale, so the ceiling that
+ * matters is Google's 50,000 `<url>` entries per sitemap, not the anime
+ * count: 17,603 anime × 3 locales is 52,809 URLs and would overflow a
+ * single document by itself.
+ *
+ * Four shards leaves a lot of headroom on purpose — the catalogue can
+ * roughly triple before a fifth is needed — because raising this number is
+ * not free. Shards are `anilist_id % ANIME_SITEMAP_SHARDS`, so changing it
+ * moves most anime into a different file, and a crawler re-reading the set
+ * sees the whole catalogue as churn. Prefer to change it rarely.
+ *
+ * The Go endpoint takes the shard count as a parameter and has no opinion
+ * about it, so this constant is the only place the layout is decided.
+ */
+export const ANIME_SITEMAP_SHARDS = 4;
+
+/**
+ * The path Next publishes shard `id` at.
+ *
+ * Derived from the `generateSitemaps` convention for `app/sitemaps/anime/
+ * sitemap.ts`, which is `<segment>/sitemap/<id>.xml`. It lives here so
+ * robots.txt and the sitemap route cannot disagree — robots.txt naming a
+ * file that does not exist is the failure mode this indirection exists to
+ * prevent, and it is silent: the sitemap still works, Google just never
+ * finds it.
+ *
+ * Note this is NOT under `/anime/`. A route segment at `app/anime/` would
+ * be a static sibling of `app/[lang]/`, and static segments win — which
+ * would put the site's most valuable URLs, `/anime/{id}`, behind a segment
+ * that has no page to serve them.
+ */
+export function animeSitemapPath(id: number): string {
+  return `/sitemaps/anime/sitemap/${id}.xml`;
+}
+
+/**
+ * Every anime sitemap URL, absolute, for the `Sitemap:` lines in robots.txt.
+ *
+ * robots.txt takes any number of Sitemap directives and Google reads all of
+ * them, which is why this set needs no index document — Next's sitemap
+ * convention emits `<urlset>` and cannot emit `<sitemapindex>`, and
+ * hand-rolling one would mean hand-rolling the hreflang XML with it.
+ */
+export function animeSitemapUrls(): string[] {
+  return Array.from(
+    { length: ANIME_SITEMAP_SHARDS },
+    (_, id) => `${SITE}${animeSitemapPath(id)}`,
+  );
+}
+
+/**
+ * API rows to sitemap rows, one per anime per locale.
+ *
+ * Pure, and exported for that reason: the route module around it can only be
+ * tested by mocking `@/lib/api`, and `mock.module` in bun:test is process-
+ * global — a mock installed here would follow into every other test file
+ * sharing the process, which is a failure this repo has already paid for
+ * once. Everything worth asserting about the anime sitemap is in here.
+ */
+export function animeSitemapRows(items: readonly SitemapAnime[]): MetadataRoute.Sitemap {
+  return items.flatMap((a) =>
+    expandLocales({
+      path: `/anime/${a.anilistId}`,
+      // The row's real modification time. The sitemap this replaces sent
+      // `new Date()` for every row on every fetch, which told Google the
+      // whole catalogue had changed one second ago — a claim it can
+      // disprove by crawling, and the documented response to a lastmod it
+      // cannot trust is to stop trusting lastmod for the site.
+      lastModified: new Date(a.updatedAt),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    }),
+  );
+}

--- a/next-app/src/lib/seo/sitemapEntry.ts
+++ b/next-app/src/lib/seo/sitemapEntry.ts
@@ -1,0 +1,60 @@
+import type { MetadataRoute } from "next";
+import { DEFAULT_LOCALE, LOCALES, localizePath, type Locale } from "@/lib/i18n/locale";
+import { SITE_ORIGIN as SITE } from "@/lib/seo/alternates";
+
+/**
+ * A sitemap row before locale expansion: a site-relative path plus the
+ * metadata that is the same in every language.
+ *
+ * The path is relative on purpose. Every URL a crawler reads has to be
+ * absolute and on the canonical origin, and the one place that turns a path
+ * into a URL is expandLocales below — so a caller cannot accidentally emit a
+ * relative or wrong-origin `<loc>`, which makes Google reject the whole
+ * document rather than the one row.
+ */
+export type SitemapEntry = Omit<MetadataRoute.Sitemap[number], "url"> & {
+  path: string;
+};
+
+/**
+ * Pages whose CONTENT exists only in the default locale.
+ *
+ * The legal pages are hardcoded Chinese JSX with no English body. Listing an
+ * /en/ URL for them, or advertising one as an alternate, would tell Google
+ * about an English page that serves Chinese — the exact defect this project
+ * spent a commit removing from eight route files. They ship as a single
+ * default-locale URL with no alternates until someone translates them.
+ */
+const UNTRANSLATED_PATHS = new Set(["/terms", "/privacy", "/copyright"]);
+
+/**
+ * One sitemap row per locale, cross-linked.
+ *
+ * Google reads sitemap `alternates.languages` the same way it reads the
+ * `<link rel="alternate">` tags in the head, reciprocity requirement
+ * included — so every row lists every locale, itself among them. Both
+ * surfaces derive from LOCALES for that reason: a sitemap that disagrees
+ * with the pages it lists is worse than one that says nothing.
+ *
+ * Shared rather than duplicated because the site now publishes more than one
+ * sitemap document. Two copies of this rule is two chances for the anime
+ * sitemap and the static one to make different hreflang claims about the
+ * same site, and Google resolves that disagreement by dropping the group.
+ */
+export function expandLocales(entry: SitemapEntry): MetadataRoute.Sitemap {
+  const { path, ...rest } = entry;
+
+  if (UNTRANSLATED_PATHS.has(path)) {
+    return [{ ...rest, url: `${SITE}${localizePath(path, DEFAULT_LOCALE)}` }];
+  }
+
+  const languages = Object.fromEntries(
+    LOCALES.map((locale) => [locale, `${SITE}${localizePath(path, locale)}`]),
+  );
+
+  return LOCALES.map((locale: Locale) => ({
+    ...rest,
+    url: `${SITE}${localizePath(path, locale)}`,
+    alternates: { languages },
+  }));
+}

--- a/next-app/src/lib/types.ts
+++ b/next-app/src/lib/types.ts
@@ -85,6 +85,18 @@ export interface TrendingItem {
 
 export type YearlyTopItem = Omit<TrendingItem, "rank" | "watcherCount">;
 
+// ─── SitemapShard (/api/anime/sitemap) ─────────────────────────────
+// Deliberately two fields. This endpoint feeds the XML sitemaps, which
+// carry a <loc> and a <lastmod> and nothing else — pulling titles or
+// covers along would be tens of megabytes crossing the wire on every
+// revalidate to be thrown away.
+
+export interface SitemapAnime {
+  anilistId: number;
+  /** RFC 3339. The row's `updated_at`, which becomes `<lastmod>`. */
+  updatedAt: string;
+}
+
 // Re-exported so consumers can `import type { FuzzyDate }` from the
 // same surface as AnimeDetail itself.
 export type { FuzzyDate };


### PR DESCRIPTION
`/sitemap.xml` sourced its anime rows from `/api/anime/yearly-top`, which
returns one year's top-rated titles and caps itself at 20. The sitemap asked
for `limit=100`; `parseLimit` clamped it silently.

The site has been advertising **20 of its 17,603 anime** to Google. The other
99.9% were reachable only by a crawler guessing ids.

Measured on production: `/sitemap.xml` serves 75 URLs, 60 of them `/anime/`
— 20 anime x 3 locales.

Nothing about this failed. The wrong endpoint answered correctly, the
document validated, and no test or log had an opinion, which is why it
survived. No limit would have fixed it either: `/yearly-top` cannot enumerate
a catalogue.

## What changed

`go-api` gains `GET /api/anime/sitemap`, an unfiltered enumeration returning
`{anilistId, updatedAt}`.

Deliberately unfiltered: every row in `anime_cache` renders a 200 at
`/anime/{id}` — the row existing *is* the page existing — so a `WHERE` clause
here would be an editorial judgement about which real pages to hide from
Google. Verified by sampling 12 random ids from production; all 200.

**Sharded by `anilist_id % n`, not LIMIT/OFFSET.** With offsets, one new row
shifts every anime after it into a different file and a crawler re-reading
the set sees the whole tail as churn. Modulo keeps an id in the same file for
life, and the id space is dense enough to stay balanced untuned — measured on
production, 4129 / 4653 / 4061 / 4760 at n=4, summing to 17,603 with no row
lost or duplicated.

Four shards because 17,603 anime x 3 locales is 52,809 URLs and Google caps a
sitemap at 50,000.

## Two constraints that shaped the layout

**The shards live at `/sitemaps/anime/`, not `/anime/`.** A route segment at
`app/anime/` would be a static sibling of `app/[lang]/`, and static segments
win — which would put `/anime/{id}`, the site's entire SEO surface, behind a
segment with no page to serve it.

**`/sitemap.xml` keeps its URL.** Adding `generateSitemaps` to the root
`app/sitemap.ts` would move the whole document to `/sitemap/0.xml` and retire
the one sitemap URL Search Console has on file and robots.txt has always
pointed at. So the static pages stay there and the catalogue is sharded
alongside.

`robots.txt` names every file. There is no index document because Next's
sitemap convention emits `<urlset>` and cannot emit `<sitemapindex>`;
robots.txt accepts any number of `Sitemap:` directives and Google reads all
of them.

## Two details worth naming

**`lastmod` is the row's own `updated_at`.** The previous version stamped
`new Date()` on every row of every fetch, telling Google the entire catalogue
had changed one second ago. Google's documented response to a `lastmod` it
can disprove is to stop trusting `lastmod` for the site — so that claim was
costing the static pages their signal too.

**`app/sitemap.ts` gets an explicit `revalidate`.** Its hourly regeneration
had been an accident of the fetch that just moved out. Without it,
`currentSeasonPath(new Date())` would have frozen at image build time,
reintroducing the exact stale-season bug that function exists to have fixed.

## Testing

- 9 Go handler tests, including the `shards=0` case that would otherwise
  reach Postgres as `id % 0`
- Bad shard coordinates are rejected with 400 rather than clamped, which is
  the opposite of `parseLimit` elsewhere in the package: a clamped `limit`
  returns fewer rows, while a clamped `shard` returns somebody else's rows,
  and duplicate `<loc>` entries across a sitemap set is a defect Google
  attributes to the site instead of reporting back
- `bun test` covers robots discovery, row expansion and hreflang reciprocity
- Sandbox e2e pins the shard URL and checks that every sitemap robots.txt
  advertises actually resolves — the failure mode with no other symptom
- Verified end to end against a real stack: 3 anime produce 9 `<url>` entries
  with reciprocal hreflang and per-row `lastmod`

## After merge

The four shard URLs should be submitted in Search Console. Google discovers
them via robots.txt regardless, but the Sitemaps report only tracks submitted
documents — without it `/sitemap.xml` will appear to drop from 75 URLs to 15
while the other ~52,000 sit in no report at all.