### PR TITLE
ci(e2e): the sandbox printed the failure and waved it through

### DIFF
--- a/.github/workflows/e2e-sandbox.yml
+++ b/.github/workflows/e2e-sandbox.yml
@@ -170,19 +170,53 @@ jobs:
         # artifact. Paying that cost here, serially, keeps it out of the
         # specs.
         #
-        # The retry-on-5xx is not defensive padding, it is a measured
-        # behaviour: Turbopack prints "Ready" and answers /api/healthz
-        # before the module graph has settled, and a burst of page requests
-        # in that window comes back 500 with NOTHING logged. Seconds later
-        # the identical URLs return 200. Warming without the retry would
-        # therefore pass while leaving the app half-cold, and Playwright
-        # would inherit the tail of that window as a flake nobody could
-        # reproduce. A route that never stops 5xx is a real failure and
-        # fails the job here, where the log is still readable.
+        # The retry is not defensive padding, it is a measured behaviour:
+        # Turbopack prints "Ready" and answers /api/healthz before the module
+        # graph has settled, and a burst of page requests in that window comes
+        # back 500 with NOTHING logged. Seconds later the identical URLs return
+        # 200. Warming without the retry would therefore pass while leaving the
+        # app half-cold, and Playwright would inherit the tail of that window as
+        # a flake nobody could reproduce.
         #
-        # Non-5xx codes are accepted as "compiled": /library, /player and
-        # /admin answer 307 to an anonymous warm-up request, which is the
-        # correct behaviour and still proves the route built.
+        # ─── Why each route now declares the status it must answer ──────────
+        #
+        # This list used to be bare paths judged by one shared rule: anything
+        # that was not 5xx counted as "compiled". That rule waved through the
+        # exact signal it was standing next to.
+        #
+        # Measured 2026-08-29, on two PRs whose diffs do not overlap (#127,
+        # #128). Both failed their first attempt with the SAME nine specs at
+        # the SAME line numbers, and both went green on a re-run with no code
+        # change. In the failed runs, every route with a dynamic segment nested
+        # inside `[lang]` answered 404 for the whole run — `[lang]/anime/[id]`,
+        # `[lang]/reset-password/[token]`, `[lang]/u/[username]`,
+        # `[lang]/seasonal/[season]/[year]`. Three-segment paths went 0 for 19.
+        # Routes where `[lang]` is the only dynamic segment kept working.
+        #
+        # `/reset-password/warmup` is the canary. That page calls no API and has
+        # no notFound() path, so a 404 there is impossible in a healthy stack.
+        # Across 14 historical runs the line `warmed /reset-password/warmup ->
+        # 404` appeared three times, and all three attempts failed. It was
+        # printed, in the log, both times — and skipped, because 404 is not 5xx.
+        #
+        # So every route names its expected status. Two things follow that the
+        # old rule could not express:
+        #
+        #   - `/library` and `/admin` assert 307. Nothing checked those before;
+        #     if the auth redirect broke and they started answering 200, the
+        #     warm-up would have called it compiled and moved on.
+        #   - `/anime/0` asserts 404, and is NOT diagnostic on its own. It
+        #     answers 404 in the healthy state too (the page bails on
+        #     `anilistId <= 0`). The positive probe for that route class is in
+        #     e2e/globalSetup.ts, which asserts `/anime/21` AFTER seeding it.
+        #
+        # One concept, not two: keep asking until the route answers what it
+        # should, then assert. Retrying only on 5xx and asserting separately
+        # would fail the job on a transient 404 that a second request would
+        # have resolved. The cost of unifying them is bounded — a genuinely
+        # wrong status burns 10 attempts on the FIRST route that mismatches and
+        # then exits, so the job still fails around a minute in rather than
+        # letting the suite run for three and report nine confusing specs.
         run: |
           set -euo pipefail
           for i in $(seq 1 60); do
@@ -210,24 +244,31 @@ jobs:
           # runs before globalSetup seeds anything, so the miss would be a
           # genuine 404 — and `loadDetail` fetches with `revalidate: 60`, so
           # Next would serve that 404 back for a minute after the row existed.
