### PR TITLE
fix(player): Chrome greys the picture, and nothing in JS could see it

### DIFF
--- a/next-app/src/app/[lang]/player/_components/VideoPlayer.tsx
+++ b/next-app/src/app/[lang]/player/_components/VideoPlayer.tsx
@@ -49,6 +49,55 @@ const PLAYBACK_RATE_KEY = "animego:playbackRate";
 const DANMAKU_VISIBLE_DEFAULT = true;
 const DANMAKU_VISIBLE_KEY = "animego:danmakuVisible";
 
+// ─── Video transfer correction ────────────────────────────────────────────
+//
+// Chrome composites <video> — and only <video> — through a transfer-function
+// conversion that lifts the midtones. The picture arrives correct: reading the
+// decoded frame back through `canvas.drawImage(video)` matches ffmpeg. It is
+// the compositing step that shifts it, which is why this went unnoticed for so
+// long — every way of inspecting the pixels from JS says they are fine.
+//
+// Measured against ffmpeg's decode with a 16-step greyscale wedge, on a file
+// carrying no colour signalling at all (no `colr` atom, VUI unspecified —
+// the normal shape of a Baha / ANi WEB-DL):
+//
+//     source   ffmpeg   Chrome        source   ffmpeg   Chrome
+//        0        0        0            136      136      147
+//       17       17       16            170      170      179
+//       51       51       58            204      203      210
+//      102      102      114            255      255      255
+//
+// Black and white are pinned, everything between is pushed up by as much as
+// +12. That is exactly what "washed out / grey next to mpv" is: the ends are
+// nailed down and the middle is flattened. mpv, IINA and VLC do not apply the
+// conversion, so the same file looks more contrasty and more saturated there.
+//
+// TABLE, NOT GAMMA, AND MEASURED, NOT DERIVED. The analytic BT.709 → sRGB
+// model predicts a large lift in the shadows that Chrome does not actually
+// apply (it predicts 17 → 32; Chrome leaves it at 16). Fitting a single
+// `type="gamma"` exponent to the midtones therefore over-darkens the bottom
+// end — exponent 1.136 is the best power fit and it still crushed code 17
+// down to 10. The table below is the inverse of the *measured* curve; put
+// back through Chrome it returns the wedge to a mean absolute error of 0.31
+// levels (vs 7.0 uncorrected, 1.44 for the best gamma) with the shadow step
+// intact.
+//
+// `color-interpolation-filters="sRGB"` is load-bearing. The SVG default is
+// linearRGB, which would apply the table in the wrong space and produce a
+// different picture again.
+//
+// Scoped deliberately to the <video> element. The jassub subtitle canvas and
+// the danmaku layer are drawn by us in sRGB and never went through Chrome's
+// video path, so correcting them would introduce the very error this removes.
+//
+// Chrome-only by decision: Safari and Firefox handle the video transfer
+// differently and were not measured, so this is not feature-detected. If the
+// correction ever needs to be conditional, that is the assumption to revisit.
+const VIDEO_TRANSFER_FILTER_ID = "animego-video-transfer";
+const VIDEO_TRANSFER_TABLE =
+  "0.0000 0.0664 0.1119 0.1640 0.2190 0.2727 0.3319 0.3910 0.4529 " +
+  "0.5185 0.5819 0.6504 0.7177 0.7843 0.8540 0.9252 1.0000";
+
 function clamp(n: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, n));
 }
