### PR TITLE
The error page blamed the upstream, and its retry button did nothing

### DIFF
--- a/next-app/src/app/[lang]/anime/[id]/error.tsx
+++ b/next-app/src/app/[lang]/anime/[id]/error.tsx
@@ -1,119 +1,30 @@
 "use client";
 
-// Route-level error boundary for /anime/[id]. Replaces the bare
-// "Internal Server Error" the user used to see when loadDetail() threw on
-// a transient upstream failure (e.g. go-api returning 502 "AniList
-// upstream error" while AniList rate-limits us during an SEO crawl, or a
-// 429 from go-api's own inbound limiter).
+// Route-level error boundary for /anime/[id].
 //
-// Unlike global-error.tsx (which replaces the whole document on a root
-// crash), this boundary only swaps the page segment — the Navbar and
-// layout chrome stay — so the user gets a coherent, retryable surface
-// instead of a blank 500. `reset()` re-runs the failed server render,
-// which usually succeeds on the second try once the upstream blip passes.
+// It exists so a throw inside this route swaps the page segment instead of the
+// whole document: the Navbar and layout chrome stay, and the visitor gets a
+// coherent surface rather than the bare "Internal Server Error" this route used
+// to answer with when loadDetail() hit a transient upstream failure — go-api
+// returning 502 "AniList upstream error" while AniList rate-limits us during an
+// SEO crawl, or a 429 from go-api's own inbound limiter.
+//
+// That is why it was written. It is not the failure it mostly catches: the 17
+// events on Sentry JAVASCRIPT-NEXTJS-N are client-side module-resolution
+// TypeErrors, all on this route. The copy and the retry button both used to be
+// written for the upstream story alone, and both were wrong for the common
+// case — see the note in RouteErrorBody, which is where the body now lives and
+// where that evidence is recorded.
+//
+// `reset` is deliberately not taken. Next still passes it; using it is what
+// made the retry button a no-op on the client-side failure.
 
-import * as Sentry from "@sentry/nextjs";
-import Link from "@/components/ui/LocaleLink";
-import { useEffect } from "react";
+import RouteErrorBody from "@/components/error/RouteErrorBody";
 
 interface DetailErrorProps {
   error: Error & { digest?: string };
-  reset: () => void;
 }
 