-          for route in / /login /register /forgot-password /reset-password/warmup \
-                       /welcome /library /player /admin /anime/0; do
+          for probe in /:200 /login:200 /register:200 /forgot-password:200 \
+                       /reset-password/warmup:200 /welcome:200 /library:307 \
+                       /player:200 /admin:307 /anime/0:404; do
+            # Split on the LAST colon, so a path that ever contains one still
+            # pairs correctly with its status.
+            route="${probe%:*}"
+            want="${probe##*:}"
             code=000
             for attempt in $(seq 1 10); do
               code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 120 "http://localhost:3000${route}")
-              case "$code" in
-                5*|000) sleep 3 ;;
-                *) break ;;
-              esac
+              [ "$code" = "$want" ] && break
+              sleep 3
             done
-            echo "warmed ${route} -> ${code} (attempt ${attempt})"
-            case "$code" in
-              5*|000)
-                echo "::error::${route} never stopped returning ${code}"
-                cat /tmp/next-dev.log
-                exit 1
-                ;;
-            esac
+            echo "warmed ${route} -> ${code} (want ${want}, attempt ${attempt})"
+            if [ "$code" != "$want" ]; then
+              echo "::error::${route} answered ${code}, expected ${want}"
+              # The dev-server hint only when it applies. This loop also guards
+              # auth redirects, and pointing an auth regression at a bundler bug
+              # would replace one misleading failure with another.
+              if [ "$code" = "404" ]; then
+                echo "::error::A 404 here is the dev-server failure documented above this loop, not a product 404: every route with a dynamic segment under [lang] stops resolving for the whole run. Check the next dev log below for the 'generate-params' phase — healthy 200s have it, these 404s do not."
+              fi
+              cat /tmp/next-dev.log
+              exit 1
+            fi
           done
 
       - name: Install e2e deps

--- a/TODOS.md
+++ b/TODOS.md
@@ -200,7 +200,6 @@
   (0.5 人天,零调用方改动)。缺陷本身也已用可运行原型复现,不是推演:
   基线下 `picked id=1 / tier=high`(绑错季且高置信),加上修复后 `picked id=2 / tier=high`;
   候选表里只有错季条目时,基线 `tier=high` 无条件绑定,修复后 `tier=low` 转 needs-review。
-||||||| 6b31a3e
 ## 若任一路由的服务端渲染慢过约 300ms，把段内 `loading.tsx` 加回去
 
 - **What:** 2026-08-28 把 `app/[lang]/loading.tsx` 从根部挪进了 `(home)/`，代价是

--- a/TODOS.md
+++ b/TODOS.md
@@ -355,8 +355,18 @@
   一旦限流，go-api 返回 `AniList rate limited`，next-app 抛 `ApiError`，页面变成
   **500**。实测：沙箱套件用 `--repeat-each=3` 并发压一下就稳定复现，dev 日志逐字写着
   `Error [ApiError]: AniList rate limited` 后跟 `GET /anime/999999999 500`。
-- **Why:** 这大概率就是沙箱 CI 里 `not-found-status.spec.ts` 那条
-  `/en answers 404` 偶尔变红、重试即过的真正原因 —— 一直被当成不明 flake。
+- **Why:** 一个不存在的 id 本该答 404，在限流窗口里答的是 500。缺陷本身与 CI 无关、
+  独立可复现（见上面的 `--repeat-each=3`），代价写在下面的 Context 里。
+  > ★**归因更正（2026-08-29）**：本条原写「这大概率就是沙箱 CI 里
+  > `not-found-status.spec.ts` 那条 `/en answers 404` 偶尔变红、重试即过的真正原因」——
+  > **那句是错的，已删**。那个 flake 的真身是 Turbopack dev 下**整类嵌套动态路由变
+  > 404**（见下一条「Turbopack dev 下……」）。三条判据各自独立地否掉了本条：
+  > 症状是 **404 不是 500**；受害路由包括 `/reset-password/[token]`，它**一次 AniList
+  > 都不调**；而失败那次里 `/anime/*` 的 404 只花了 42ms（`next.js: 5ms`），
+  > 根本没进过第三方调用。两件事只是恰好都落在同一个套件上。
+  > ⚠️ **同一句错误归因也逐字写在 `e2e/specs/sandbox/not-found-status.spec.ts:59-60`
+  > 的注释里**（"almost certainly the cause of the `/en answers 404 (retry #1)`
+  > flake"），修这条缺陷时一并改掉，否则它会继续把下一个人引到 AniList 上。
 - **Pros:** 修法和 2026-08-28 的搜索改动是同一个思路：**目录里没有的 id，本地就能判定
   不存在，不必问第三方**。`anime_cache` 有 17,689 行，一个 id 不在里面且不是新番的
   概率极高。至少可以做到「AniList 不可达时退回本地判定」而不是直接 500。