@@ -918,6 +967,31 @@ export function VideoPlayer({
 
   return (
     <div style={s.wrapper}>
+      {/* Transfer correction applied to art.video by the `.art-video-player
+          video` rule in globals.css. It lives here, in the only component that
+          constructs an Artplayer, so the definition and its one consumer mount
+          and unmount together — a `filter: url(#id)` whose target is missing
+          renders the element uncorrected rather than failing loudly, so the
+          two must not be able to drift apart. `videoTransferFilter.test.ts`
+          pins the id and the table against globals.css. */}
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        width="0"
+        height="0"
+        style={{ position: "absolute" }}
+      >
+        <filter
+          id={VIDEO_TRANSFER_FILTER_ID}
+          colorInterpolationFilters="sRGB"
+        >
+          <feComponentTransfer>
+            <feFuncR type="table" tableValues={VIDEO_TRANSFER_TABLE} />
+            <feFuncG type="table" tableValues={VIDEO_TRANSFER_TABLE} />
+            <feFuncB type="table" tableValues={VIDEO_TRANSFER_TABLE} />
+          </feComponentTransfer>
+        </filter>
+      </svg>
       <div ref={containerRef} style={s.player} />
       <input
         ref={fileInputRef}

--- a/next-app/src/app/[lang]/player/_components/videoTransferFilter.test.ts
+++ b/next-app/src/app/[lang]/player/_components/videoTransferFilter.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// The gate on a correction that fails silently in both directions.
+//
+// The transfer correction is split across two files by necessity: the SVG
+// filter has to be in the DOM (VideoPlayer.tsx renders it) and the rule that
+// applies it has to be in the stylesheet (globals.css), joined only by a
+// string id. Neither half complains if the join breaks:
+//
+//   · a `filter: url(#id)` whose target does not exist renders the video
+//     *uncorrected* in Chrome — no console error, no thrown exception, just
+//     the grey picture back again;
+//   · an unreferenced <filter> in the DOM is inert and invisible.
+//
+// So the only observable symptom of a rename on either side is "the picture
+// looks a bit flat", which is precisely the complaint that took a wedge chart
+// and a pixel-level A/B against ffmpeg to pin down in the first place. It is
+// not something a reviewer will catch by reading a diff.
+//
+// Three assertions, doing different jobs:
+//
+//   · the id agrees across both files, in both rules;
+//   · the fullscreen rule still names the transfer filter. `filter` is a
+//     single property, so the more specific fullscreen rule silently replaces
+//     the base one — writing just `opacity(0.999)` there would drop the
+//     correction in fullscreen only, which is both the hardest case to notice
+//     and the one people actually watch in;
+//   · the table is a well-formed monotonic ramp from 0 to 1. A table that
+//     does not start at 0 lifts black, one that does not end at 1 clips
+//     white, and a non-monotonic one posterises — all of which look like
+//     "the correction is wrong" rather than "the table is malformed".
+
+const COMPONENT = readFileSync(
+  join(import.meta.dir, "VideoPlayer.tsx"),
+  "utf8",
+);
+const CSS = readFileSync(
+  join(import.meta.dir, "../../../globals.css"),
+  "utf8",
+);
+
+/** The id the component declares on its <filter>. */
+function declaredId(): string {
+  const m = COMPONENT.match(
+    /const VIDEO_TRANSFER_FILTER_ID\s*=\s*"([^"]+)"/,
+  );
+  if (!m) throw new Error("VIDEO_TRANSFER_FILTER_ID not found in VideoPlayer.tsx");
+  return m[1];
+}
+
+/**
+ * The table values, as numbers. Written in source as concatenated string
+ * literals so the line stays readable, so join the pieces back before parsing.
+ */
+function declaredTable(): number[] {
+  const m = COMPONENT.match(
+    /const VIDEO_TRANSFER_TABLE\s*=\s*([\s\S]*?);\n/,
+  );
+  if (!m) throw new Error("VIDEO_TRANSFER_TABLE not found in VideoPlayer.tsx");
+  const joined = [...m[1].matchAll(/"([^"]*)"/g)].map((p) => p[1]).join("");
+  return joined.trim().split(/\s+/).map(Number);
+}
+
+/** Every `filter:` declaration in globals.css that targets a player <video>. */
+function videoFilterRules(): string[] {
+  const out: string[] = [];
+  for (const [, selector, body] of CSS.matchAll(
+    /([^{}]*\bvideo\b[^{}]*)\{([^}]*)\}/g,
+  )) {
+    if (!/\.art-video-player/.test(selector)) continue;
+    const filter = body.match(/(?:^|;|\*\/)\s*filter\s*:\s*([^;]+);/);
+    if (filter) out.push(filter[1].trim());
+  }
+  return out;
+}
+
+describe("video transfer filter", () => {
+  test("every player-video filter rule references the id the component renders", () => {
+    const id = declaredId();
+    const rules = videoFilterRules();
+
+    // Two rules today: the base one and the fullscreen one. If a third
+    // appears it is held to the same standard rather than silently exempt.
+    expect(rules.length).toBeGreaterThanOrEqual(2);
+    for (const rule of rules) {
+      expect(rule).toContain(`url(#${id})`);
+    }
+  });
+
+  test("the component actually renders a filter with that id", () => {
+    const id = declaredId();
+    expect(COMPONENT).toContain("id={VIDEO_TRANSFER_FILTER_ID}");
+    // sRGB is load-bearing — the SVG default is linearRGB, which would apply
+    // the table in the wrong space and produce a different picture entirely.
+    expect(COMPONENT).toContain('colorInterpolationFilters="sRGB"');
+    expect(id).toMatch(/^[a-z][a-z0-9-]*$/);
+  });
+
+  test("the fullscreen rule keeps the transfer filter alongside opacity", () => {
+    const fullscreen = videoFilterRules().find((r) => r.includes("opacity("));
+    expect(fullscreen).toBeDefined();
+    // Both, in one declaration. Either alone is a regression: dropping url()
+    // loses the correction in fullscreen, dropping opacity() walks back the
+    // subtitle-flicker fix (#24) on an untested assumption.
+    expect(fullscreen).toContain(`url(#${declaredId()})`);
+    expect(fullscreen).toContain("opacity(0.999)");
+  });
+
+  test("the table is a monotonic ramp across the full range", () => {
+    const table = declaredTable();
+
+    // 17 entries — the sampling the curve was measured and fitted at.
+    expect(table).toHaveLength(17);
+    expect(table.every(Number.isFinite)).toBe(true);
+    expect(table[0]).toBe(0);
+    expect(table[table.length - 1]).toBe(1);
+    for (const v of table) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+    for (let i = 1; i < table.length; i++) {
+      expect(table[i]).toBeGreaterThan(table[i - 1]);
+    }
+  });
+
+  test("the table darkens the midtones, which is the whole point", () => {
+    const table = declaredTable();
+    const last = table.length - 1;
+    const identity = (i: number) => i / last;
+
+    // Chrome pushes the middle of the range up, so the correction pulls it
+    // back down. A table that drifted toward identity would satisfy every
+    // structural check above while quietly doing nothing, so assert the shape
+    // itself.
+    for (let i = 2; i < last; i++) {
+      expect(table[i]).toBeLessThan(identity(i));
+    }
+    const middle = table[last / 2];
+    expect(0.5 - middle).toBeGreaterThan(0.02);
+
+    // The deepest step is the exception, and deliberately so: Chrome does not
+    // lift the bottom of the range — measured, it nudges code 17 down to 16 —
+    // so the inverse nudges it back up. This is exactly where a fitted
+    // `type="gamma"` curve went wrong (it assumed a shadow lift that is not
+    // there and crushed 17 to 10), which is why the table is measured rather
+    // than derived. Bounded so a genuinely wrong value still fails.
+    expect(table[1]).toBeGreaterThan(identity(1));
+    expect(table[1] - identity(1)).toBeLessThan(0.02);
+  });
+});

