### PR TITLE
feat(player): put the danmaku speed ladder where it is readable

### DIFF
--- a/next-app/src/app/[lang]/player/_components/VideoPlayer.tsx
+++ b/next-app/src/app/[lang]/player/_components/VideoPlayer.tsx
@@ -6,6 +6,11 @@ import type { Danmu } from "artplayer-plugin-danmuku";
 import { applyHeatmapPath } from "@/lib/heatmapPath";
 import { convertAssToVtt, convertSrtToVtt } from "@/lib/subtitleConvert";
 import { mountJassub, destroyJassub } from "./jassubOverlay";
+import {
+  DANMAKU_SPEED_STEPS,
+  readDanmakuSpeed,
+  writeDanmakuSpeed,
+} from "@/lib/playerSettings";
 import { useLang } from "@/lib/lang-client";
 import type {
   WatchTick,
@@ -306,6 +311,7 @@ export function VideoPlayer({
   const subtitleOffsetRef = useRef(readSubtitleOffset());
   const playbackRateRef = useRef(readPlaybackRate());
   const danmakuVisibleRef = useRef(readDanmakuVisible());
+  const danmakuSpeedRef = useRef(readDanmakuSpeed());
   // P2 in-memory resume — used only when progressKey is absent (unmatched files).
   const resumeAtRef = useRef(resumeAt);
   const onProgressTickRef = useRef(onProgressTick);
@@ -350,6 +356,7 @@ export function VideoPlayer({
     const initialOffset = subtitleOffsetRef.current;
     const initialRate = playbackRateRef.current;
     const initialDanmakuVisible = danmakuVisibleRef.current;
+    const initialDanmakuSpeed = danmakuSpeedRef.current;
     // Always wire VTT plaintext as the resilient base layer. When jassub
     // mounts successfully on top, we hide the VTT div so they don't double.
     // If jassub fails to load, VTT remains visible — user always sees
@@ -474,7 +481,20 @@ export function VideoPlayer({
         plugins: [
           artplayerPluginDanmuku({
             danmuku: danmakuList || [],
-            speed: 5,
+            // The plugin ships a five-stop ladder (10 / 7.5 / 5 / 2.5 / 1) with
+            // only three of them labelled and 5 as the middle. Replaced with
+            // three stops that all sit at the slow end, defaulting to the
+            // slowest the plugin will render — the ladder, the ceiling that
+            // caps it and the reasoning are in lib/playerSettings.ts.
+            speed: initialDanmakuSpeed,
+            SPEED: {
+              min: 0,
+              max: DANMAKU_SPEED_STEPS.length - 1,
+              // Spread so the plugin cannot see our frozen array. It writes
+              // `...this.option.SPEED` over its own defaults and reads `steps`
+              // back out on every slider move.
+              steps: DANMAKU_SPEED_STEPS.map((s) => ({ ...s })),
+            },
             opacity: 0.8,
             fontSize: 24,
             antiOverlap: true,
@@ -498,6 +518,24 @@ export function VideoPlayer({
       if (!initialDanmakuVisible) {
         art.plugins?.artplayerPluginDanmuku?.hide?.();
       }
+
+      // Remember where the user left the speed slider.
+      //
+      // The plugin owns that control — it is inside its own config panel, not
+      // in artplayer's settings menu where the other preferences live — so
+      // there is no onChange of ours to hang this on. `…:config` is the only
+      // signal, and it fires for every config change the plugin makes,
+      // including the comment list we hand it on each episode switch. Hence
+      // the ref: it keeps the whole thing to one storage write per actual
+      // change instead of one per episode, and `writeDanmakuSpeed` refuses
+      // anything outside the ladder anyway.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      art.on("artplayerPluginDanmuku:config", (opt: any) => {
+        const next = opt?.speed;
+        if (typeof next !== "number" || next === danmakuSpeedRef.current) return;
+        danmakuSpeedRef.current = next;
+        writeDanmakuSpeed(next);
+      });
 
       // Chrome auto-exposes embedded MKV subtitle tracks as video.textTracks
       // and renders cue.text as plaintext — for ASS payloads it prints raw

--- a/next-app/src/lib/playerSettings.test.ts
+++ b/next-app/src/lib/playerSettings.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
   AUTO_MARK_DONE_KEY,
+  DANMAKU_SPEED_DEFAULT,
+  DANMAKU_SPEED_KEY,
+  DANMAKU_SPEED_MAX,
+  DANMAKU_SPEED_MIN,
+  DANMAKU_SPEED_STEPS,
+  readDanmakuSpeed,
+  speedLadderIsRenderable,
+  writeDanmakuSpeed,
   prefStore,
   readAutoMarkDone,
   subscribeAutoMarkDone,
@@ -262,5 +270,76 @@ describe("prefStore", () => {
     withWindow(hostileWindow, () => {
       expect(prefStore()).toBeNull();
     });
+  });
+});
+
+describe("danmaku speed ladder", () => {
+  test("every step survives the plugin's clamp", () => {
+    // artplayer-plugin-danmuku does `clamp(this.option.speed, 1, 10)` inside
+    // config(), and the slider then locates its handle with an exact
+    // `findIndex(item => item.value === option.speed)`. A step outside [1, 10]
+    // therefore does not render "a bit off" — it collapses onto whichever step
+    // holds the clamped value and the handle lands on the wrong label. This is
+    // measured behaviour: config({speed: 15}) reads back as 10.
+    expect(speedLadderIsRenderable()).toBe(true);
+    for (const { value } of DANMAKU_SPEED_STEPS) {
+      expect(value).toBeGreaterThanOrEqual(DANMAKU_SPEED_MIN);
+      expect(value).toBeLessThanOrEqual(DANMAKU_SPEED_MAX);
+    }
+  });
+
+  test("rejects a ladder that would misbehave", () => {
+    expect(speedLadderIsRenderable([{ value: 15 }])).toBe(false); // clamped
+    expect(speedLadderIsRenderable([{ value: 0.5 }])).toBe(false); // clamped
+    expect(speedLadderIsRenderable([{ value: 8 }, { value: 8 }])).toBe(false); // ambiguous
+    expect(speedLadderIsRenderable([])).toBe(false);
+  });
+
+  test("the ladder runs slowest-first and the default is the slowest", () => {
+    const values = DANMAKU_SPEED_STEPS.map((s) => s.value);
+    // The slider renders steps left to right, and slow belongs on the left.
+    for (let i = 1; i < values.length; i++) {
+      expect(values[i]).toBeLessThan(values[i - 1]);
+    }
+    expect(DANMAKU_SPEED_DEFAULT).toBe(values[0]);
+    // Every tier is slower than the 5 the player used to hard-code — the
+    // point of the change, and the thing a future edit is most likely to undo.
+    for (const v of values) expect(v).toBeGreaterThan(5);
+  });
+
+  test("reads back a stored step", () => {
+    const store = fakeStore({ [DANMAKU_SPEED_KEY]: "8" });
+    expect(readDanmakuSpeed(store)).toBe(8);
+  });
+
+  test("a value that is not on the ladder falls back to the default", () => {
+    // Everyone who played anything before this ladder existed has no stored
+    // value at all; anyone mid-migration could hold the old hard-coded 5.
+    // Neither has a slider position, so neither may be handed back.
+    for (const raw of ["5", "7.5", "abc", ""]) {
+      expect(readDanmakuSpeed(fakeStore({ [DANMAKU_SPEED_KEY]: raw }))).toBe(
+        DANMAKU_SPEED_DEFAULT,
+      );
+    }
+    expect(readDanmakuSpeed(fakeStore())).toBe(DANMAKU_SPEED_DEFAULT);
+    expect(readDanmakuSpeed(null)).toBe(DANMAKU_SPEED_DEFAULT);
+    expect(readDanmakuSpeed(throwingStore())).toBe(DANMAKU_SPEED_DEFAULT);
+  });
+
+  test("only writes values the slider can find again", () => {
+    const store = fakeStore();
+    expect(writeDanmakuSpeed(8, store)).toBe(true);
+    expect(store.raw.get(DANMAKU_SPEED_KEY)).toBe("8");
+
+    // The config event fires for opacity, margin, font size and the comment
+    // list too, so this is called with whatever speed happens to be current.
+    expect(writeDanmakuSpeed(15, store)).toBe(false);
+    expect(writeDanmakuSpeed(5, store)).toBe(false);
+    expect(store.raw.get(DANMAKU_SPEED_KEY)).toBe("8");
+  });
+
+  test("a failed write is reported, not swallowed", () => {
+    expect(writeDanmakuSpeed(8, throwingStore())).toBe(false);
+    expect(writeDanmakuSpeed(8, null)).toBe(false);
   });
 });

--- a/next-app/src/lib/playerSettings.ts
+++ b/next-app/src/lib/playerSettings.ts
@@ -1,7 +1,9 @@
 /**
  * Player preferences that live on the device, not on the server.
  *
- * Today that is one switch: `autoMarkDone`. When it is on, the player marks an
+ * Two of them so far: `autoMarkDone` and the danmaku speed ladder.
+ *
+ * `autoMarkDone` — when it is on, the player marks an
  * episode watched once playback crosses the completion threshold and pushes
  * the watch progress up (design doc §4 decision 6 / §5.1 — ported from
  * Animeko's `VideoScaffoldConfig.autoMarkDone: Boolean = true`, which is on by
@@ -134,4 +136,107 @@ export function subscribeAutoMarkDone(onChange: () => void): () => void {
     window.removeEventListener(CHANGE_EVENT, onChange);
     window.removeEventListener("storage", onChange);
   };
+}
+
+/* ── Danmaku speed ─────────────────────────────────────────────────────── */
+
+/** Same namespace as the rest (`animego:playbackRate`, `animego:danmakuVisible`). */
+export const DANMAKU_SPEED_KEY = "animego:danmakuSpeed";
+
+/**
+ * How long a comment takes to cross the screen, in seconds. Bigger is slower.
+ *
+ * THE CEILING IS 10 AND IT IS NOT OURS. artplayer-plugin-danmuku clamps inside
+ * `config()`:
+ *
+ *     this.option.speed = clamp(this.option.speed, 1, 10);
+ *
+ * so a step of 15 does not render slowly — it silently becomes 10. Measured,
+ * not assumed: `config({speed: 15})` and `config({speed: 12})` both read back
+ * as 10. That failure is invisible from the UI in the worst possible way,
+ * because the slider finds its position by matching `option.speed` against
+ * these values (`SPEED.steps.findIndex(item => item.value === option.speed)`)
+ * — an out-of-range step would collapse onto whichever step holds 10 and the
+ * handle would jump to the wrong label. `speedLadderIsRenderable()` pins it.
+ *
+ * The ladder deliberately sits at the slow end: the fastest tier here (6.5) is
+ * still slower than the 5 the player used to hard-code, because dense comment
+ * streams at 5s are the thing that made them unreadable.
+ */
+export const DANMAKU_SPEED_STEPS: ReadonlyArray<{ name: string; value: number }> = [
+  { name: "极慢", value: 10 },
+  { name: "缓慢", value: 8 },
+  { name: "适中", value: 6.5 },
+];
+
+/** The slowest tier. Deliberately the default — see DANMAKU_SPEED_STEPS. */
+export const DANMAKU_SPEED_DEFAULT = DANMAKU_SPEED_STEPS[0].value;
+
+/** The bounds the plugin enforces; exported so the guard test can name them. */
+export const DANMAKU_SPEED_MIN = 1;
+export const DANMAKU_SPEED_MAX = 10;
+
+/**
+ * Would every step survive the plugin's clamp and stay findable on the slider?
+ *
+ * Exists so the ladder cannot be edited into a shape that looks fine in the
+ * source and misbehaves only once a comment is on screen.
+ */
+export function speedLadderIsRenderable(
+  steps: ReadonlyArray<{ value: number }> = DANMAKU_SPEED_STEPS,
+): boolean {
+  const seen = new Set<number>();
+  for (const { value } of steps) {
+    if (!Number.isFinite(value)) return false;
+    if (value < DANMAKU_SPEED_MIN || value > DANMAKU_SPEED_MAX) return false;
+    if (seen.has(value)) return false;
+    seen.add(value);
+  }
+  return steps.length > 0;
+}
+
+/**
+ * The stored speed, snapped to a step we actually offer.
+ *
+ * Snapping rather than clamping is the point: the slider locates the handle by
+ * exact equality against the step values, so a stored 5 — which every user who
+ * played anything before this ladder existed has — is not "a bit fast", it is
+ * *no position at all* (`findIndex` returns -1). Falling back to the default
+ * puts the handle somewhere real.
+ */
+export function readDanmakuSpeed(store: PrefStore | null = prefStore()): number {
+  if (!store) return DANMAKU_SPEED_DEFAULT;
+  try {
+    const raw = Number(store.getItem(DANMAKU_SPEED_KEY));
+    if (!Number.isFinite(raw)) return DANMAKU_SPEED_DEFAULT;
+    return DANMAKU_SPEED_STEPS.some((s) => s.value === raw)
+      ? raw
+      : DANMAKU_SPEED_DEFAULT;
+  } catch {
+    return DANMAKU_SPEED_DEFAULT;
+  }
+}
+
+/**
+ * Persist the speed. Returns whether it landed, for the same reason
+ * `writeAutoMarkDone` does.
+ *
+ * A value outside the ladder is refused rather than written: the plugin's
+ * `artplayerPluginDanmuku:config` event fires for every config change it makes
+ * — opacity, margin, font size, the comment list we hand it on each episode —
+ * so this is called with whatever `option.speed` happens to be, and writing an
+ * unknown value would mean `readDanmakuSpeed` discards it next time anyway.
+ */
+export function writeDanmakuSpeed(
+  value: number,
+  store: PrefStore | null = prefStore(),
+): boolean {
+  if (!store) return false;
+  if (!DANMAKU_SPEED_STEPS.some((s) => s.value === value)) return false;
+  try {
+    store.setItem(DANMAKU_SPEED_KEY, String(value));
+  } catch {
+    return false;
+  }
+  return true;
 }


### PR DESCRIPTION
The five-stop ladder the plugin ships (10 / 7.5 / 5 / 2.5 / 1 seconds to cross
the screen) labels only three of its stops and puts 5 in the middle, and the
player hard-coded that middle. On a dense episode 5 seconds is not enough time
to read a line before it leaves.

## The ladder

| | before | after |
|---|---|---|
| stops | 5 (10 / 7.5 / 5 / 2.5 / 1) | 3 |
| labelled | 3 of 5 — 7.5 and 2.5 are `hide: true` | all 3 |
| default | 5s | **10s (the slowest)** |

    极慢 10s   缓慢 8s   适中 6.5s
    ▲ default

Every tier is slower than the 5 that was hard-coded.

## The ceiling is 10, and it is not ours

`artplayer-plugin-danmuku` clamps inside `config()`:

```js
this.option.speed = clamp(this.option.speed, 1, 10);
```

So a slower-looking step does not render slowly — it silently becomes 10.
Measured against the running plugin, not read off the source:

```
config({speed: 15}) → option.speed = 10
config({speed: 12}) → option.speed = 10
config({speed: 10}) → option.speed = 10
config({speed: 0.5}) → option.speed = 1
```

The failure mode is invisible from the UI in the worst way: the slider locates
its handle with `SPEED.steps.findIndex(item => item.value === option.speed)`,
so an out-of-range step collapses onto whichever stop holds 10 and the handle
lands on the **wrong label**. `speedLadderIsRenderable()` and its test pin
this, because the next person who wants "slower" will reach for a bigger
number first — I did.

## Persistence

The choice is remembered, like subtitle size and playback rate.

The control lives in the plugin's own config panel rather than artplayer's
settings menu, so there is no `onChange` of ours to hang the write on.
`artplayerPluginDanmuku:config` is the only signal, and it fires for every
config change the plugin makes — including the comment list handed over on
each episode switch. A ref reduces that to one storage write per real change,
and `writeDanmakuSpeed` refuses anything off the ladder regardless.

A stored value that is not on the ladder falls back to the default rather than
being clamped toward it. Anyone who played an episode before this existed has
either nothing stored or the old `5`, and neither has a slider position at all
— `findIndex` returns `-1` and the handle has nowhere to sit.

## Test plan

- [x] `bun test` — 1768 pass, 0 fail (7 new)
- [x] `bunx tsc --noEmit` — clean
- [x] `node scripts/ci/eslint-ratchet.mjs` — OK
- [x] `node scripts/ci/assert-isr.mjs` — PASS
- [x] `next build --webpack` — succeeds
- [x] Driven through the real control in a production build — hover the gear,
      click the middle stop on the track:

      first open   steps ["极慢","缓慢","适中"]  label 极慢  speed 10  stored null
      click middle                              label 缓慢  speed  8  stored "8"
      reopen                                    label 缓慢  speed  8  stored "8"

      Worth recording: calling `config({speed})` directly moves the speed but
      leaves the label stale, because the label is repainted by the slider's
      own `onChange`. My first run did exactly that and it reads like a bug in
      the product rather than in the test.

## Known and unchanged

The plugin's config panel is hard-coded Chinese (按类型屏蔽 / 滚动 / 顶部 …),
so these step names match what is already around them, and `/en` shows Chinese
in that panel either way. Out of scope here.