@@ -367,3 +377,97 @@
   `not-found-status.spec.ts` 里那几条状态断言故意保持严格（只接受 404），**不要**为了
   让 CI 变绿而放宽成「404 或 500」—— 那会把这个缺陷永久藏起来。
 - **Depends on / blocked by:** 无。与本地搜索独立，但共用同一个判断。
+
+## Turbopack dev 下，嵌套在 `[lang]` 里的动态路由会整类 404
+
+- **What:** 沙箱 e2e 时红时绿、重跑即过，一直被当成不明 flake。真身不在测试里：
+  `next dev` 用的是 Turbopack（Next 16 起是默认），而某些进程实例里**凡是 `[lang]`
+  下面还有一层动态段的路由，一整轮全部 404** —— `[lang]/anime/[id]`、
+  `[lang]/reset-password/[token]`、`[lang]/u/[username]`、
+  `[lang]/seasonal/[season]/[year]` 无一幸免。止血办法是让沙箱的 dev server 也走
+  webpack（`next dev --webpack`，该 flag 确认存在），与 `next build --webpack` 对齐。
+- **Why:** 形状本身就排除了产品代码：两个 PR（#127 改 CSS/SVG filter、#128 改弹幕速度
+  设置）**diff 毫无交集**，却在 attempt 1 挂掉**同样 9 条用例、同样的行号**
+  （散落在 6 个 spec 文件里），且都在**零代码改动**的重跑里全绿。
+  再看范围：`[lang]` 是唯一动态段的路由（`[lang]/faq`、`[lang]/search`、
+  `[lang]/privacy`）自始至终正常，`[lang]` **之外**的动态路由
+  `/sitemaps/anime/sitemap/[id].xml` 同一轮里也正常 200 —— 坏的恰好是
+  「`[lang]` + 再嵌一层动态段」这一类，三段路径 **0 成功 / 19 次失败**。
+- **Pros:** 两条判据都能直接从 CI 日志读出来，不必复现：
+  1. **`generate-params` 阶段在不在。** next-dev.log 里每条 200 都带
+     `generate-params: …`，每条 404 **一个都没有**。这一段缺失＝该段从没被编译。
+  2. **404 花了多久。** 健康时 `/anime/0` 是 `404 in 942ms (next.js: 870ms)` ——
+     段编译过了、页面在 `anilistId <= 0` 上主动 `notFound()`，这是**产品的** 404。
+     故障时是 `404 in 42ms (next.js: 5ms)` —— 从没编译过，404 来自路由层。
+     ★**状态码一模一样，来源完全不同** —— 只看状态码永远分不出这两件事。
+- **Cons:** `--webpack` 是**止血不是修复**，而且 2026-08-29 的对照组实测证明**现在还不能上**。
+  同一个 commit 推 6 个分支各跑一次（不同 ref 才能绕开 `cancel-in-progress`，同 ref 连发只会
+  互相取消）：
+
+  | | Turbopack 基线 | webpack 6 次 |
+  |---|---|---|
+  | 嵌套动态段 404 指纹 | 14 次里出现 3 次 | **0/6，确实消失了** |
+  | job 时长 | ~4 分钟 | **8m08s–9m23s，约 2.2 倍** |
+  | 套件结果 | 间歇性红 | **6/6 全红** |
+
+  ★**它换来了一个更糟的缺陷**：7 条用例在 6 次里每次都挂（`auth` 3 条、`locale-routing`
+  2 条、`stale-tab` 2 条），确定性的，不是抖动。机理在第一条里写着 —— 期望
+  「邮箱或密码错误」，实际拿到「邮箱格式不正确」，即**打字进了 DOM 没进 React state**，
+  正是 #129 修 `/search` 时记下的水合竞态。#129 只修了那一个 spec，其余会打字的 spec
+  仍然不等 `__reactFiber$`，而 webpack 更慢的编译把那个窗口从偶发撑成了必现。
+  **结论：套件本来就依赖 dev server 足够快，Turbopack 的速度一直在掩盖这件事。**
+  换打包器之前必须先把这些 spec 的水合等待补上，否则是拿一个间歇性红换一个确定性红。
+
+  另外两块代价不变：沙箱从此不再覆盖生产之外的第二个打包器；**上游那半还没查** ——
+  这是不是已知的 Next issue、有没有在更晚的 16.x 里修掉，目前是空白
+  （查的时候 web search 额度已耗尽，不是查过没有）。在补上这一步之前，
+  只能说「webpack 下没复现 404」，**不能**说「根因是 Turbopack 的某某」。
+- **Context:** 全仓只有沙箱在跑 Turbopack —— `next-app/package.json` 的 build 是
+  `next build --webpack`，只有 `dev` 走默认。当前钉的是 `next@16.2.6`。
+  ★**最值钱的是早期指纹**：warm-up 那一行 `warmed /reset-password/warmup -> 404`。
+  那个页面不调任何 API、也没有任何 `notFound()` 分支，**健康栈里它不可能是 404**。
+  翻了 14 次历史运行它出现过 3 次，**3 次对应的 attempt 全部失败**。而 warm-up 的守卫
+  只对 `5xx|000` 判失败，所以它两次都把指纹打印出来又原样放行了。把这一行收紧成
+  「`/reset-password/warmup` 不是 200 就直接失败」成本一行，收益是把一次半小时的
+  e2e 排查压成一条报错。
+  ★**取证顺序**：重跑会**覆盖** job 日志，但
+  `gh api repos/OWNER/REPO/actions/runs/<id>/attempts/1/logs` 仍取得到失败那次；
+  而 `Dump service logs on failure` 是 `if: failure()`，所以 next-dev.log 和容器日志
+  **只有失败那次才存在**，重跑变绿之后就永远没有了。**先取证，再重跑。**
+- **Depends on / blocked by:** 无。
+  ★**退出条件 —— 什么情况下可以把 Turbopack 换回来**，三条都满足才动：
+  ① 找到对应的上游 issue，并确认它在某个具体的 16.x 里标为已修；
+  ② 升到那个版本；
+  ③ **用同一个指纹复验**：连跑若干次沙箱，`warmed /reset-password/warmup` 全是 200，
+  且 next-dev.log 里嵌套动态路由的 200 全都带 `generate-params`。
+  「跑了一次没红」**不算数** —— 这个缺陷本来就是间歇的，n=1 在本仓已经骗过人不止一次。
+
+## 断言「不存在」的用例，在整体故障下会以错误的理由变绿
+
+- **What:** 扫一遍沙箱套件，把「断言 404 / 不可见 / 空结果」却**没有同路由族正例配对**的
+  用例挑出来，逐条补上正例。**这条 TODO 的本体是那次扫描**，不是某一个文件 ——
+  下面的样本只是发现它的入口，不是全部。
+- **Why:** 2026-08-29 那次故障给了一个教科书级的样本：**全站每一条嵌套动态路由都在
+  404**，而 `not-found-status.spec.ts` 里断言 404 的 **10 条用例全绿** ——
+  `/anime/0`、`/anime/abc`、`/anime/-1`、`/anime/999999999`、
+  `/seasonal/notaseason/2026`、`/u/{不存在}` 及其 `followers`/`following`，
+  再加三个 locale 前缀各一条。它们要的答案是 404，而路由层正在无差别地发 404，
+  于是**每一条都以完全错误的理由通过了**。一条断言「这个不存在」的用例，
+  在「什么都不存在」的时候没有任何判别力。
+- **Pros:** 配对的效力不是推演，**同一个文件里就有现成的对照组**：
+  `not-found-status.spec.ts:207` 的 "a real anime still answers 200 in every locale
+  form"。那一轮 11 条状态断言里**唯一变红的就是它**，而它的注释当初就把理由写清楚了 ——
+  "a change that 404s the whole catalogue passes every assertion above"。
+  作者预见到了这个形状并挡住了；缺的只是把同一条规则推广到其余用例。
+- **Cons:** 配对不是免费的：正例需要一条真实存在的夹具数据，而夹具生命周期在
+  `fullyParallel` 下本身就是出过 bug 的地方（#123 修过一次共享夹具的并发缺陷，
+  #118 那轮的三条红也全是我自己 spec 的并发缺陷）。补正例时别顺手引入新的共享可变状态，
+  否则治好一个盲区、换来一个 flake。
+- **Context:** 沙箱 20 个 spec 里有 12 个含形如 `toBe(404)` / `not.toBeVisible` /
+  `toHaveCount(0)` / `toBeHidden` 的负向断言，共 **35 处** —— 这是扫描的**分母**，
+  **不是**「35 处都有问题」的结论，也**不是**「已经扫过了」。逐条只问一个问题：
+  **「如果被测的这个能力彻底坏掉，这条断言会不会照样绿？」** 会，就补正例。
+  ★配套的一条判据见上一条：状态码相同不代表路径相同，用例分辨不了的，
+  服务端日志能分辨（`generate-params` 在不在 / 404 花了几毫秒）。
+- **Depends on / blocked by:** 无。与 Turbopack 那条彼此独立 —— 打包器换回去之后，
+  这个盲区照样在。