--- a/next-app/src/app/globals.css
+++ b/next-app/src/app/globals.css
@@ -263,6 +263,23 @@ h4 {
   }
 }
 
+/* ── Player: undo Chrome's video transfer shift ────────────────────────
+   Chrome composites <video> — and only <video> — through a transfer conversion
+   that lifts the midtones while pinning black and white, which reads as a flat,
+   grey picture next to mpv / IINA. The decoded frame is correct; it is the
+   compositing step that shifts it. Measured against ffmpeg with a greyscale
+   wedge: mean absolute error 7 levels, peaking at +12 around code 102.
+
+   The table is the measured inverse of that curve, and it lives in
+   VideoPlayer.tsx next to the measurements that produced it — that component
+   also renders the <svg> this url() points at, so the definition and its one
+   consumer mount together. Keep the id in step with VIDEO_TRANSFER_FILTER_ID:
+   a stale reference does not throw, it just silently stops correcting, which
+   is why videoTransferFilter.test.ts asserts the two agree. */
+.art-video-player video {
+  filter: url(#animego-video-transfer);
+}
+
 /* ── Player: fullscreen subtitle-cue flicker ───────────────────────────
    Real root cause (confirmed by live testing): in NATIVE fullscreen Chrome
    promotes the <video> to a hardware OVERLAY plane (scanned out directly,
@@ -288,8 +305,14 @@ h4 {
 .art-video-player.art-fullscreen video,
 .art-video-player:fullscreen video,
 :fullscreen .art-video-player video {
-  /* opacity() filter disqualifies the <video> from hardware-overlay promotion */
-  filter: opacity(0.999);
+  /* Both filters, deliberately. `filter` is one property, so naming only
+     opacity() here would drop the transfer correction the moment the user
+     goes fullscreen — which is most of the time they are watching.
+     opacity() is kept even though url() already disqualifies the <video>
+     from hardware-overlay promotion: the promotion block is what fixes the
+     subtitle flicker (#24), and that fix has not been re-verified against a
+     url() filter alone. Chaining costs nothing and cannot regress it. */
+  filter: url(#animego-video-transfer) opacity(0.999);
 }
 .art-video-player .art-subtitle {
   transform: translateZ(0);


### PR DESCRIPTION
Reported as "the site looks washed out next to my local player". It is not a
rendering bug in the player and it is not the file: Chrome composites
`<video>` — and only `<video>` — through a transfer conversion that lifts the
midtones while pinning black and white.

## What is actually happening

Measured against ffmpeg's decode with a 16-step greyscale wedge, on a file
carrying no colour signalling at all (no `colr` atom, VUI unspecified — the
normal shape of a Baha / ANi WEB-DL):

| source | ffmpeg | Chrome | | source | ffmpeg | Chrome |
|---:|---:|---:|---|---:|---:|---:|
| 0 | 0 | 0 | | 136 | 136 | 147 |
| 17 | 17 | 16 | | 170 | 170 | 179 |
| 51 | 51 | 58 | | 204 | 203 | 210 |
| 102 | 102 | 114 | | 255 | 255 | 255 |

Mean absolute error 7 levels, peaking at +12. The ends are nailed down and the
middle is flattened, which is exactly what reads as grey. mpv, IINA and VLC do
not apply the conversion, so the same file is more contrasty there.

**The player itself was innocent.** A colour-band clip rendered through
`/player` and through a bare `<video>` came out byte-identical on all six
patches, the video's computed style is `filter:none / opacity:1 /
mixBlendMode:normal`, and the only element stacked over it (`.art-bottom`) is
`opacity: 0` during playback.

## Why this hid so well

The decode is correct — reading the frame back with
`canvas.drawImage(video)` matches ffmpeg to within 2 levels. Only the
composited output is shifted, so **every way of inspecting the pixels from
JavaScript says the picture is fine**. It has to be caught with a screenshot,
against a CSS swatch of the same nominal colour as a control — the swatch
comes out exact, which is what proves the shift is video-specific rather than
an artefact of the capture path.

Two fixes that sound right and are not:

- **Tagging the file.** The same bitstream stream-copied into untagged /
  BT.709 / sRGB-TRC variants renders identically. Chrome does not listen to
  the tags here.
- **The display colour profile.** `--force-color-profile=srgb` is identical to
  the default; `--force-color-profile=display-p3-d65` shifts video *and* CSS
  together, while the defect is video shifting and CSS not.

## The correction: measured, not derived

The analytic BT.709 → sRGB model predicts a large shadow lift Chrome does not
actually apply — it predicts 17 → 32, Chrome leaves it at 16. Fitting a single
`feFunc type="gamma"` exponent to the midtones therefore over-darkens the
bottom end; 1.136 is the best power fit and it still crushed code 17 to 10.

The committed table is the inverse of the *measured* curve. Put back through
Chrome:

| | mean abs error vs ffmpeg | code 17 |
|---|---:|---:|
| uncorrected | 7.00 | 16 |
| best gamma fit (1.136) | 1.44 | 10 |
| **this table** | **0.31** | **16** |

End to end on the reported file, same frame, same geometry, only the filter
changing (`.art-bottom` hidden so the control gradient does not pollute the
statistics):

| | mean R/G/B | saturation |
|---|---|---|
| ffmpeg reference | 122.8 / 108.9 / 85.4 | 37.5% |
| before | 133.7 / 118.4 / 92.6 | 36.8% |
| after | 124.4 / 109.2 / 84.5 | 37.9% |

`contrast()` / `saturate()` cannot do this — contrast pivots on mid-grey and
measured 140, unmoved. CSS `filter` has no gamma or table primitive; only SVG
filters do.

## Cost

None measurable. Six alternating 20s runs at 1920x1080 with 4000 danmaku and
the ASS overlay up: **zero dropped frames in every run**, filter or not. The
late-frame counts climb monotonically with run order regardless of the filter
(an unfiltered run scored worse than a filtered one), so that drift is machine
load rather than the correction. A single run had suggested otherwise.

## Two details that are load-bearing

- **The fullscreen rule now names both filters.** `filter` is a single
  property, so leaving it as `opacity(0.999)` alone would silently drop the
  correction in fullscreen only — the hardest case to notice and the one
  people actually watch in. `opacity()` is kept rather than assumed redundant:
  it is what blocks hardware-overlay promotion and so what fixes the subtitle
  flicker (#24), and that has not been re-verified against a `url()` filter
  alone.
- **`color-interpolation-filters="sRGB"`.** The SVG default is linearRGB,
  which would apply the table in the wrong space entirely.

The filter is scoped to the `<video>` element. The jassub subtitle canvas and
the danmaku layer are drawn by us in sRGB and never went through Chrome's
video path, so correcting them would introduce the error this removes.

Chrome-only by decision, not feature-detected: Safari and Firefox handle the
video transfer differently and were not measured.

## Test plan

- [x] `bun test` — 1761 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] `node scripts/ci/eslint-ratchet.mjs` — OK
- [x] `node scripts/ci/assert-isr.mjs` — PASS
- [x] `next build --webpack` — succeeds
- [x] Verified in a production build of `/player`, real Chrome, real file:
      computed filter is `url("#animego-video-transfer")`, the definition is
      present with `sRGB` interpolation and three `table` functions, and the
      colour bands move 139 → 127 at 50% grey
- [x] Playback cost measured (above)
- [ ] Eyeball check against a desktop player — the numbers say the picture is
      back at the reference, but "does it look right" is not something a
      histogram answers

`videoTransferFilter.test.ts` pins the id across the two files, the presence of
both filters in the fullscreen rule, and the shape of the table. A
`filter: url(#id)` whose target is missing renders the video uncorrected
without any error — verified, Chrome does not hide the element — so a rename on
either side would otherwise be completely silent.