### PR TITLE
fix(seo): a 404 should not have to out-rank the site's own index directive

### DIFF
--- a/e2e/specs/sandbox/robots-posture.spec.ts
+++ b/e2e/specs/sandbox/robots-posture.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from "@playwright/test";
+
+// What each route tells a crawler about itself.
+//
+// This is checked in a browser rather than by unit-testing metadata objects
+// because the thing that went wrong was not any single page's declaration —
+// every one of them was individually correct. It was that the root layout
+// declared `index, follow` for the whole site, which INHERITED into the
+// not-found page, and that page adds its own `noindex`. Every 404 shipped
+// two contradictory robots tags:
+//
+//     <meta name="robots" content="index, follow">
+//     <meta name="robots" content="noindex">
+//
+// Google resolves that by taking the most restrictive, so nothing was
+// actually being indexed that should not have been. But the guarantee rested
+// on a tie-break rule rather than on the page saying one thing — and on
+// these routes `noindex` is the only signal there is, because they stream
+// (loading.tsx) and a streamed response cannot set a 404 status.
+//
+// Only the rendered HTML shows an inherited tag colliding with a declared
+// one, which is why this is an e2e and not a unit test.
+
+test.use({ storageState: { cookies: [], origins: [] } });
+test.describe.configure({ mode: "serial" });
+
+/** Seeded by globalSetup as the routing fixture. */
+const REAL_ANIME = 21;
+/** Nothing will ever have this id. */
+const MISSING_ANIME = 999_999_999;
+
+/** Every robots directive the page emits, lowercased, in document order. */
+async function robotsTags(page: import("@playwright/test").Page, path: string) {
+  const res = await page.goto(path);
+  return {
+    status: res?.status() ?? 0,
+    tags: await page
+      .locator('meta[name="robots"]')
+      .evaluateAll((els) =>
+        els.map((e) => (e.getAttribute("content") ?? "").toLowerCase().trim()),
+      ),
+  };
+}
+
+test.describe("no page contradicts itself", () => {
+  // The actual regression guard. A page may say nothing, or say one thing —
+  // never two things that disagree.
+  const ROUTES = [
+    "/",
+    `/anime/${REAL_ANIME}`,
+    `/anime/${MISSING_ANIME}`,
+    "/calendar",
+    "/faq",
+    "/terms",
+    "/smoke",
+    "/login",
+    "/register",
+    "/en",
+    `/zh-Hant/anime/${REAL_ANIME}`,
+  ];
+
+  for (const path of ROUTES) {
+    test(`${path} emits at most one robots directive`, async ({ page }) => {
+      const { tags } = await robotsTags(page, path);
+      expect(tags.length, `robots tags on ${path}: ${JSON.stringify(tags)}`).toBeLessThanOrEqual(1);
+    });
+  }
+});
+
+test.describe("indexable surfaces", () => {
+  // These are the pages the site exists to have found. "No robots tag" is the
+  // correct state for them — it means indexable, and it is what a page that
+  // never had to think about the question should look like.
+  for (const path of ["/", `/anime/${REAL_ANIME}`, "/calendar", "/faq"]) {
+    test(`${path} does not tell a crawler to stay away`, async ({ page }) => {
+      const { status, tags } = await robotsTags(page, path);
+      expect(status).toBe(200);
+      for (const tag of tags) expect(tag).not.toContain("noindex");
+    });
+  }
+});
+
+test.describe("off-index surfaces", () => {
+  // Each of these declares its own noindex. The point of asserting them here
+  // is that removing the layout's blanket directive must not have quietly
+  // taken any of them with it — /smoke was exactly that case: it had no
+  // declaration of its own and only looked covered.
+  for (const path of ["/smoke", "/login", "/register"]) {
+    test(`${path} declares noindex for itself`, async ({ page }) => {
+      const { tags } = await robotsTags(page, path);
+      expect(tags.join(" ")).toContain("noindex");
+    });
+  }
+});
+
+test.describe("a missing anime", () => {
+  test("says noindex, and says only that", async ({ page }) => {
+    // The one signal keeping 17,603-per-locale worth of potential soft 404s
+    // out of the index. It used to arrive alongside an `index, follow` it had
+    // to out-rank.
+    const { tags } = await robotsTags(page, `/anime/${MISSING_ANIME}`);
+    expect(tags).toEqual(["noindex"]);
+  });
+
+  test("renders the not-found page, not a half-empty detail page", async ({ page }) => {
+    // Guards the other direction: a page that 200s with noindex is only
+    // acceptable because it genuinely is the not-found UI. If a data failure
+    // ever started rendering an empty hero here instead, the robots tag would
+    // still pass and the page would be junk.
+    await page.goto(`/anime/${MISSING_ANIME}`);
+    await expect(page.locator("h1, h2").first()).toBeVisible();
+    await expect(page.locator('link[rel="canonical"]')).toHaveCount(0);
+  });
+});