--- a/e2e/globalSetup.ts
+++ b/e2e/globalSetup.ts
@@ -108,6 +108,30 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
     titleChinese: "E2E 路由固定装置",
     episodes: 12,
   });
+  // The positive probe for the `[lang]/anime/[id]` route class, which until
+  // now had none anywhere in the pipeline.
+  //
+  // Under the Turbopack dev server, every route carrying a dynamic segment
+  // NESTED inside `[lang]` intermittently 404s for a whole run —
+  // `[lang]/anime/[id]`, `[lang]/reset-password/[token]`, `[lang]/u/[username]`,
+  // `[lang]/seasonal/[season]/[year]` — while routes where `[lang]` is the only
+  // dynamic segment keep serving throughout. Measured on the 2026-08-29 failure:
+  // three-segment paths went 0 for 19.
+  //
+  // Nothing in the run could see it. The workflow warms `/anime/0`, and 0
+  // answers 404 in BOTH states — healthy, because the page bails on
+  // `anilistId <= 0` before calling loadDetail (a real product 404), and broken,
+  // because the router 404s without compiling the segment. A probe whose answer
+  // is identical either way is not a probe, so the class went unwatched and the
+  // specs met the defect instead, as a dozen unrelated-looking failures.
+  //
+  // Directly after the seed is the EARLIEST point at which a real id is a valid
+  // probe, and that ordering is load-bearing in both directions. Earlier is a
+  // genuine miss, and `loadDetail` fetches with `revalidate: 60`, so Next would
+  // hand that 404 back for a minute after the row existed. The workflow's
+  // warm-up step documents the same reasoning for why it warms 0 and not 21 —
+  // the two halves are a pair, and neither is safe to "simplify" alone.
+  await assertRoutingFixtureRenders();
   await closePg();
 
   const browser = await chromium.launch();