-const card = {
-  maxWidth: 460,
-  margin: "0 auto",
-  padding: "56px 24px 80px",
-  textAlign: "center" as const,
-};
-
-const primaryBtn = {
-  padding: "10px 22px",
-  borderRadius: 10,
-  border: "none",
-  background: "#0a84ff",
-  color: "#fff",
-  fontSize: 14,
-  fontWeight: 700,
-  cursor: "pointer",
-};
-
-const secondaryBtn = {
-  padding: "10px 22px",
-  borderRadius: 10,
-  border: "1px solid rgba(84,84,88,0.65)",
-  background: "transparent",
-  color: "rgba(235,235,245,0.75)",
-  fontSize: 14,
-  fontWeight: 600,
-  textDecoration: "none",
-  display: "inline-flex",
-  alignItems: "center",
-};
-
-export default function DetailError({ error, reset }: DetailErrorProps) {
-  useEffect(() => {
-    Sentry.captureException(error);
-  }, [error]);
-
-  return (
-    <main className="container" style={card}>
-      <div style={{ fontSize: 40, marginBottom: 16 }} aria-hidden="true">
-        🌥️
-      </div>
-      <h1
-        style={{
-          fontFamily: "var(--font-display)",
-          fontSize: 22,
-          color: "#ffffff",
-          marginBottom: 10,
-          lineHeight: 1.3,
-        }}
-      >
-        这一页暂时加载不出来
-      </h1>
-      <p
-        style={{
-          color: "rgba(235,235,245,0.60)",
-          fontSize: 14,
-          lineHeight: 1.7,
-          marginBottom: 28,
-        }}
-      >
-        可能是上游数据源一时繁忙。稍等片刻再试，通常很快就好。
-        <br />
-        <span style={{ color: "rgba(235,235,245,0.40)", fontSize: 13 }}>
-          Couldn&apos;t load this page right now — please try again.
-        </span>
-      </p>
-      <div
-        style={{
-          display: "flex",
-          gap: 12,
-          justifyContent: "center",
-          flexWrap: "wrap",
-        }}
-      >
-        <button type="button" onClick={() => reset()} style={primaryBtn}>
-          重试
-        </button>
-        <Link href="/" style={secondaryBtn}>
-          返回首页
-        </Link>
-      </div>
-      {error.digest && (
-        <p
-          style={{
-            marginTop: 24,
-            color: "rgba(235,235,245,0.25)",
-            fontSize: 11,
-            fontFamily: "'JetBrains Mono', monospace",
-          }}
-        >
-          {error.digest}
-        </p>
-      )}
-    </main>
-  );
+export default function DetailError({ error }: DetailErrorProps) {
+  return <RouteErrorBody error={error} scope="detail" />;
 }

--- a/next-app/src/app/[lang]/seasonal/[season]/[year]/error.tsx
+++ b/next-app/src/app/[lang]/seasonal/[season]/[year]/error.tsx
@@ -1,121 +1,24 @@
 "use client";
 
-// Route-level error boundary for /seasonal/[season]/[year]. Mirrors
-// anime/[id]/error.tsx: without a boundary here, any throw inside this
-// route's server render bubbles to the root and replaces the whole
-// document with a blank 500 (that was Sentry issue JAVASCRIPT-NEXTJS-2 —
-// 15 full-page crashes on /seasonal/summer/2026, users retrying two or
-// three times and giving up). With the boundary, only the page segment
-// swaps — Navbar and layout chrome stay — and `reset()` re-runs the
-// failed server render, which usually succeeds once the upstream blip
-// passes.
+// Route-level error boundary for /seasonal/[season]/[year].
 //
-// Sentry must be captured explicitly: an error.tsx boundary swallows the
-// error before the SDK's global handlers see it, so without this call a
-// regression here would be invisible.
+// Without one, a throw inside this route's server render bubbles to the root
+// and replaces the whole document with a blank 500. That was Sentry issue
+// JAVASCRIPT-NEXTJS-2: 15 full-page crashes on /seasonal/summer/2026, with
+// visitors retrying two or three times and giving up. With the boundary, only
+// the page segment swaps.
+//
+// The body is shared with /anime/[id] — see RouteErrorBody, including why the
+// retry button is a full reload rather than `reset()` or `unstable_retry()`.
+//
+// `reset` is deliberately not taken; Next still passes it.
 
-import * as Sentry from "@sentry/nextjs";
-import Link from "@/components/ui/LocaleLink";
-import { useEffect } from "react";
+import RouteErrorBody from "@/components/error/RouteErrorBody";
 
 interface SeasonalErrorProps {
   error: Error & { digest?: string };
-  reset: () => void;
 }
 
-const card = {
-  maxWidth: 460,
-  margin: "0 auto",
-  padding: "56px 24px 80px",
-  textAlign: "center" as const,
-};
-
-const primaryBtn = {
-  padding: "10px 22px",
-  borderRadius: 10,
-  border: "none",
-  background: "#0a84ff",
-  color: "#fff",
-  fontSize: 14,
-  fontWeight: 700,
-  cursor: "pointer",
-};
-
-const secondaryBtn = {
-  padding: "10px 22px",
-  borderRadius: 10,
-  border: "1px solid rgba(84,84,88,0.65)",
-  background: "transparent",
-  color: "rgba(235,235,245,0.75)",
-  fontSize: 14,
-  fontWeight: 600,
-  textDecoration: "none",
-  display: "inline-flex",
-  alignItems: "center",
-};
-
-export default function SeasonalError({ error, reset }: SeasonalErrorProps) {
-  useEffect(() => {
-    Sentry.captureException(error);
-  }, [error]);
-
-  return (
-    <main className="container" style={card}>
-      <div style={{ fontSize: 40, marginBottom: 16 }} aria-hidden="true">
-        🌥️
-      </div>
-      <h1
-        style={{
-          fontFamily: "var(--font-display)",
-          fontSize: 22,
-          color: "#ffffff",
-          marginBottom: 10,
-          lineHeight: 1.3,
-        }}
-      >
-        这一季的番剧暂时加载不出来
-      </h1>
-      <p
-        style={{
-          color: "rgba(235,235,245,0.60)",
-          fontSize: 14,
-          lineHeight: 1.7,
-          marginBottom: 28,
-        }}
-      >
-        可能是上游数据源一时繁忙。稍等片刻再试，通常很快就好。
-        <br />
-        <span style={{ color: "rgba(235,235,245,0.40)", fontSize: 13 }}>
-          Couldn&apos;t load this season right now — please try again.
-        </span>
-      </p>
-      <div
-        style={{
-          display: "flex",
-          gap: 12,
-          justifyContent: "center",
-          flexWrap: "wrap",
-        }}
-      >
-        <button type="button" onClick={() => reset()} style={primaryBtn}>
-          重试
-        </button>
-        <Link href="/" style={secondaryBtn}>
-          返回首页
-        </Link>
-      </div>
-      {error.digest && (
-        <p
-          style={{
-            marginTop: 24,
-            color: "rgba(235,235,245,0.25)",
-            fontSize: 11,
-            fontFamily: "'JetBrains Mono', monospace",
-          }}
-        >
-          {error.digest}
-        </p>
-      )}
-    </main>
-  );
+export default function SeasonalError({ error }: SeasonalErrorProps) {
+  return <RouteErrorBody error={error} scope="seasonal" />;
 }

--- a/next-app/src/components/error/RouteErrorBody.render.test.tsx
+++ b/next-app/src/components/error/RouteErrorBody.render.test.tsx
@@ -47,7 +47,14 @@ const SRC = join(import.meta.dir, "..", "..");
  * string literal, and none of the three files it reads contains one.
  */
 function codeOnly(src: string): string {
-  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    // Trailing comments too, not just whole-line ones. The first version
+    // anchored at ^, so `something(); // reset()` kept the prose and any
+    // assertion built on this could be satisfied by a comment sitting to the
+    // right of real code. `(?<!:)` spares `https://` in a string literal,
+    // which is the only other `//` these three files can contain.
+    .replace(/(?<!:)\/\/.*$/gm, "");
 }
 
 function err(digest?: string): Error & { digest?: string } {
@@ -223,9 +230,9 @@ describe("the retry button reloads rather than resetting", () => {
     join(SRC, "components/error/RouteErrorBody.tsx"),
     "utf8",
   );
-  const BOUNDARIES = [
-    "app/[lang]/anime/[id]/error.tsx",
-    "app/[lang]/seasonal/[season]/[year]/error.tsx",
+  const BOUNDARIES: Array<{ file: string; scope: ErrorScope }> = [
+    { file: "app/[lang]/anime/[id]/error.tsx", scope: "detail" },
+    { file: "app/[lang]/seasonal/[season]/[year]/error.tsx", scope: "seasonal" },
   ];
 
   test("the source this suite reads is the real component", () => {
@@ -238,17 +245,47 @@ describe("the retry button reloads rather than resetting", () => {
     expect(codeOnly(BODY_SRC)).toContain("window.location.reload()");
   });
 
+  test("the boundary still reports to Sentry", () => {
+    // An error.tsx boundary swallows the error before the SDK's global
+    // handlers see it, so this call is the only reason either route is
+    // observable at all — the issue that motivated this whole change is known
+    // only because it was there.
+    //
+    // Deleting the effect passes everything else: 33 green, and `tsc --noEmit`
+    // stays clean too, because tsconfig.json does not set noUnusedLocals, so
+    // even the orphaned `import * as Sentry` raises nothing. Sentry would go
+    // quiet, which reads as "fixed".
+    expect(codeOnly(BODY_SRC)).toContain("Sentry.captureException(error)");
+  });
+
   test("no boundary takes reset out of its props", () => {
     // `reset()` re-renders the children without re-fetching them (Next's own
     // docs), so on the client-side module error it reproduces the same throw.
     // Taking the prop is the first step back to that, and it is a one-word
     // edit; this is the thing that notices.
-    for (const rel of BOUNDARIES) {
-      const code = codeOnly(readFileSync(join(SRC, rel), "utf8"));
+    for (const { file } of BOUNDARIES) {
+      const code = codeOnly(readFileSync(join(SRC, file), "utf8"));
       expect(code).toContain("RouteErrorBody");
-      expect(code).not.toMatch(/\breset\s*[,:}]/);
+      // `\??` because `reset?: () => void` is the shape a props interface
+      // would actually use, and without it the guard reads right past the
+      // one declaration most likely to be written.
+      expect(code).not.toMatch(/\breset\s*\??\s*[,:}]/);
       expect(code).not.toMatch(/\breset\s*\(\s*\)/);
     }
     expect(codeOnly(BODY_SRC)).not.toMatch(/\breset\s*\(\s*\)/);
+  });
+
+  test("each boundary passes its own scope", () => {
+    // Nothing else notices this. Both files render, both produce a coherent
+    // error page, and the seasonal route apologises for "this page" — the one
+    // sentence that distinguishes them, wrong, with every test green. Swapping
+    // the two literals is a plausible copy-paste and was undetectable until
+    // this assertion.
+    for (const { file, scope } of BOUNDARIES) {
+      const code = codeOnly(readFileSync(join(SRC, file), "utf8"));
+      expect(code).toContain(`scope="${scope}"`);
+      const other = scope === "detail" ? "seasonal" : "detail";
+      expect(code).not.toContain(`scope="${other}"`);
+    }
   });
 });

--- a/next-app/src/components/error/RouteErrorBody.render.test.tsx
+++ b/next-app/src/components/error/RouteErrorBody.render.test.tsx
@@ -1,0 +1,254 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import RouteErrorBody, {
+  BACK_HOME,
+  BODY,
+  RELOAD,
+  TITLE,
+  type ErrorScope,
+} from "./RouteErrorBody";
+import { LANGS, type Lang } from "../../lib/i18n/lang";
+import { LanguageProvider } from "../../lib/lang-client";
+
+// renderToStaticMarkup from react-dom/server, following
+// ActivitySection.render.test.tsx: no jsdom, no testing-library, no new
+// dependency.
+//
+// Every language is rendered for real, by wrapping the component in
+// LanguageProvider — useLang() reads the provider's value first and only falls
+// back to usePathname() when there is no provider to read. An earlier version
+// of this file asserted the other two languages off the copy tables alone and
+// said in a comment that useLang() had "no seam to inject a locale through".
+// That was wrong, and it mattered: table assertions prove the strings exist,
+// not that the component reaches for the right one. A component that read
+// TITLE[scope].zh unconditionally would have passed the whole suite.
+//
+// What still cannot be reached by rendering is the retry button's BEHAVIOUR.
+// renderToStaticMarkup attaches no handlers, and which function that handler
+// calls is the entire point of this change, so it is asserted against the
+// source text at the bottom of this file. That is a weaker instrument than a
+// click and it is the one available here; it is written to fail on the
+// regression rather than on a reformat, and it was checked by making the
+// regression and watching it go red.
+
+const SRC = join(import.meta.dir, "..", "..");
+
+/**
+ * Source with comments removed, so an assertion about what the CODE does is
+ * not answered by prose that happens to mention the same call.
+ *
+ * Written after the first version of the `reset` assertion below failed on the
+ * sentence explaining why `reset` is avoided — the comment is the point, and a
+ * guard that forbids naming the thing it guards against is a guard nobody can
+ * document around. Naive on purpose: it does not understand `//` inside a
+ * string literal, and none of the three files it reads contains one.
+ */
+function codeOnly(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+function err(digest?: string): Error & { digest?: string } {
+  return Object.assign(new Error("boom"), digest ? { digest } : {});
+}
+
+/** The component as a reader in `lang` sees it. */
+function renderIn(lang: Lang, scope: ErrorScope, digest?: string): string {
+  return renderToStaticMarkup(
+    <LanguageProvider lang={lang}>
+      <RouteErrorBody error={err(digest)} scope={scope} />
+    </LanguageProvider>,
+  );
+}
+
+const SCOPES: ErrorScope[] = ["detail", "seasonal"];
+
+describe("RouteErrorBody renders in every language", () => {
+  for (const lang of LANGS) {
+    for (const scope of SCOPES) {
+      test(`${lang} / ${scope}: headline, body, reload button, way home`, () => {
+        const html = renderIn(lang, scope);
+        expect(html).toContain(TITLE[scope][lang]);
+        expect(html).toContain(BODY[lang]);
+        expect(html).toContain(RELOAD[lang]);
+        expect(html).toContain(BACK_HOME[lang]);
+        expect(html).toContain("<button");
+        expect(html).toContain('href="/"');
+      });
+    }
+
+    test(`${lang}: no other language leaks in`, () => {
+      // The failure this catches is a component that resolves the locale once
+      // and then indexes a table with a constant — every string present, every
+      // string wrong for two readers out of three.
+      const html = renderIn(lang, "detail");
+      for (const other of LANGS) {
+        if (other === lang) continue;
+        expect(html).not.toContain(TITLE.detail[other]);
+        expect(html).not.toContain(BODY[other]);
+      }
+    });
+  }
+
+  test("without a provider it still renders, in the default language", () => {
+    // Error boundaries sit under the root layout, so LanguageProvider is
+    // normally above them. "Normally" is not "always" — useLang() falls back to
+    // the path-derived locale, which with no router resolves to zh. Pinned
+    // because the fallback throwing would turn an error page into a blank one.
+    const html = renderToStaticMarkup(
+      <RouteErrorBody error={err()} scope="detail" />,
+    );
+    expect(html).toContain(TITLE.detail.zh);
+  });
+});
+
+describe("RouteErrorBody renders the right thing", () => {
+  test("the two scopes do not share a headline", () => {
+    // The scope prop is the only thing distinguishing the two boundaries. If
+    // it stopped being read, both routes would still render — with the wrong
+    // one of these two sentences, and nothing else would fail.
+    const detail = renderIn("zh", "detail");
+    expect(detail).toContain(TITLE.detail.zh);
+    expect(detail).not.toContain(TITLE.seasonal.zh);
+  });
+
+  test("the digest shows when there is one and is absent when there is not", () => {
+    // The digest is what matches a report to the server-side log. It was
+    // conditional in both files this replaced; keep it that way rather than
+    // rendering an empty mono line on client-side errors, which carry none.
+    expect(renderIn("zh", "detail", "a1b2c3d4")).toContain("a1b2c3d4");
+    expect(renderIn("zh", "detail")).not.toContain("JetBrains Mono");
+  });
+
+  test("the copy does not blame the upstream any more", () => {
+    // The sentence this replaced named a cause the page cannot know, and named
+    // the wrong one for 17 of 17 recorded events. Pinned so a well-meaning copy
+    // edit does not restore it.
+    for (const lang of LANGS) {
+      expect(renderIn(lang, "detail")).not.toContain("上游");
+      expect(BODY[lang]).not.toContain("上游");
+      expect(BODY[lang].toLowerCase()).not.toContain("upstream");
+    }
+  });
+
+  test("no straight apostrophe survives into the English copy", () => {
+    // React escapes ' to &#x27;. Invisible to a reader, and it broke the first
+    // version of the assertions above — the copy uses U+2019 instead, and this
+    // is what stops the next edit from typing the straight one back.
+    const english = [
+      TITLE.detail.en,
+      TITLE.seasonal.en,
+      BODY.en,
+      RELOAD.en,
+      BACK_HOME.en,
+    ];
+    for (const s of english) expect(s).not.toContain("'");
+  });
+});
+
+describe("RouteErrorBody copy covers every language", () => {
+  test("every table has a non-empty entry for every LANG", () => {
+    // Record<Lang, string> already makes a missing language a compile error.
+    // This catches the other half — an entry that exists and says nothing,
+    // which tsc is happy with and a visitor is not.
+    const tables: Array<[string, Record<string, string>]> = [
+      ["TITLE.detail", TITLE.detail],
+      ["TITLE.seasonal", TITLE.seasonal],
+      ["BODY", BODY],
+      ["RELOAD", RELOAD],
+      ["BACK_HOME", BACK_HOME],
+    ];
+    const empty: string[] = [];
+    for (const [name, table] of tables) {
+      for (const lang of LANGS) {
+        if (!table[lang] || table[lang].trim() === "")
+          empty.push(`${name}.${lang}`);
+      }
+    }
+    expect(empty).toEqual([]);
+  });
+
+  test("the three languages actually differ", () => {
+    // A copy-paste that left zh-Hant holding the Simplified string would pass
+    // every check above. The Traditional and Simplified forms of these
+    // particular sentences differ in at least one character each, so equality
+    // means somebody skipped the conversion.
+    for (const table of [TITLE.detail, TITLE.seasonal, BODY, RELOAD, BACK_HOME]) {
+      expect(table.zh).not.toBe(table["zh-Hant"]);
+      expect(table.zh).not.toBe(table.en);
+    }
+  });
+
+  // Mirrors locales/hantVocabulary.test.ts, which runs this check over the
+  // dictionaries. These strings live in a .tsx and so are outside its reach —
+  // the standing cost of keeping copy out of the dictionaries, paid here rather
+  // than left unpaid.
+  const SIMPLIFIED_ONLY: Array<[string, string]> = [
+    ["页", "頁"],
+    ["载", "載"],
+    ["剧", "劇"],
+    ["试", "試"],
+    ["过", "過"],
+    ["别", "別"],
+    ["会", "會"],
+    ["还", "還"],
+    ["来", "來"],
+    ["个", "個"],
+    ["间", "間"],
+    ["题", "題"],
+    ["关", "關"],
+    ["数", "數"],
+  ];
+
+  for (const [simp, trad] of SIMPLIFIED_ONLY) {
+    test(`zh-Hant copy contains no ${simp} (want ${trad})`, () => {
+      const hits = [
+        ["TITLE.detail", TITLE.detail["zh-Hant"]],
+        ["TITLE.seasonal", TITLE.seasonal["zh-Hant"]],
+        ["BODY", BODY["zh-Hant"]],
+        ["RELOAD", RELOAD["zh-Hant"]],
+        ["BACK_HOME", BACK_HOME["zh-Hant"]],
+      ]
+        .filter(([, value]) => value.includes(simp))
+        .map(([name, value]) => `${name}: ${value}`);
+      expect(hits).toEqual([]);
+    });
+  }
+});
+
+describe("the retry button reloads rather than resetting", () => {
+  const BODY_SRC = readFileSync(
+    join(SRC, "components/error/RouteErrorBody.tsx"),
+    "utf8",
+  );
+  const BOUNDARIES = [
+    "app/[lang]/anime/[id]/error.tsx",
+    "app/[lang]/seasonal/[season]/[year]/error.tsx",
+  ];
+
+  test("the source this suite reads is the real component", () => {
+    // Guards the guard. A moved or renamed file would make every assertion
+    // below read something else, or an empty string, and pass.
+    expect(BODY_SRC).toContain("export default function RouteErrorBody");
+  });
+
+  test("the handler calls window.location.reload()", () => {
+    expect(codeOnly(BODY_SRC)).toContain("window.location.reload()");
+  });
+
+  test("no boundary takes reset out of its props", () => {
+    // `reset()` re-renders the children without re-fetching them (Next's own
+    // docs), so on the client-side module error it reproduces the same throw.
+    // Taking the prop is the first step back to that, and it is a one-word
+    // edit; this is the thing that notices.
+    for (const rel of BOUNDARIES) {
+      const code = codeOnly(readFileSync(join(SRC, rel), "utf8"));
+      expect(code).toContain("RouteErrorBody");
+      expect(code).not.toMatch(/\breset\s*[,:}]/);
+      expect(code).not.toMatch(/\breset\s*\(\s*\)/);
+    }
+    expect(codeOnly(BODY_SRC)).not.toMatch(/\breset\s*\(\s*\)/);
+  });
+});

--- a/next-app/src/components/error/RouteErrorBody.tsx
+++ b/next-app/src/components/error/RouteErrorBody.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+// The one body behind every route-level error boundary.
+//
+// It replaced two files — app/[lang]/anime/[id]/error.tsx and
+// app/[lang]/seasonal/[season]/[year]/error.tsx — that were the same 120 lines
+// twice over, differing only in one noun inside one sentence. Both had drifted
+// into being wrong in the same two ways, which is the usual argument for
+// keeping one copy: a fix applied to one of them would have left the other.
+//
+// ── What was wrong, and what the evidence was ─────────────────────────────
+//
+// 1. The copy blamed the upstream. It read "可能是上游数据源一时繁忙" —
+//    the data source is busy — and that is not what visitors were hitting.
+//    Every one of the 17 events on Sentry JAVASCRIPT-NEXTJS-N between
+//    2026-08-07 and 2026-08-30 is a CLIENT-side TypeError:
+//
+//      Cannot read properties of undefined (reading 'call')
+//        at __webpack_require__  (webpack-<hash>.js:1:144)
+//
+//    thrown while React resolves a client module during render, with
+//    `handled: yes` — caught right here. Nothing upstream is involved. The
+//    sentence named a cause the page could not know, and named the wrong one.
+//
+//    The boundary does also catch the failure it was originally written for
+//    (loadDetail() throwing on a go-api 502 while AniList rate-limits an SEO
+//    crawl), so the copy cannot swing to blaming the browser either. It now
+//    says what is true for both — that this did not load — and then says the
+//    thing that actually works.
+//
+// 2. The retry button could not fix the error it was most often shown for.
+//    It called `reset()`, which Next documents as clearing the error state and
+//    re-rendering the children "without re-fetching the contents"
+//    (node_modules/next/dist/docs/01-app/03-api-reference/03-file-conventions/
+//    error.md, under `reset`). Re-rendering the same tree over the same broken
+//    module graph reproduces the same TypeError, so the visible behaviour of
+//    "重试" on the client-side failure was: nothing changes. The Sentry bursts
+//    are consistent with that — 3 events in 47 seconds on 2026-08-30, on three
+//    different anime, ending when the visitor gave up rather than when
+//    anything recovered.
+//
+// ── Why the button is a full reload, and not `unstable_retry()` ───────────
+//
+// Next 16.2 added `unstable_retry`, and the same docs page says to prefer it
+// over `reset()` in most cases: it re-FETCHES and re-renders, so it does fix
+// the transient-upstream case properly. It is still not the right primary
+// action here, because it reuses the JavaScript already in the page. When the
+// failure is a module missing from `__webpack_modules__`, re-fetching the RSC
+// payload hands the same module ids to the same runtime and fails again.
+//
+// A full document load is the only action that clears BOTH classes: the
+// server-side blip gets a new request, and the client-side one gets a new
+// module graph. It costs one page load, and on /anime/* that is an ISR page
+// behind Cloudflare, so it is close to free. One button that always works
+// beats two buttons that each work half the time.
+//
+// If a soft retry is ever wanted back, `unstable_retry` is the prop to take —
+// NOT `reset`. Escalating (soft first, hard on the second click) needs state
+// that survives a failed retry, and whether this component keeps its state
+// across one is unverified; do not assume it does.
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect, type CSSProperties } from "react";
+
+import Link from "@/components/ui/LocaleLink";
+import { type Lang } from "@/lib/i18n/lang";
+import { useLang } from "@/lib/lang-client";
+
+/**
+ * Which route is apologising. Only the headline changes; everything else is
+ * shared, because everything else is true of any route that failed to render.
+ */
+export type ErrorScope = "detail" | "seasonal";
+
+// Per-language tables rather than dictionary lookups, following
+// app/[lang]/_components/NotFoundBody.tsx — the site's other "something has
+// already gone wrong" surface, which chose the same thing for the same reason.
+//
+// t() returns the KEY ITSELF on a miss, silently (see lib/i18n.ts), so a copy
+// key that reaches only zh-spa.js renders as `errors.routeErrorTitle` in the
+// browser. spaDictCoverage.test.ts is the gate against that, and it is a test
+// somebody has to run. A Record<Lang, string> is a compile error instead, and
+// an error page is the worst place on the site to discover a missing key.
+//
+// The cost is real and worth naming: these strings are not where a translator
+// looks. Two surfaces is the whole exception, and it stops here.
+export const TITLE: Record<ErrorScope, Record<Lang, string>> = {
+  detail: {
+    zh: "这一页没能加载出来",
+    // Curly apostrophe, not "didn't". React escapes a straight one to &#x27;
+    // in the rendered HTML — invisible to a reader, and a trap for any test
+    // that asserts on markup; the first version of the suite failed on exactly
+    // that. U+2019 is also the correct typography.
+    en: "This page didn’t load",
+    "zh-Hant": "這一頁沒能載入",
+  },
+  seasonal: {
+    zh: "这一季的番剧没能加载出来",
+    en: "This season didn’t load",
+    "zh-Hant": "這一季的番劇沒能載入",
+  },
+};
+
+export const BODY: Record<Lang, string> = {
+  zh: "刷新一次通常就好。如果还是不行，过一会儿再来，或者先回首页看看别的。",
+  en: "Reloading usually fixes it. If it keeps happening, try again in a bit, or head back to the homepage.",
+  "zh-Hant": "重新整理一次通常就好。如果還是不行，等一下再試試，或者先回首頁看看別的。",
+};
+
+export const RELOAD: Record<Lang, string> = {
+  zh: "刷新页面",
+  en: "Reload",
+  "zh-Hant": "重新整理",
+};
+
+export const BACK_HOME: Record<Lang, string> = {
+  zh: "回首页",
+  en: "Back home",
+  "zh-Hant": "回首頁",
+};
+
+const s = {
+  card: {
+    maxWidth: 460,
+    margin: "0 auto",
+    padding: "56px 24px 80px",
+    textAlign: "center",
+  } as CSSProperties,
+  glyph: { fontSize: 40, marginBottom: 16 } as CSSProperties,
+  title: {
+    fontFamily: "var(--font-display)",
+    fontSize: 22,
+    color: "#ffffff",
+    marginBottom: 10,
+    lineHeight: 1.3,
+  } as CSSProperties,
+  body: {
+    color: "rgba(235,235,245,0.60)",
+    fontSize: 14,
+    lineHeight: 1.7,
+    marginBottom: 28,
+  } as CSSProperties,
+  actions: {
+    display: "flex",
+    gap: 12,
+    justifyContent: "center",
+    flexWrap: "wrap",
+  } as CSSProperties,
+  primaryBtn: {
+    padding: "10px 22px",
+    borderRadius: 10,
+    border: "none",
+    background: "#0a84ff",
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: 700,
+    cursor: "pointer",
+  } as CSSProperties,
+  secondaryBtn: {
+    padding: "10px 22px",
+    borderRadius: 10,
+    border: "1px solid rgba(84,84,88,0.65)",
+    background: "transparent",
+    color: "rgba(235,235,245,0.75)",
+    fontSize: 14,
+    fontWeight: 600,
+    textDecoration: "none",
+    display: "inline-flex",
+    alignItems: "center",
+  } as CSSProperties,
+  digest: {
+    marginTop: 24,
+    color: "rgba(235,235,245,0.25)",
+    fontSize: 11,
+    fontFamily: "'JetBrains Mono', monospace",
+  } as CSSProperties,
+};
+
+interface RouteErrorBodyProps {
+  error: Error & { digest?: string };
+  scope: ErrorScope;
+}
+
+export default function RouteErrorBody({ error, scope }: RouteErrorBodyProps) {
+  const { lang } = useLang();
+
+  // Sentry has to be told explicitly. An error.tsx boundary swallows the error
+  // before the SDK's global handlers ever see it, so without this call a
+  // regression in either route would be invisible — and this issue is only
+  // known at all because the two files it replaced each made this call.
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <main className="container" style={s.card}>
+      <div style={s.glyph} aria-hidden="true">
+        🌥️
+      </div>
+      <h1 style={s.title}>{TITLE[scope][lang]}</h1>
+      <p style={s.body}>{BODY[lang]}</p>
+      <div style={s.actions}>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          style={s.primaryBtn}
+        >
+          {RELOAD[lang]}
+        </button>
+        <Link href="/" prefetch={false} style={s.secondaryBtn}>
+          {BACK_HOME[lang]}
+        </Link>
+      </div>
+      {error.digest && <p style={s.digest}>{error.digest}</p>}
+    </main>
+  );
+}


### PR DESCRIPTION
## What this is

The route error boundary that `/anime/[id]` and `/seasonal/[season]/[year]` share. Two files, the same 120 lines twice, wrong in the same two ways.

## Why

Sentry `JAVASCRIPT-NEXTJS-N` — 17 events since 2026-08-07, all on `/anime/:id`:

```
TypeError: Cannot read properties of undefined (reading 'call')
  at __webpack_require__  (webpack-<hash>.js:1:144)
```

thrown while React resolves a client module, `handled: yes` — caught by this boundary. So:

**The copy named the wrong cause.** It said 「可能是上游数据源一时繁忙」. Nothing upstream is involved in any of the 17. The boundary *does* also catch the failure it was written for (a go-api 502 during an SEO crawl), so the copy can't swing to blaming the browser either — it now says what is true for both, and then says the thing that works.

**The retry button couldn't fix the error it was mostly shown for.** It called `reset()`, which Next documents as re-rendering the children *"without re-fetching the contents"*. Re-rendering the same tree over the same broken module graph throws the same error. On the client-side failure, pressing 重试 did nothing. The bursts look like that — 3 events in 47 s on 2026-08-30 across three different anime, ending when the visitor gave up.

## The button is a full reload

Not `unstable_retry()`, which Next 16.2 added and its docs prefer over `reset()`. It does re-fetch, so it fixes the upstream case properly — but it reuses the JavaScript already in the page, so it cannot fix a module missing from `__webpack_modules__`. A document load clears both classes. On `/anime/*` that is an ISR page behind Cloudflare.

## Localisation

Three locales, via `Record<Lang, string>` tables rather than the dictionaries — following `NotFoundBody.tsx`, the site's other "something already went wrong" surface. `t()` returns the key itself on a miss, silently; an error page is the worst place to find that out. The cost is that these strings aren't where a translator looks, and two surfaces is the whole exception.

## Verification

Browser, production build, driving the real failure (a client-side throw during hydration on `/anime/:id`) rather than an upstream one:

| | zh | en | zh-Hant |
|---|---|---|---|
| `<html lang>` | `zh-CN` | `en` | `zh-Hant` |
| headline | 这一页没能加载出来 | This page didn't load | 這一頁沒能載入 |
| button | 刷新页面 | Reload | 重新整理 |
| home link | `/` | `/en` | `/zh-Hant` |

Navbar survives (route boundary, not a root crash), button is hydrated, no overflow at 1280 or 390. Clicking it **replaces the document** — a stamp set on `window` before the click is gone after, which is exactly what `reset()` would have preserved.

35 unit tests. Every guard mutation-tested: hardcoding the locale turns six red, swapping a boundary's `scope` turns one red, reinstating `reset` turns one red, deleting the Sentry call turns one red, hiding the reload call in a trailing comment turns one red. `tsc`, `eslint`, `next build --webpack`, full suite (1896) green.

## Not changed, worth knowing

When the throw happens during the **initial server render**, the boundary never appears — Next answers a bare 21-byte `Internal Server Error`. The boundary is reached on client-side render errors, which is what all 17 Sentry events are. Found while verifying this; it is its own piece of work.