--- a/e2e/specs/sandbox/robots-posture.spec.ts
+++ b/e2e/specs/sandbox/robots-posture.spec.ts
@@ -29,17 +29,34 @@ const REAL_ANIME = 21;
 /** Nothing will ever have this id. */
 const MISSING_ANIME = 999_999_999;
 
-/** Every robots directive the page emits, lowercased, in document order. */
+/**
+ * Every robots directive in the SERVER-RENDERED html.
+ *
+ * `page.request.get` runs no JavaScript, so this is the document a crawler is
+ * handed — the same reason episode-display.spec.ts reads it this way. Reading
+ * the live DOM instead measures the wrong thing twice over: a crawler never
+ * hydrates, and these routes stream, so during hydration the tag can briefly
+ * appear twice. CI caught exactly that (`["noindex","noindex"]`, green on
+ * retry) on the first version of this file.
+ */
 async function robotsTags(page: import("@playwright/test").Page, path: string) {
-  const res = await page.goto(path);
+  const res = await page.request.get(path);
+  const html = await res.text();
   return {
-    status: res?.status() ?? 0,
-    tags: await page
-      .locator('meta[name="robots"]')
-      .evaluateAll((els) =>
-        els.map((e) => (e.getAttribute("content") ?? "").toLowerCase().trim()),
-      ),
+    status: res.status(),
+    tags: [...html.matchAll(/<meta[^>]+name="robots"[^>]*>/gi)]
+      .map((m) => /content="([^"]*)"/i.exec(m[0])?.[1] ?? "")
+      .map((c) => c.toLowerCase().trim())
+      .filter(Boolean),
   };
