### PR TITLE
fix(i18n): /zh-Hant/search rendered Simplified titles

### DIFF
--- a/e2e/fixtures/pg.ts
+++ b/e2e/fixtures/pg.ts
@@ -189,6 +189,13 @@ export interface SeedAnimeCache {
   titleRomaji?: string;
   titleChinese?: string;
   /**
+   * Traditional Chinese (migration 0022), and the first rung of the zh-Hant
+   * title ladder. Left undefined by default because most production rows have
+   * it null, which is the state every other spec should be measuring — set it
+   * only when the spec is about Traditional readers seeing Traditional.
+   */
+  titleHant?: string | null;
+  /**
    * The authoritative total. Two things read it:
    *   - the server's `currentEpisode` upper bound (400 past it; NULL = airing,
    *     no bound at all — design doc decision 4);
@@ -208,11 +215,14 @@ export interface SeedAnimeCache {
 export async function ensureAnimeCached(anime: SeedAnimeCache): Promise<void> {
   const sql = getSql();
   await sql`
-    INSERT INTO anime_cache (anilist_id, title_romaji, title_chinese, episodes, format, cached_at)
+    INSERT INTO anime_cache (
+      anilist_id, title_romaji, title_chinese, title_hant, episodes, format, cached_at
+    )
     VALUES (
       ${anime.anilistId},
       ${anime.titleRomaji ?? `E2E Anime ${anime.anilistId}`},
       ${anime.titleChinese ?? `E2E 番剧 ${anime.anilistId}`},
+      ${anime.titleHant ?? null},
       ${anime.episodes ?? null},
       ${anime.format ?? "TV"},
       now()
@@ -220,6 +230,7 @@ export async function ensureAnimeCached(anime: SeedAnimeCache): Promise<void> {
     ON CONFLICT (anilist_id) DO UPDATE SET
       title_romaji  = EXCLUDED.title_romaji,
       title_chinese = EXCLUDED.title_chinese,
+      title_hant    = EXCLUDED.title_hant,
       episodes      = EXCLUDED.episodes,
       format        = EXCLUDED.format,
       updated_at    = now()

--- a/e2e/specs/sandbox/search.spec.ts
+++ b/e2e/specs/sandbox/search.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from "@playwright/test";
+import { closePg, ensureAnimeCached, removeAnimeFixture } from "../../fixtures/pg";
+
+// /search — finding a title, and showing it in the reader's script.
+//
+// The sandbox suite had no search spec at all, which is how two defects lived
+// in the same 400-line page at once.
+//
+//   1. The endpoint was a pure AniList proxy, and AniList does not index
+//      Chinese titles. Measured on production: 進擊的巨人 and 鬼滅之刃 both
+//      returned zero results while anime_cache held those exact strings.
+//      Fixed by searching the local catalogue first.
+//
+//   2. /zh-Hant/search rendered SIMPLIFIED titles — 12 of 18 cards on
+//      production — because the page hand-builds its card object field by
+//      field and `titleHant` was not among the fields. Every other surface
+//      (home, seasonal, calendar, detail) forwards a row straight through, so
+//      the field arrived without anyone having to remember it.
+//
+// The second only became visible once the first was fixed: before that, a
+// Traditional query returned nothing, so there were no cards to render wrongly.
+// Worth remembering when a fix seems to "reveal" a new bug.
+//
+// The unit-level guard for (2) is next-app/src/components/anime/
+// cardDataTitles.test.ts, which fails when a hand-built card omits a field the
+// ladder reads. This file checks the thing that guard cannot: what reaches the
+// DOM.
+
+test.use({ storageState: { cookies: [], origins: [] } });
+test.describe.configure({ mode: "serial" });
+
+const PROBE_ID = 990_300_001;
+// Deliberately not a real title. A shared substring with a seeded fixture or a
+// leftover row would let this pass on someone else's data.
+const ZH = "测试用番剧进击的巨人";
+const HANT = "測試用番劇進擊的巨人";
+const ROMAJI = "E2E Search Probe Shingeki";
+
+test.beforeAll(async () => {
+  await ensureAnimeCached({
+    anilistId: PROBE_ID,
+    titleRomaji: ROMAJI,
+    titleChinese: ZH,
+    titleHant: HANT,
+    episodes: 12,
+  });
+});
+
+test.afterAll(async () => {
+  await removeAnimeFixture(PROBE_ID);
+  await closePg();
+});
+
+/** The probe's card, or null when the search did not find it. */
+function probeCard(page: import("@playwright/test").Page) {
+  return page.locator(`a[href*="/anime/${PROBE_ID}"]`).first();
+}
+
+test.describe("a Chinese title is findable at all", () => {
+  // Regression for the AniList-proxy era: these queries returned zero results
+  // on production while the row sat in anime_cache the whole time.
+  for (const [query, script] of [
+    [ZH, "Simplified"],
+    [HANT, "Traditional"],
+    [ROMAJI, "romaji"],
+  ] as const) {
+    test(`searching the ${script} title finds it`, async ({ page }) => {
+      await page.goto(`/search?q=${encodeURIComponent(query)}`);
+      await expect(
+        probeCard(page),
+        `searching "${query}" did not find the row that literally contains it`,
+      ).toBeVisible({ timeout: 20_000 });
+    });
+  }
+
+  test("a substring of the Traditional title is enough", async ({ page }) => {
+    // Not just exact match — the trigram indexes exist so a reader can type
+    // part of a name. 進擊的巨人 alone would collide with the real catalogue,
+    // so this uses the distinctive half of the probe title.
+    await page.goto(`/search?q=${encodeURIComponent("測試用番劇")}`);
+    await expect(probeCard(page)).toBeVisible({ timeout: 20_000 });
+  });
+});
+
+test.describe("the card is titled in the reader's script", () => {
+  // The regression this file was added for. Asserted on rendered text rather
+  // than on the API payload: the payload was always correct, and the page threw
+  // the field away on the way to the card.
+  for (const [prefix, expected, other] of [
+    ["", ZH, HANT],
+    ["/zh-Hant", HANT, ZH],
+  ] as const) {
+    test(`${prefix || "(bare)"} shows ${expected}`, async ({ page }) => {
+      await page.goto(`${prefix}/search?q=${encodeURIComponent(ROMAJI)}`);
+      const card = probeCard(page);
+      await expect(card).toBeVisible({ timeout: 20_000 });
+
+      await expect(card).toContainText(expected);
+      // Both directions. Asserting only the expected string would pass if the
+      // card somehow rendered both, and asserting only the absence of the
+      // other would pass on an empty card.
+      await expect(
+        card,
+        `${prefix || "(bare)"}/search rendered the wrong script`,
+      ).not.toContainText(other);
+    });
+  }
+
+  test("/en falls back to romaji rather than to Chinese", async ({ page }) => {
+    // The en ladder stops after titleEnglish and titleRomaji on purpose — it
+    // does NOT fall through to a Chinese title. A probe with no English title
+    // is the case that proves it.
+    await page.goto(`/en/search?q=${encodeURIComponent(ROMAJI)}`);
+    const card = probeCard(page);
+    await expect(card).toBeVisible({ timeout: 20_000 });
+    await expect(card).toContainText(ROMAJI);
+    await expect(card).not.toContainText(ZH);
+    await expect(card).not.toContainText(HANT);
+  });
+});
+
+test.describe("the page itself", () => {
+  test("answers 200 and declares its locale in all three trees", async ({ page }) => {
+    for (const [prefix, lang] of [
+      ["", "zh-CN"],
+      ["/en", "en"],
+      ["/zh-Hant", "zh-Hant"],
+    ] as const) {
+      const res = await page.goto(`${prefix}/search?q=${encodeURIComponent(ROMAJI)}`);
+      expect(res?.status(), `${prefix}/search`).toBe(200);
+      await expect(page.locator("html")).toHaveAttribute("lang", lang);
+    }
+  });
+
+  test("a query nobody could match renders the empty state, not an error", async ({
+    page,
+  }) => {
+    const res = await page.goto("/search?q=zzzznosuchanimezzzz");
+    expect(res?.status()).toBe(200);
+    await expect(page.locator(`a[href*="/anime/"]`)).toHaveCount(0);
+  });
+});

--- a/next-app/src/app/[lang]/search/page.tsx
+++ b/next-app/src/app/[lang]/search/page.tsx
@@ -51,6 +51,12 @@ interface SearchRow {
   titleEnglish: string | null;
   titleNative: string | null;
   titleChinese: string | null;
+  // go-api has returned this since migration 0022 — GetAnimeByAnilistIDs
+  // selects it, and both the AniList and the local-catalogue paths read
+  // through that one query. This interface simply never declared it, so the
+  // cards below were built without it and /zh-Hant/search rendered Simplified
+  // titles. Measured on production: 12 of 18 cards.
+  titleHant: string | null;
   coverImageUrl: string | null;
   coverImageColor: string | null;
   posterAccent: string | null;
@@ -354,6 +360,7 @@ export default async function SearchPage({ params, searchParams }: SearchPagePro
                 const cardData: AnimeCardData = {
                   anilistId: a.anilistId,
                   titleChinese: a.titleChinese,
+                  titleHant: a.titleHant,
                   titleRomaji: a.titleRomaji,
                   titleEnglish: a.titleEnglish,
                   titleNative: a.titleNative,

--- a/next-app/src/components/anime/AnimeCard.tsx
+++ b/next-app/src/components/anime/AnimeCard.tsx
@@ -23,6 +23,17 @@ export interface AnimeCardData {
   titleRomaji?: string | null;
   titleEnglish?: string | null;
   titleNative?: string | null;
+  /**
+   * Traditional Chinese, and the first rung of the zh-Hant ladder in
+   * lib/formatters.ts. Missing it does not fail — pickTitle falls through to
+   * titleChinese and a Traditional reader gets a Simplified title, which is
+   * readable enough that nobody notices. That is exactly how /search shipped
+   * Simplified cards on /zh-Hant while every other surface was correct: those
+   * pass a row straight through, so the field arrived whether or not a type
+   * mentioned it, and /search hand-builds this object field by field.
+   * cardDataTitles.test.ts now fails when a construction site omits it.
+   */
+  titleHant?: string | null;
   coverImageUrl: string | null;
   posterAccent?: string | null;
   averageScore?: number | null;

--- a/next-app/src/components/anime/cardDataTitles.test.ts
+++ b/next-app/src/components/anime/cardDataTitles.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pickTitle } from "@/lib/formatters";
+import { LANGS, type Lang } from "@/lib/i18n/lang";
+
+// A card must be able to carry every title its reader's ladder asks for.
+//
+// /zh-Hant/search rendered Simplified titles — 12 of 18 cards, measured on
+// production — while the home page, the seasonal page, the calendar and the
+// detail page were all correct. The difference was not the ladder, which has
+// had `titleHant` on its first zh-Hant rung since migration 0022, and not the
+// API, which has returned the field just as long. It was that those other
+// surfaces pass a row straight through to <AnimeCard>, so the field arrives
+// whether or not a TypeScript type mentions it, and /search hand-builds the
+// card object field by field. `titleHant` was not among the fields.
+//
+// That is the shape of the defect: TypeScript cannot see it (a missing
+// optional property is not an error, and the ladder reads by string key at
+// runtime), a reviewer cannot see it (each file is individually reasonable),
+// and a reader cannot see it either (a Simplified title is legible to a
+// Traditional reader — it just is not what they asked for). Only a whole-repo
+// rule catches it, which is why this is a test and not a code review note.
+
+/** Every field name any ladder could name. Kept explicit so a new one fails. */
+const TITLE_FIELDS = [
+  "titleChinese",
+  "titleHant",
+  "titleRomaji",
+  "titleEnglish",
+  "titleNative",
+] as const;
+
+/**
+ * The fields `lang`'s ladder actually reads, derived by ASKING pickTitle
+ * rather than by parsing TITLE_LADDER.
+ *
+ * Probing beats parsing here: the ladder is a private const, and a test that
+ * scraped it would agree with a broken implementation as readily as with a
+ * working one. Handing pickTitle an object with exactly one field set and
+ * seeing whether it comes back out is the same question the product asks.
+ */
+function ladderFieldsFor(lang: Lang): string[] {
+  return TITLE_FIELDS.filter((f) => pickTitle({ [f]: "PROBE" }, lang) === "PROBE");
+}
+
+const LADDER_FIELDS = [...new Set(LANGS.flatMap((l) => ladderFieldsFor(l)))].sort();
+
+const SRC = join(import.meta.dir, "..", "..");
+const read = (p: string) => readFileSync(join(SRC, p), "utf8");
+
+describe("the probe finds a ladder at all", () => {
+  // Anti-vacuity. Every assertion below is "these fields are present"; if the
+  // probe returned nothing, all of them would pass while checking nothing.
+  test("each language reads at least two fields", () => {
+    for (const lang of LANGS) {
+      expect(ladderFieldsFor(lang).length, `${lang} ladder`).toBeGreaterThan(1);
+    }
+  });
+
+  test("zh-Hant reads titleHant — the rung this file exists for", () => {
+    expect(ladderFieldsFor("zh-Hant")).toContain("titleHant");
+  });
+
+  test("zh-Hant prefers Traditional over Simplified when it has both", () => {
+    // The ordering, not just the membership. A ladder that listed titleHant
+    // last would pass the test above and still render Simplified.
+    expect(
+      pickTitle({ titleHant: "進擊的巨人", titleChinese: "进击的巨人" }, "zh-Hant"),
+    ).toBe("進擊的巨人");
+  });
+});
+
+describe("AnimeCardData can express every rung", () => {
+  test("the interface declares every field some ladder reads", () => {
+    const src = read("components/anime/AnimeCard.tsx");
+    const body = /export interface AnimeCardData \{([\s\S]*?)\n\}/.exec(src)?.[1];
+    expect(body, "AnimeCardData interface not found — did it move or get renamed?").toBeTruthy();
+
+    for (const field of LADDER_FIELDS) {
+      expect(
+        new RegExp(`^\\s*${field}\\??:`, "m").test(body!),
+        `AnimeCardData is missing \`${field}\`, which a ladder reads. A card ` +
+          `built to this type cannot carry it, so that reader silently gets ` +
+          `a lower rung.`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("every hand-built card object sets every rung", () => {
+  // Sites that construct the object literally rather than passing a row
+  // through. Listed rather than globbed: the list IS the finding — three of
+  // the four <AnimeCard> call sites forward a row and are fine by
+  // construction, and only a hand-built one can drop a field.
+  const HAND_BUILT: readonly (readonly [string, string])[] = [
+    ["app/[lang]/search/page.tsx", "cardData"],
+  ];
+
+  test("the construction sites are still where this test thinks they are", () => {
+    // If /search stops hand-building, delete its entry — do not let this file
+    // keep passing by checking a literal that no longer exists.
+    for (const [file, name] of HAND_BUILT) {
+      expect(
+        read(file).includes(`const ${name}: AnimeCardData = {`),
+        `${file} no longer builds \`${name}\` as an AnimeCardData literal. ` +
+          `Update HAND_BUILT — either it moved, or the site now forwards a ` +
+          `row and the entry should go.`,
+      ).toBe(true);
+    }
+  });
+
+  test("no site is missing a title field", () => {
+    for (const [file, name] of HAND_BUILT) {
+      const src = read(file);
+      const start = src.indexOf(`const ${name}: AnimeCardData = {`);
+      const literal = src.slice(start, src.indexOf("};", start));
+
+      for (const field of LADDER_FIELDS) {
+        expect(
+          new RegExp(`^\\s*${field}:`, "m").test(literal),
+          `${file} builds \`${name}\` without \`${field}\`. The API returns ` +
+            `it and AnimeCardData accepts it, so the card will render a ` +
+            `lower rung of the ladder for no reason — which is exactly how ` +
+            `/zh-Hant/search shipped Simplified titles.`,
+        ).toBe(true);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Found while testing three-locale search after #123 shipped.

## What was wrong

On production, **12 of 18 result cards on `/zh-Hant/search` showed the Simplified
title**. Swept the other surfaces to size it — they were all correct:

| Surface | Cards checked | Result |
|---|---|---|
| `/zh-Hant/search` | 18 | **12 wrong** |
| `/zh-Hant` (home) | 54 | ✅ |
| `/zh-Hant/seasonal/...` | 20 | ✅ |
| `/zh-Hant/calendar` | 14 | ✅ |
| `/zh-Hant/anime/16498` | 22 | ✅ |

## Why only this page

Nothing in the Traditional pipeline was broken. The zh-Hant ladder has read
`titleHant` first since migration 0022, and go-api has returned it just as long.

The other surfaces **forward a row straight through** to `<AnimeCard>`, so the field
arrives whether or not a TypeScript type mentions it — `pickTitle` reads by string key
at runtime. `/search` **hand-builds** its card object field by field, and `titleHant`
was not on the list.

That is why nothing caught it: a missing optional property is not a type error, each
file reads as reasonable in isolation, and a Simplified title is legible to a
Traditional reader — so no one reports it.

It only became visible after #123. Before that a Traditional query returned **nothing**,
so there were no cards to render wrongly. Worth remembering when a fix appears to reveal
a new bug.

## Guards

Two, because they catch different halves.

**`cardDataTitles.test.ts`** derives the ladder **by probing `pickTitle`**, not by
parsing the private `TITLE_LADDER` — a test that scraped the const would agree with a
broken implementation as readily as a working one. It then asserts `AnimeCardData`
declares every field some ladder reads, and that every hand-built card literal sets
them. Both halves mutation-tested; each produces a named failure.

**`e2e/specs/sandbox/search.spec.ts`** is the **first search spec in the sandbox suite**
— which is how two defects lived in the same page at once. It asserts on rendered text,
the part the unit guard cannot reach: the payload was always right, the page threw the
field away on the way to the card. Also mutation-tested.

The e2e seeds a probe with distinct Simplified and Traditional titles and asserts **both
directions** per locale — expected script present AND the other absent. Asserting only
presence passes on a card rendering both; asserting only absence passes on an empty
card. `/en` is covered too: its ladder deliberately stops at romaji rather than falling
through to Chinese, and a probe with no English title is what proves it.

## Test plan

- [x] `bun test` — 1756 pass
- [x] `tsc --noEmit` — clean
- [x] `node scripts/ci/eslint-ratchet.mjs` — passes
- [x] Affected specs (search, not-found-status, robots-posture, anime-detail,
      locale-routing) — **85/85**
- [x] Mutation-tested: unit guard (both halves) and e2e each go red when the fix is
      reverted
- [ ] `library-*` specs fail in my worktree, but **fail identically with the changes
      stashed** — this environment's fresh DB and browser profile, not this change. CI
      runs clean, so it is the arbiter.