@@ -126,4 +150,86 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
 
   await context.storageState({ path: STORAGE_STATE_PATH });
   await browser.close();
+}
+
+// Appended to every failure below, because the loudest error in the log will
+// not be one of them.
+//
+// globalSetup throws before the browser login, so `.auth/user.json` is never
+// written, and Playwright then fails EVERY sandbox spec on a missing storage
+// state. That message arrives later, repeats once per spec, and describes a
+// file — it out-shouts the single line above it that says what actually broke.
+// Someone who chases it goes looking at auth, at the seed user, at
+// `storageState` config, and finds nothing wrong with any of them.
+const STORAGE_STATE_RED_HERRING =
+  `DO NOT CHASE THE NEXT ERROR IN THIS LOG. globalSetup stops here, before the ` +
+  `browser login, so e2e/.auth/user.json is never written and every sandbox spec ` +
+  `afterwards reports "storage state file not found". That is downstream of this ` +
+  `failure, not a second one. Fix this line and it goes away.`;
+
+/**
+ * Demand a 200 from `/anime/{ROUTING_FIXTURE_ANILIST_ID}`.
+ *
+ * The check is one fetch; the messages are the reason this function exists.
+ * The condition it detects has three plausible-looking explanations that are
+ * all wrong — the fixture, the login, the database — and the reader gets
+ * exactly one error before the storage-state noise buries it, so each throw
+ * has to rule those out by name rather than leave them open.
+ *
+ * Deliberately one request, not a retry loop. The failure is per dev-server
+ * process, not per request (0 for 19 in the failed run), so a retry would only
+ * spend time before reporting the same thing — and the workflow's warm-up step
+ * has already absorbed the separate startup window where Turbopack answers 5xx
+ * for a few seconds with nothing logged.
+ *
+ * A throw skips the `closePg()` that follows the call site and leaves the pool
+ * open. Not worth guarding: Playwright ends a failed run through
+ * `gracefullyProcessExitDoNotHang`, which calls `process.exit()` outright.
+ */
+async function assertRoutingFixtureRenders(): Promise<void> {
+  const url = `${BASE_URL}/anime/${ROUTING_FIXTURE_ANILIST_ID}`;
+
+  let status: number;
+  try {
+    // Redirects followed on purpose: the specs reach this page with a browser,
+    // so the status that matters is the one at the end of the chain, not a
+    // locale-prefix hop along the way.
+    const response = await fetch(url, { redirect: "follow" });
+    status = response.status;
+  } catch (cause) {
+    // Without this catch the whole diagnosis is replaced by `TypeError: fetch
+    // failed`, which names neither the URL nor the reason and is followed
+    // immediately by the storage-state cascade.
+    throw new Error(
+      `${url} could not be reached at all — nothing is answering on that host.\n\n` +
+        `This is not the fixture and not auth. globalSetup got this far, which means ` +
+        `Postgres accepted the seed and ensureAnimeDetail() verified its own ` +
+        `postcondition; this request never reached a server at all. Check that the ` +
+        `app server is up and that E2E_SANDBOX_BASE_URL (currently ${BASE_URL}) matches ` +
+        `the baseURL in playwright.config.ts.\n\n` +
+        STORAGE_STATE_RED_HERRING,
+      { cause },
+    );
+  }
+
+  if (status !== 200) {
+    throw new Error(
+      `GET ${url} answered ${status}, not 200.\n\n` +
+        `The anime_cache row for ${ROUTING_FIXTURE_ANILIST_ID} EXISTS. ` +
+        `ensureAnimeDetail() checks its own postcondition — one studio, one ` +
+        `character with a role, the two things isStale trips on — and it returned ` +
+        `without throwing on the line above this probe. So the seed is not the ` +
+        `problem. Neither is auth: this request carried no cookies and /anime/* is ` +
+        `public to anonymous readers.\n\n` +
+        `The page was asked for a row that is there and did not render it. That is ` +
+        `the nested-dynamic-segment failure: under the dev server, routes with a ` +
+        `dynamic segment inside [lang] — [lang]/anime/[id], ` +
+        `[lang]/reset-password/[token], [lang]/u/[username], ` +
+        `[lang]/seasonal/[season]/[year] — 404 for an entire run, while routes ` +
+        `where [lang] is the only dynamic segment keep serving. It is a property ` +
+        `of the dev-server process, not of any one request: re-running a single ` +
+        `spec proves nothing, because the whole run is affected or none of it is.\n\n` +
+        STORAGE_STATE_RED_HERRING,
+    );
+  }
 }