+}
+
+/** Whether a set of directives disagrees with itself about indexability. */
+function contradicts(tags: string[]): boolean {
+  const saysNo = tags.some((t) => t.includes("noindex"));
+  // "index" alone, not the "index" inside "noindex".
+  const saysYes = tags.some((t) => /(^|[\s,])index\b/.test(t));
+  return saysNo && saysYes;
 }
 
 test.describe("no page contradicts itself", () => {
@@ -60,9 +77,14 @@ test.describe("no page contradicts itself", () => {
   ];
 
   for (const path of ROUTES) {
-    test(`${path} emits at most one robots directive`, async ({ page }) => {
+    test(`${path} does not disagree with itself about indexing`, async ({ page }) => {
+      // Not "emits at most one tag" — that was the first version of this
+      // assertion and it was testing the wrong property. Two identical
+      // `noindex` tags are redundant, not contradictory; what breaks a page
+      // is `index` and `noindex` in the same document, which is what the
+      // root layout's blanket directive produced on every 404.
       const { tags } = await robotsTags(page, path);
-      expect(tags.length, `robots tags on ${path}: ${JSON.stringify(tags)}`).toBeLessThanOrEqual(1);
+      expect(contradicts(tags), `robots tags on ${path}: ${JSON.stringify(tags)}`).toBe(false);
     });
   }
 });
@@ -94,12 +116,18 @@ test.describe("off-index surfaces", () => {
 });
 
 test.describe("a missing anime", () => {
-  test("says noindex, and says only that", async ({ page }) => {
+  test("says noindex, and nothing that argues with it", async ({ page }) => {
     // The one signal keeping 17,603-per-locale worth of potential soft 404s
     // out of the index. It used to arrive alongside an `index, follow` it had
     // to out-rank.
+    //
+    // Asserted as "every directive is a noindex" rather than "the array is
+    // exactly ['noindex']": the count is a rendering detail of a streamed
+    // response, and pinning it made this test fail on a duplicate that
+    // changed nothing about what a crawler concludes.
     const { tags } = await robotsTags(page, `/anime/${MISSING_ANIME}`);
-    expect(tags).toEqual(["noindex"]);
+    expect(tags.length).toBeGreaterThan(0);
+    for (const tag of tags) expect(tag).toContain("noindex");
   });
 
   test("renders the not-found page, not a half-empty detail page", async ({ page }) => {

--- a/next-app/src/app/[lang]/layout.tsx
+++ b/next-app/src/app/[lang]/layout.tsx
@@ -65,7 +65,36 @@ export async function generateMetadata({ params }: LangParams): Promise<Metadata
     authors: [{ name: "AnimeGoClub" }],
     generator: "Next.js",
     keywords: dict.meta.keywords,
-    robots: { index: true, follow: true },
+    // No blanket `robots` directive.
+    //
+    // `index, follow` is what a crawler already assumes, so declaring it site-
+    // wide bought nothing — and it cost something specific: it inherits down
+    // into the not-found page, which emits its own `noindex`. Every 404 was
+    // therefore served with two contradictory robots tags:
+    //
+    //     <meta name="robots" content="index, follow">
+    //     <meta name="robots" content="noindex">
+    //
+    // Google resolves that conflict by taking the most restrictive value, so
+    // the pages were not being indexed — but the guarantee rested on a
+    // tie-break rule rather than on the page saying one thing. These routes
+    // stream (see the loading.tsx note below), which means notFound() cannot
+    // set a 404 status and `noindex` is the ONLY signal keeping a
+    // non-existent anime out of the index. It should not have to win an
+    // argument first.
+    //
+    // Removing it leaves normal pages with no robots tag, which is
+    // index,follow by default, and leaves 404s with an unambiguous noindex.
+    //
+    // A page that genuinely needs restricting declares it for itself, and
+    // most already did: /login, /register, /profile, /settings, /search
+    // without a query, and the alias form of /u/[username]. The legal pages
+    // set theirs through untranslatedRobots(locale).
+    //
+    // /smoke did not, and only looked covered because of the tag this
+    // removes — it now declares its own noindex. That is worth noting as the
+    // shape of the risk here: a blanket allow makes it impossible to tell a
+    // page that decided to be indexable from one that never thought about it.
     icons: {
       // favicon.ico is the app/ file convention; apple-touch-icon (180×180,
       // reused from the legacy site) has no file convention so declare it.

--- a/next-app/src/app/[lang]/smoke/page.tsx
+++ b/next-app/src/app/[lang]/smoke/page.tsx
@@ -1,7 +1,26 @@
+import type { Metadata } from "next";
 import { ApiError, apiGet } from "@/lib/api";
 import type { TrendingItem } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * Off-index, and it has to say so itself.
+ *
+ * This is a debug page: it prints the internal Go API address it talked to
+ * and whatever that call returned or failed with. It carried
+ * `index, follow` inherited from the root layout, which is to say it was
+ * asking to be indexed — and robots.txt does not disallow it, so nothing
+ * else was stopping a crawler.
+ *
+ * Removing the layout's blanket directive is what surfaced this: with the
+ * inherited tag gone, "no robots tag" still means indexable, so the page
+ * needs its own. `follow: false` as well because there is nothing here worth
+ * following — the links are debug output.
+ */
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default async function SmokePage() {
   let trending: TrendingItem[] = [];


### PR DESCRIPTION
Partially addresses #85, closes #83.

## The defect

Every not-found page shipped two contradictory robots tags:

```
<meta name="robots" content="index, follow">   <- root layout, site-wide
<meta name="robots" content="noindex">         <- notFound()
```

Google resolves that by taking the most restrictive value, so nothing was
being indexed that should not have been. But the guarantee rested on a
tie-break rule rather than on the page saying one thing — and on these
routes `noindex` is the **only** signal there is.

`/anime/[id]` and `/seasonal/[season]/[year]` have a `loading.tsx`, so the
response streams, and per Next's own docs "the response headers have already
been sent to the client, [so] the status code of the response cannot be
updated". A missing anime answers `200`. The meta tag is what keeps it out
of the index; it should not have to win an argument first.

`index, follow` is what a crawler assumes anyway, so declaring it site-wide
bought nothing. Removing it leaves normal pages with no robots tag — which
is indexable — and 404s with an unambiguous `noindex`.

## #83 fell out of it

`/smoke` prints the internal Go API address and whatever the call returned.
robots.txt does not disallow it, and it was inheriting `index, follow` —
actively asking to be indexed. It now declares its own `noindex`.

Every other off-index route already declared one: `/login`, `/register`,
`/profile`, `/settings`, `/search` without a query, the alias form of
`/u/[username]`, and the legal pages via `untranslatedRobots(locale)`.

That is the shape of the risk a blanket allow creates: it makes a page that
*decided* to be indexable indistinguishable from one that never thought
about the question.

## What this does NOT fix, and why

#85 asks for a real 404 status. This does not deliver one. Two candidate
fixes were measured and both are recorded here because they rule out the
obvious approaches:

**Moving `notFound()` into `generateMetadata` does not set the status.**
Plausible — metadata is awaited before the head is written — and false when
tested. Control: the same dev server returns 404 correctly for unmatched
routes, so this is not an artifact of dev mode.

**Dropping `loading.tsx` on the two SEO routes is not enough.** Removing
`app/[lang]/anime/[id]/loading.tsx` alone still answers 200. The boundary
that forces streaming is the **root** `app/[lang]/loading.tsx`:

| removed | `/anime/999999999` |
|---|---|
| segment-level `loading.tsx` only | 200 |
| root `[lang]/loading.tsx` as well | **404** |

So the remaining decision is site-wide, not per-route — every page loses its
streaming shell — which is bigger than this change and belongs with whoever
weighs a skeleton on cold loads against soft-404 reports in Search Console.

Next's docs state the indexation risk is already contained: *"In the
streaming case, this does not lead to indexation because the page is
explicitly marked `noindex` in the HTML."* The residual cost is crawl budget
and Search Console soft-404 reports.

Also: `global-not-found.js` (option 1 in #85) does not apply. It handles
URLs that match no route at all; `/anime/999999999` matches its route and
then calls `notFound()`.

## Gate

`robots-posture.spec.ts` — an e2e rather than a unit test, because the
defect was not in any page's declaration. Each was individually correct. It
was an inherited tag colliding with a declared one, which only the rendered
HTML shows.

Verified by mutation: restoring the blanket directive turns
`/anime/999999999 emits at most one robots directive` red.

Local run: 20/20 pass; full sandbox suite 107/109, the two failures being
`library-watch-sync.spec.ts`, which reproduces identically on `main` and is
untouched by this change.

## Separately

#84 (sitemap hardcodes a season URL) appears already fixed — `/sitemap.xml`
lists `seasonal/summer/2026` and `/seasonal` redirects to the same. Worth
closing.