--- a/e2e/specs/sandbox/not-found-status.spec.ts
+++ b/e2e/specs/sandbox/not-found-status.spec.ts
@@ -56,11 +56,26 @@ const MISSING_USER = "definitelynosuchuser99";
  * negative cache: a cache miss plus pgx.ErrNoRows goes straight to AniList
  * (detail.go:423), so EVERY request for an uncatalogued id opens a live
  * third-party call. When AniList rate-limits, the page answers 500 rather than
- * 404 — reproduced locally, and almost certainly the cause of the
- * `/en answers 404 (retry #1)` flake this suite showed in CI. That is a real
- * product defect and it is written up in TODOS.md; it is not something to
- * discover eight times per run through a status assertion that cannot tell a
- * regression from an upstream hiccup.
+ * 404 — reproduced locally. That is a real product defect and it is written up
+ * in TODOS.md; it is not something to discover eight times per run through a
+ * status assertion that cannot tell a regression from an upstream hiccup.
+ *
+ * This comment used to go on to call that defect "almost certainly the cause"
+ * of the `/en answers 404 (retry #1)` flake this suite showed in CI. It is
+ * not, and the correction matters because the guess pointed the next reader at
+ * the wrong system. Traced 2026-08-29 off two failing attempts: the symptom is
+ * 404, not 500, and it lands on routes that never call AniList at all —
+ * `/reset-password/[token]` among them. Every route with a dynamic segment
+ * nested inside `[lang]` stops resolving for the whole run, and the failing
+ * `/anime/*` request returned in 42ms with 5ms inside next.js, so nothing
+ * reached a third party. See TODOS.md.
+ *
+ * Worth knowing while reading the assertions below. In that state every
+ * negative assertion in this file passes, for the wrong reason: a run where
+ * the entire catalogue 404s satisfies "a missing id answers 404" perfectly.
+ * Ten of them went green that way. The one that went red was the paired
+ * POSITIVE case — a real anime still answering 200 — which is the shape a
+ * suite of negative assertions needs in order to stay honest.
  *
  * ONE test below still uses a large id, on purpose, to cover the path 0 does
  * not reach. It is the only one allowed to depend on AniList being up.


### PR DESCRIPTION
The sandbox suite has been intermittently red for months, filed as an
unexplained flake (#101). It is not unexplained, and the warm-up step has been
printing the evidence in every failing run.

## What actually happens

Under the dev server, every route carrying a dynamic segment **nested inside
`[lang]`** stops resolving for a whole run — `[lang]/anime/[id]`,
`[lang]/reset-password/[token]`, `[lang]/u/[username]`,
`[lang]/seasonal/[season]/[year]`. Routes where `[lang]` is the only dynamic
segment keep serving, and so does a dynamic route outside it
(`/sitemaps/anime/sitemap/[id].xml`).

Counted off the failed attempt's `next-dev.log`: **three-segment paths went 0
for 19.**

Two PRs whose diffs do not overlap (#127, #128) both failed their first attempt
with the **same nine specs at the same line numbers**, and both went green on a
re-run with no code change. That pairing is what ruled out either diff.

Two signatures separate the broken state from the healthy one:

| | healthy | broken |
|---|---|---|
| every 200 in the log | carries a `generate-params` phase | — |
| every 404 in the log | — | has none |
| `/anime/0` | `404 in 942ms (next.js: 870ms)` — segment compiled, page bailed on `anilistId <= 0`, a product 404 | `404 in 42ms (next.js: 5ms)` — never compiled, the 404 came from the router |

Same status code, different origin. Reading the status alone cannot tell them
apart, which is why this survived so long.

## Why nothing caught it

**The warm-up.** It judged ten bare paths by one rule: anything not 5xx counted
as compiled. `warmed /reset-password/warmup -> 404` was printed, in the log, in
both failing runs — and skipped, because 404 is not 5xx. That page calls no API
and has no `notFound()` path, so a 404 there is impossible in a healthy stack.
Across 14 historical runs the line appeared three times and **all three attempts
failed**.

**The specs.** `not-found-status.spec.ts` asserts that missing ids answer 404, so
a run where *every* dynamic route 404s satisfies it — ten of its assertions
stayed green for the wrong reason. A suite of negative assertions is blind to a
total outage by construction. The one assertion that went red was the paired
positive case.

## What this changes

Each warmed route now declares the status it must answer. Two things follow that
the old rule could not express:

- `/library` and `/admin` assert 307. Nothing checked those before, so an auth
  redirect regressing to 200 would have been called compiled and waved on.
- `/anime/0` asserts 404 **and is documented as not diagnostic**, because it
  answers 404 in the healthy state too.

The positive probe for that route class goes in `globalSetup`, immediately after
`ensureAnimeDetail` seeds id 21. That position is load-bearing in both
directions: earlier is a genuine miss, and `loadDetail` fetches with
`revalidate: 60`, so Next would hand that 404 back for a minute after the row
existed.

Its failure message spends more lines than the check does, on purpose.
`globalSetup` throws before the browser login, so `.auth/user.json` is never
written and every spec afterwards reports a missing storage state. That louder,
repeated, wrong error is what a reader would otherwise chase — so the message
rules out the seed, rules out auth, names the real condition, and says outright
not to follow the next error in the log.

Retry and assertion are **one** concept, not two. Retrying only on 5xx and
asserting separately would fail on a transient 404 that a second request would
have resolved. Unifying them costs a bounded 30s on the first genuinely wrong
route before the job exits — still a minute in, rather than three minutes and
nine confusing specs.

## Verified by mutation

Against the loop text **extracted from this file** rather than a retyped copy,
driven by a stub server replaying real recorded statuses:

| state | this guard | the guard on main |
|---|---|---|
| healthy | exit 0 | exit 0 |
| `/reset-password/warmup` = 404 | **exit 1** | exit 0 ← the bug |
| `/library` = 200 (auth regressed) | **exit 1** | exit 0 ← also missed |

The second mutation earned its keep beyond pass/fail: the first draft hard-coded
the nested-dynamic-segment hint into the failure line, so an auth regression on
`/library` was told to go read about bundlers. The hint is now conditional on
the status actually being 404.

## What this does NOT do

It does not fix the underlying defect. The gate will still go red at roughly the
old rate — it will just say why, 35 seconds in.

A `--webpack` control group was run to test the obvious suspect (the sandbox is
the only place in the repo running Turbopack; `next build --webpack` is what
ships). Six runs, same commit, six separate refs:

| | Turbopack baseline | webpack, 6 runs |
|---|---|---|
| 404 fingerprint | 3 of 14 runs | **0 of 6** — genuinely gone |
| job duration | ~4 min | **8m08s – 9m23s** |
| suite result | intermittently red | **6 of 6 red** |

It trades the bundler defect for a worse one. Seven specs fail in **every** run
(auth ×3, locale-routing ×2, stale-tab ×2) — deterministic, not flake. The first
one names the mechanism: expected "邮箱或密码错误", got "邮箱格式不正确", i.e.
typing landed in the DOM but not in React state. That is the hydration race
#129 documented for `/search`; the other typing specs still do not wait for
`__reactFiber$`, and webpack's slower compile widens the window from occasional
to certain.

So the suite has been depending on the dev server being fast, and Turbopack's
speed was hiding it. That is its own problem and it is written up in TODOS.md
with the control-group numbers. The branch stays at `ci/sandbox-webpack-control`
for whoever picks it up; it is deliberately not merged here.

## Also in here

Two things already on main, both found while writing the TODOS entry:

- `not-found-status.spec.ts` carried the same wrong causal claim the TODOS entry
  did (the AniList-rate-limit 500 as "almost certainly the cause"). Corrected;
  the rate-limit defect itself is real and stays documented.
- `TODOS.md:203` held a bare `||||||| 6b31a3e` — a diff3 conflict marker
  committed into a file tracked in a public repo, rendering as literal garbage.
  One line, deleted.

## Test plan

- [x] `python3 -c "yaml.safe_load(...)"` — workflow parses, 16 steps, guard present
- [x] Mutation matrix above, three states × two guard versions
- [x] `bunx tsc --noEmit` in `e2e/` — 0 errors in `globalSetup.ts`. Note the
      directory has 16 pre-existing `noUncheckedIndexedAccess` errors unrelated
      to this change (byte-identical before and after), and `e2e` is not
      typechecked by CI at all — only `next-app` is.
- [x] `assertRoutingFixtureRenders` exercised against three live servers: 404 →
      the nested-segment message; dead port → the network message with `cause`
      preserved; 307→200 chain → no throw, confirming the final status is what
      is asserted
- [ ] This PR's own sandbox run — which is the real test of the guard, and may
      itself hit the defect it detects. If it fails at the warm-up naming
      `/reset-password/warmup`, that is the guard working, not a regression.