### PR TITLE
Fill episode titles from dandanplay, once by hand and then on a timer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,12 @@ JWT_REFRESH_EXPIRES_IN=7d
 DANDANPLAY_APP_ID=<your-dandanplay-app-id>
 DANDANPLAY_APP_SECRET=<your-dandanplay-app-secret>
 
+# Gates the airing-show episode-title sweep (river worker
+# `episode_titles_releasing`). Absent or falsey = disabled, which is the
+# intended state until a release is verified. Read at work time; for an
+# immediate stop without a restart, pause the `episode_titles` queue.
+EPISODE_TITLES_SWEEP_ENABLED=false
+
 # ─── v2.0.x (Express + Mongo) — still drives `main` and prod ───
 MONGODB_URI=mongodb://localhost:27017/animego
 PORT=5001

--- a/.env.production.template
+++ b/.env.production.template
@@ -115,6 +115,22 @@ GMAIL_APP_PASSWORD=REPLACE_ME_gmail_app_password_16_chars
 DANDANPLAY_APP_ID=REPLACE_ME_dandanplay_app_id
 DANDANPLAY_APP_SECRET=REPLACE_ME_dandanplay_app_secret
 
+# [E]  Gates the airing-show episode-title sweep (river worker
+# `episode_titles_releasing`). Absent or falsey = the worker returns
+# immediately without touching the network, which is the intended state for a
+# first deploy; set to `true` once the release is verified.
+#
+# Read at WORK time, not at registration, so a restart with it off also
+# silences anything river already had queued. Changing it needs a restart --
+# for an immediate stop without a deploy, pause the `episode_titles` queue
+# instead; the sweep has its own queue precisely so that lever exists.
+#
+# The sweep asks dandanplay about shows whose status is RELEASING and whose
+# last attempt is older than 26h, at most 200 per pass, every 6h. It shares the
+# one 800ms dandanplay token bucket with user-facing /match, so leaving it on
+# costs a small, bounded slice of that budget.
+EPISODE_TITLES_SWEEP_ENABLED=false
+
 # ============================================================================
 # 5. Sentry (error reporting)
 # ============================================================================

--- a/TODOS.md
+++ b/TODOS.md
@@ -538,3 +538,46 @@
 - **Cons:** smoke 跑在 `$COMPOSE up -d` **之后**,所以「失败」时新版已经在线且没有回滚。要么接受「大声报错但不回滚」(仍比静默好),要么顺带接上回滚 —— 后者就不是小改动了。`scripts/p9-rollback.sh` 已存在,可以先看它能不能直接接。
 - **Context:** 2026-08-30 的 `/plan-eng-review` 中发现:外部声音指出 smoke 在 `up -d` 之后且不 gate,由读脚本确认。⚠️ 注意别顺手把它改成 `set -e` 直接退出 —— 那会在「新版已上线」的状态下留下一个半完成的部署,比现在更难收拾;先决定失败语义再动手。
 - **Depends on / blocked by:** 无。纯 shell,与任何代码改动零交集。
+
+## `bangumi_version` 是单向棘轮，version≥2 的行没有任何重跑路径
+
+**What** — 给富化流水线加一条「让一行重新过一遍 V1→V2→V3」的入队路径，不依赖把 `bangumi_version` 手动改回 0。
+
+**Why** — 现在所有 V1 生产者（orphan scan、`/search` 与 `/schedule` 的 upsert 后置、warm_season、admin ReEnrich(0)）都过滤 `bangumi_version = 0`，而 `UpsertAnimeCache` 在冲突时**刻意不覆写**版本号（`go-api/internal/db/queries/anime_cache.sql:253-258`）。V2 一跑完把版本推到 2，这一行就永久掉出所有扫描；V2 本身又只由 V1 绑定成功后的 `chainV2`（`bangumi_v1.go:264`）链式触发，没有任何周期任务生产 V2 作业。结果是**那一次跑空了就永远是空的**——`bangumi_v2.go:344` 把 episodes fetch 错误记个 warn 就 `return nil`，作业标记完成，river 不重试，而版本已经推进。
+
+**Context** — 2026-09-02 分集标题方案评审中查出。当时的处理是**绕过**而不是修：存量用 `cmd/bgmbackfill` 的一次性 CLI 补，而不是让流水线自己重跑。但同一个棘轮对 V2/V3 写的**每一个**字段都成立——characters、bangumi_score、title_chinese、分集标题——所以下一个「某个富化字段大面积缺失」的问题会再撞一次，而且每次都得再写一个一次性 CLI。
+实测规模：1,784 行有 bgm_id 却零分集标题，其中 1,522 行任何自动任务都够不到（772 行卡在 v1、3 行 v2、747 行 v3）。
+⚠️ 动它之前先确认真实的 `MaxAttempts`：三个 worker 的头注释都写「river 默认 3 次」是**错的**，v0.37.1 的 `MaxAttemptsDefault` 是 **25**，配 attempt^4 退避约 20 天。
+
+**Depends on / blocked by** — 无。但与 `## 分割放送会 50% 概率绑错` 那条同属富化流水线，建议一起看。
+
+## id-map 一致并不排除「范围不符」，而它挡着分集网格取 max
+
+**What** — 在绑定校验里加第三个信号：上游正片集数与 `anime_cache.episodes` 的量级比对。现有两个信号（标题相似度、季号标记）和 id-map 都答不了这个问题。
+
+**Why** — id-map 回答的是「这个 anilist 条目对应哪个 bgm subject」，**不是**「这个 subject 的集列表就是这个条目的集列表」。一个 3 集的 ONA 可以合法地映射到整部正片的 subject 上，于是我们把正片几百集的标题写进了这个小条目。实测 `anime_episode_titles.episode > anime_cache.episodes` 的有 776 部：`+6..24` 那档 **335 部**抽样全是 ONA/SP 绑到正片 subject（`我的幸福婚姻` ONA 写着 3 集库里 12 行；`机动战士SD高达` SPECIAL 3 集 17 行）；溢出 >100 集的 18 部里有 **9 部是 id-map 确认的绑定**——也就是说权威映射表点头了，数据仍然是错的。
+
+**Context** — 2026-09-02 评审实测。⚠️ **这条阻塞分集标题方案里的 T9**（`next-app/src/components/anime/episodeGridSkeleton.ts:101` 的 authoritative 分支取 max）：不先解决范围不符，取 max 会把这批陈旧溢出重新渲染出来，`与莫芬一起` 那种 5 集 ONA 会被画出 3,528 个格子。所需信号很便宜——上游集数本来就在同一个响应里，不额外花请求。
+⚠️ 阈值要小心：实测溢出量是 +1 到 +820 的**连续谱**，`+1` 那档 164 部多是 AniList 少算一集的真实情况（`格斗美神·武龙` 25 集 / 上游 26 集，行是密的），不能一刀切。
+
+**Depends on / blocked by** — 无。做完它 T9 才能安全上线。
+
+## dandanplay client 把所有 4xx 压成「没有数据」
+
+**What** — 让 `go-api/internal/dandanplay/client.go:386` 区分 401/403（凭据或授权问题）、404（该资源确实不存在）、其他 4xx，而不是统一返回 `(nil, nil)`。
+
+**Why** — 现在调用方拿到的「没有数据」同时可能意味着「这个 subject 上游确实没有」「AppId/AppSecret 失效了」「请求被拒了」。前者是正常的数据稀疏，后两者是需要人介入的故障，而它们在日志和返回值上完全一样。
+
+**Context** — 2026-09-02 评审中由外部声音（Codex）指出，读代码确认。**严重度不高**：分集标题回填走的是人工跑的 CLI，凭据失效会让整份报告 100% EMPTY，跑的人一眼就能看出来；真正无人值守的只有 RELEASING 那个小 sweep（实测 TV 52 部），它静默空转的代价是「缺口不修但没人知道」。弹幕匹配路径（`match.go` / `handlers.go`）同样分不出这三种，改一次两边都受益。
+
+**Depends on / blocked by** — 无。但它动的是共享 client，回归面包含现有弹幕功能。
+
+## 绑定覆盖率：811 部死 bgm_id + 5,222 部压根没有 bgm_id
+
+**What** — 清理指向已不存在 subject 的绑定，并提高无绑定行的匹配覆盖率。
+
+**Why** — 这是分集标题缺口里最大的一块，但它是**绑定问题不是富化问题**。5,222 部没有 bgm_id，对应 32,471 个集位完全没有上游可取；另有 811 部卡在 `bangumi_version = 1`，抽样 12 个 bgm_id **12/12 上游返回 404**（`/v0/subjects/207567` 明说 resource has been removed），811 行里只有 1 行在 `bgm_id_map` 里有任何条目——是 `fuzzy_high` 绑到了不存在的 subject id。这批绑定不但补不回一条标题，还在每轮富化里静默消耗上游配额。
+
+**Context** — 2026-09-02 评审实测。这 811 部创建集中在 2026-05-31～06-08，格式以 OVA/ONA 为主。解决后分集标题、中文简介、评分三个缺口一起受益。注意 `bgm_id_map` 是从 `data/anilist_bgm_map.json` 灌进来的**输入**表不是匹配器产物，所以「改进匹配器」和「扩充 map」是两条不同的路。
+
+**Depends on / blocked by** — 无。与 `## 分割放送会 50% 概率绑错` 同属绑定质量，建议合并考虑。

--- a/go-api/cmd/bgmbackfill/episode_titles.go
+++ b/go-api/cmd/bgmbackfill/episode_titles.go
@@ -1,0 +1,346 @@
+// episode_titles.go — the one-off pass that fills anime_episode_titles from
+// dandanplay, and the audit trail it has to produce before it is allowed to.
+//
+// # Why this lives in a CLI and not in a worker
+//
+// The gap it closes is a backlog, not a stream.  A finished show's episode
+// titles do not change, so they need filling once; what needs re-asking is the
+// airing slice, and that is small enough to be its own periodic sweep with one
+// timestamp behind it.  Building a permanent five-state queue worker to drain
+// a one-time backlog would have added a job kind, a migration, a cooldown
+// vocabulary and a kill switch, each with its own failure surface, to do work
+// that a command run twice does better -- because a command can be read before
+// it writes, and a worker cannot.
+//
+// That is the second reason: --report is the safety mechanism, not a
+// convenience.  Deciding that a binding is wrong is a judgement made from two
+// disagreeing external sources, and the consequence of getting it wrong is
+// deleting correct titles from a public, indexed page.  So the default mode
+// writes nothing and produces a classification of every row; --apply is a
+// separate, deliberate second invocation against a report a human has read.
+//
+// # Who decides identity, and why it is not dandanplay
+//
+// Both this pass and the classify flow next door need to know whether the
+// bgm_id on a row really belongs to that anilist entry.  Two independent
+// sources can answer:
+//
+//	bgm_id_map    the vendored AniList->Bangumi map.  It is what
+//	              BangumiV1Worker binds from in the first place, so where it
+//	              has an entry it is not a second opinion -- it is the
+//	              provenance of the binding under test.
+//	dandanplay    ships an anilist.co cross-link in the same response as the
+//	              episodes, so it costs nothing extra to consult.
+//
+// The map wins wherever it speaks, and dandanplay is consulted only where it
+// is silent.  That is the same order runHeal and classifyAll already use, and
+// the reason is measurable rather than aesthetic: dandanplay's cross-links are
+// not always consistent with the map, so promoting them to arbiter would let a
+// third-party disagreement retract bindings the authoritative map confirms.
+// Where the map has nothing, dandanplay is the only independent signal there
+// is, and that is exactly the population where mis-bindings concentrate.
+//
+// # What this pass will NOT decide
+//
+// A map-confirmed binding can still be a scope mismatch: a three-episode ONA
+// may legitimately map to the subject of the full series, and then the
+// subject's episode list is not this entry's episode list.  Neither authority
+// answers that -- the map says which subject, not which episodes -- and the
+// signal that would (comparing the upstream main-episode count against
+// anime_cache.episodes) is deliberately not acted on here.  It is RECORDED in
+// the report, per row, so the decision can be made from data rather than from
+// a threshold picked in advance.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/dandanplay"
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+	"github.com/lawrenceli0228/animego/go-api/internal/episodetitles"
+)
+
+// Classification of one row.  Every row lands in exactly one, and the counts
+// are the summary a human reads before deciding whether to run --apply.
+const (
+	// epClassWritten — the binding was accepted and usable titles were found.
+	// In report mode this means "would have been written".
+	epClassWritten = "WRITTEN"
+	// epClassNoTitles — the binding was accepted and upstream had nothing
+	// usable.  Also where a 4xx lands: the client collapses every non-2xx
+	// below 500 into an empty result, so "this subject has no episodes" and
+	// "our credentials stopped working" are the same value here.  A run whose
+	// NO_TITLES share is far above the historical norm is the symptom of the
+	// latter; see the closing summary.
+	epClassNoTitles = "NO_TITLES"
+	// epClassMapConflict — bgm_id_map names a DIFFERENT subject for this
+	// entry.  The authoritative map contradicts the stored binding, so
+	// nothing is written and no upstream request is spent.
+	epClassMapConflict = "MAP_CONFLICT"
+	// epClassRebind — the map is silent and dandanplay says this subject
+	// belongs to a different anilist entry.  Reported, never acted on: it is
+	// input for a re-binding decision, not a licence to write.
+	epClassRebind = "DDP_REBIND"
+	// epClassUndecided — the map is silent and dandanplay published no
+	// cross-link.  Nothing vouches for the binding, so nothing is written.
+	// Absence of evidence, kept distinct from evidence of absence.
+	epClassUndecided = "UNDECIDED"
+	// epClassFetchFail — the request itself failed.
+	epClassFetchFail = "FETCH_FAIL"
+	// epClassSkipped — --limit was exhausted before this row was reached.
+	epClassSkipped = "SKIPPED"
+)
+
+// epTitleRow is one line of the JSON report.
+//
+// UpstreamMain and CatalogueEpisodes sit next to each other on purpose.  Their
+// ratio is the scope-mismatch signal this pass declines to act on, and having
+// both in the artifact means the question can later be answered from a real
+// distribution instead of a guessed threshold.
+type epTitleRow struct {
+	AnilistID         int32  `json:"anilist_id"`
+	BgmID             int32  `json:"bgm_id"`
+	Class             string `json:"class"`
+	Title             string `json:"title,omitempty"`
+	MapBgmID          *int32 `json:"map_bgm_id,omitempty"`
+	DdpAnilistID      int32  `json:"ddp_anilist_id,omitempty"`
+	UpstreamMain      int    `json:"upstream_main_episodes"`
+	CatalogueEpisodes *int32 `json:"catalogue_episodes,omitempty"`
+	TitlesUsable      int    `json:"titles_usable"`
+	TitlesChinese     int    `json:"titles_chinese"`
+	Written           int    `json:"written,omitempty"`
+	Retracted         int    `json:"retracted,omitempty"`
+	Err               string `json:"err,omitempty"`
+}
+
+// epTitleReport is the whole artifact.
+type epTitleReport struct {
+	Mode          string         `json:"mode"`
+	Total         int            `json:"total"`
+	Counts        map[string]int `json:"counts"`
+	DdpAPICalls   int            `json:"ddp_api_calls"`
+	TitlesWritten int            `json:"titles_written"`
+	TitlesCN      int            `json:"titles_chinese"`
+	Retracted     int            `json:"retracted"`
+	Rows          []epTitleRow   `json:"rows"`
+}
+
+// runEpisodeTitleHeal classifies every bgm-bound row and, in apply mode,
+// writes the titles the classification accepted.
+//
+// apply=false performs every read and every decision and writes nothing, so
+// the two modes cannot drift: the report is produced by the same code path
+// that does the writing, not by a parallel description of it.
+func runEpisodeTitleHeal(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	q *dbgen.Queries,
+	ddp *dandanplay.Client,
+	limitDDP int,
+	apply bool,
+	outPath string,
+) error {
+	rows, err := q.ListBgmBoundForBackfill(ctx)
+	if err != nil {
+		return fmt.Errorf("ListBgmBoundForBackfill: %w", err)
+	}
+	slog.Info("episode-title heal: candidates", "count", len(rows), "apply", apply)
+
+	rep := epTitleReport{
+		Mode:   map[bool]string{true: "apply", false: "report"}[apply],
+		Total:  len(rows),
+		Counts: map[string]int{},
+		Rows:   make([]epTitleRow, 0, len(rows)),
+	}
+
+	for i, row := range rows {
+		if i > 0 && i%200 == 0 {
+			slog.Info("episode-title heal: progress",
+				"processed", i, "total", len(rows),
+				"written", rep.TitlesWritten, "ddp_api_calls", rep.DdpAPICalls)
+		}
+		if row.BgmID == nil {
+			continue // the query's own predicate guarantees this; belt and braces
+		}
+		out := healOneRow(ctx, pool, q, ddp, row, limitDDP, apply, &rep)
+		rep.Counts[out.Class]++
+		rep.Rows = append(rep.Rows, out)
+	}
+
+	printEpisodeTitleSummary(&rep)
+
+	if err := writeJSON(outPath, rep); err != nil {
+		return fmt.Errorf("write report %s: %w", outPath, err)
+	}
+	slog.Info("episode-title report written", "path", outPath)
+	return nil
+}
+
+// healOneRow runs the whole decision for a single anime.  It mutates only the
+// running totals on rep; the per-row result is returned.
+func healOneRow(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	q *dbgen.Queries,
+	ddp *dandanplay.Client,
+	row dbgen.ListBgmBoundForBackfillRow,
+	limitDDP int,
+	apply bool,
+	rep *epTitleReport,
+) epTitleRow {
+	bgmID := *row.BgmID
+	out := epTitleRow{
+		AnilistID:         row.AnilistID,
+		BgmID:             bgmID,
+		CatalogueEpisodes: row.Episodes,
+		Title:             firstNonNil(row.TitleChinese, row.TitleRomaji),
+	}
+
+	// 1. The authoritative map, first and for free.  A contradiction here ends
+	//    the row before an upstream request is spent on it.
+	mapBgm, mapErr := q.LookupBgmIdMap(ctx, row.AnilistID)
+	mapSpeaks := mapErr == nil
+	if mapErr != nil && mapErr != pgx.ErrNoRows {
+		out.Class = epClassFetchFail
+		out.Err = fmt.Sprintf("LookupBgmIdMap: %v", mapErr)
+		return out
+	}
+	if mapSpeaks {
+		out.MapBgmID = &mapBgm
+		if mapBgm != bgmID {
+			out.Class = epClassMapConflict
+			return out
+		}
+	}
+
+	// 2. Upstream.  --limit caps live calls so a run can be sized to whatever
+	//    share of the shared request budget is acceptable right now.
+	if limitDDP > 0 && rep.DdpAPICalls >= limitDDP {
+		out.Class = epClassSkipped
+		return out
+	}
+	data, err := ddp.FetchEpisodesByBgmID(ctx, bgmID)
+	rep.DdpAPICalls++
+	if err != nil {
+		out.Class = epClassFetchFail
+		out.Err = err.Error()
+		return out
+	}
+	if data == nil {
+		out.Class = epClassNoTitles
+		return out
+	}
+	out.DdpAnilistID = data.AniListID
+
+	// 3. Where the map was silent, dandanplay's cross-link is the only
+	//    independent voucher for the binding.
+	if !mapSpeaks {
+		switch {
+		case data.AniListID == 0:
+			out.Class = epClassUndecided
+			return out
+		case data.AniListID != row.AnilistID:
+			out.Class = epClassRebind
+			return out
+		}
+	}
+
+	// 4. Main episodes only.  NOT via BuildEpisodeMap: that function maps
+	//    O1/S2 specials ONTO ordinary episode numbers and falls back to the
+	//    whole list when no pure-numeric entry exists, which is right for
+	//    matching a file to a danmaku track and exactly wrong here.
+	titles := episodetitles.Usable(data.Episodes)
+	out.UpstreamMain = episodetitles.CountMain(data.Episodes)
+	out.TitlesUsable = len(titles)
+	for _, t := range titles {
+		if t.NameCn != "" {
+			out.TitlesChinese++
+		}
+	}
+	if len(titles) == 0 {
+		out.Class = epClassNoTitles
+		return out
+	}
+
+	out.Class = epClassWritten
+	rep.TitlesCN += out.TitlesChinese
+	if !apply {
+		// Report mode stops here having made every decision.
+		return out
+	}
+
+	written, retracted, err := episodetitles.Apply(ctx, pool, q, row.AnilistID, bgmID, titles)
+	if err != nil {
+		out.Class = epClassFetchFail
+		out.Err = err.Error()
+		return out
+	}
+	out.Written, out.Retracted = written, retracted
+	rep.TitlesWritten += written
+	rep.Retracted += retracted
+	return out
+}
+
+// printEpisodeTitleSummary prints the table a human reads before --apply.
+//
+// The NO_TITLES share is called out separately because it is the one number
+// that distinguishes a healthy run from a broken one without naming the
+// failure: the client cannot tell a 4xx from an empty subject, so expired
+// credentials arrive as a run where nearly everything is NO_TITLES rather than
+// as an error.  A number on screen is a weaker guarantee than a typed outcome
+// would be, and it is what is available until the client learns to
+// distinguish them.
+func printEpisodeTitleSummary(rep *epTitleReport) {
+	fmt.Printf("\nEpisode-title heal (%s mode)\n", rep.Mode)
+	fmt.Printf("%-14s %8s %8s\n", "CLASS", "COUNT", "PCT")
+	fmt.Printf("%-14s %8s %8s\n", "──────────────", "────────", "────────")
+	for _, c := range []string{
+		epClassWritten, epClassNoTitles, epClassMapConflict,
+		epClassRebind, epClassUndecided, epClassFetchFail, epClassSkipped,
+	} {
+		n := rep.Counts[c]
+		pct := 0.0
+		if rep.Total > 0 {
+			pct = float64(n) / float64(rep.Total) * 100
+		}
+		fmt.Printf("%-14s %8d %7.1f%%\n", c, n, pct)
+	}
+	fmt.Printf("\n  dandanplay calls: %d\n", rep.DdpAPICalls)
+	fmt.Printf("  titles usable:    %d (chinese: %d)\n", totalUsable(rep), rep.TitlesCN)
+	if rep.Mode == "apply" {
+		fmt.Printf("  titles written:   %d\n", rep.TitlesWritten)
+		fmt.Printf("  rows retracted:   %d\n", rep.Retracted)
+	}
+	decided := rep.Total - rep.Counts[epClassSkipped]
+	if decided > 0 {
+		share := float64(rep.Counts[epClassNoTitles]) / float64(decided) * 100
+		fmt.Printf("\n  NO_TITLES share:  %.1f%% of decided rows\n", share)
+		if share > 50 {
+			fmt.Printf("  ^ unusually high. The client reports a 4xx and an empty subject\n")
+			fmt.Printf("    identically, so check DANDANPLAY_APP_ID/SECRET before trusting this.\n")
+		}
+	}
+	fmt.Println()
+}
+
+func totalUsable(rep *epTitleReport) int {
+	n := 0
+	for _, r := range rep.Rows {
+		n += r.TitlesUsable
+	}
+	return n
+}
+
+func firstNonNil(vals ...*string) string {
+	for _, v := range vals {
+		if v != nil && *v != "" {
+			return *v
+		}
+	}
+	return ""
+}

--- a/go-api/cmd/bgmbackfill/main.go
+++ b/go-api/cmd/bgmbackfill/main.go
@@ -98,15 +98,19 @@ func main() {
 	skipDDP := flag.Bool("skip-ddp", false, "id-map-only pass, skip dandanplay calls")
 	outFile := flag.String("out", "report.json", "path for the JSON report")
 	healMode := flag.Bool("heal", false, "WRITES: fill title_chinese from dandanplay for map-confirmed rows missing CN")
+	epTitlesMode := flag.Bool("heal-episode-titles", false, "fill anime_episode_titles from dandanplay; read-only unless combined with --apply")
 	flag.Parse()
 
 	// Default to report mode when no explicit mode is set.
-	if !*applyMode && !*reportMode && !*healMode {
+	if !*applyMode && !*reportMode && !*healMode && !*epTitlesMode {
 		*reportMode = true
 	}
 
-	if *applyMode {
+	if *applyMode && !*epTitlesMode {
 		fmt.Fprintln(os.Stderr, "WARNING: --apply will mutate production rows (BackfillResetRows). Proceeding...")
+	}
+	if *applyMode && *epTitlesMode {
+		fmt.Fprintln(os.Stderr, "WARNING: --heal-episode-titles --apply will WRITE and RETRACT anime_episode_titles rows. Proceeding...")
 	}
 	if *healMode {
 		fmt.Fprintln(os.Stderr, "WARNING: --heal will WRITE title_chinese to production rows. Proceeding...")
@@ -146,6 +150,24 @@ func main() {
 			os.Exit(1)
 		}
 		defer ddpClient.Close()
+	}
+
+	// ── episode-title heal: fill anime_episode_titles from dandanplay ─────
+	// Its own row set (every bgm-bound row) and its own write path, so like
+	// --heal it returns early rather than falling through to the classifier.
+	// Unlike --heal it is read-only by default: the decision it makes can
+	// retract titles from a public page, so writing takes an explicit --apply
+	// against a report someone has read.
+	if *epTitlesMode {
+		if *skipDDP || ddpClient == nil {
+			slog.Error("--heal-episode-titles needs dandanplay; do not combine with --skip-ddp")
+			os.Exit(1)
+		}
+		if err := runEpisodeTitleHeal(ctx, pool, q, ddpClient, *limitFlag, *applyMode, *outFile); err != nil {
+			slog.Error("episode-title heal failed", "err", err)
+			os.Exit(1)
+		}
+		return
 	}
 
 	// ── heal mode: fill CN from dandanplay for map-confirmed rows ─────────

--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -155,6 +155,29 @@ func main() {
 	// an in-process token bucket, so the backfill only stays inside the
 	// bgm.tv budget while it draws from this same instance.  A standalone
 	// backfill CLI would open a second bucket and double the real rate.
+	// P2.6 — dandanplay 3-phase match.  Independent rate limiter
+	// (800ms, separate from Bangumi's 800ms) so admin enrichment
+	// queues don't starve user-triggered /match calls.  X-AppId /
+	// X-AppSecret read from env; absent values mean public-tier
+	// requests (stricter dandanplay limits, but the API still
+	// responds).
+	//
+	// Constructed HERE, several hundred lines before its HTTP handlers, and
+	// the position is load-bearing rather than tidy.  The episode-title sweep
+	// registered below is a river worker, so it must hold the client before
+	// queue.Boot runs -- and it must hold THIS client, not one of its own.
+	// A second instance would open a second 800ms bucket against the same
+	// AppId and double the real rate, which is the same argument the comment
+	// on WorkersWithBangumiAndNormalizer makes for sharing bangumiClient.
+	dandanClient, err := dandanplay.NewClient(
+		dandanplay.WithCredentials(os.Getenv("DANDANPLAY_APP_ID"), os.Getenv("DANDANPLAY_APP_SECRET")),
+	)
+	if err != nil {
+		slog.Error("dandanplay client init failed", "err", err)
+		os.Exit(1)
+	}
+	defer dandanClient.Close()
+
 	workers := queue.WorkersWithBangumiAndNormalizer(
 		bangumiClient,
 		anilistClient,
@@ -180,6 +203,13 @@ func main() {
 	// holds so its two-requests-per-row draw from the one token bucket
 	// rather than opening a second one beside it.
 	queue.AddEpisodesBgmWorkers(workers, bangumiClient, q, enqueuer)
+	// Airing-show episode-title top-up.  Takes the shared dandanplay client
+	// for the same reason the sweep above takes the shared bangumiClient, and
+	// the pool because its write is a four-statement transaction shared with
+	// cmd/bgmbackfill (internal/episodetitles).  Gated at work time by
+	// EPISODE_TITLES_SWEEP_ENABLED; registering it is not the same as running
+	// it.
+	queue.AddEpisodeTitlesWorker(workers, pool, q, dandanClient)
 
 	riverClient, err := queue.Boot(pool, queue.Config{
 		Workers: workers,
@@ -227,6 +257,14 @@ func main() {
 			// on-demand enrichment.  The separate queue is for isolation
 			// and pausability, not parallelism.
 			queue.EpisodesBgmQueueName: {MaxWorkers: 1},
+			// Airing episode titles: MaxWorkers MUST stay 1.  One pass is
+			// one job that walks its whole candidate list inline, and every
+			// row costs a token from the dandanplay bucket that user-facing
+			// /match draws on.  A second concurrent pass would not go faster
+			// -- the bucket is the constraint, not the worker count -- it
+			// would only take twice as many tokens away from the request
+			// path.
+			queue.EpisodeTitlesQueueName: {MaxWorkers: 1},
 		},
 		PeriodicJobs: []*river.PeriodicJob{
 			queue.PeriodicWarmSeasonJob(),
@@ -237,6 +275,7 @@ func main() {
 			// next run as now+period on every Start, so a deploy would
 			// otherwise push the sweep a full hour out every time.
 			queue.PeriodicEpisodesBgmScanJob(),
+			queue.PeriodicEpisodeTitlesJob(),
 			// 90 days, and deliberately NOT RunOnStart — see the note on
 			// PeriodicHantBackfillJob for why this one reads the opposite
 			// way round from the two sweeps above it, and for what that
@@ -717,20 +756,6 @@ func main() {
 	safetyHandlers := safety.NewHandlers(q)
 	danmakuHandlers := danmaku.NewHandlers(pool, q)
 
-	// P2.6 — dandanplay 3-phase match.  Independent rate limiter
-	// (800ms, separate from Bangumi's 800ms) so admin enrichment
-	// queues don't starve user-triggered /match calls.  X-AppId /
-	// X-AppSecret read from env; absent values mean public-tier
-	// requests (stricter dandanplay limits, but the API still
-	// responds).
-	dandanClient, err := dandanplay.NewClient(
-		dandanplay.WithCredentials(os.Getenv("DANDANPLAY_APP_ID"), os.Getenv("DANDANPLAY_APP_SECRET")),
-	)
-	if err != nil {
-		slog.Error("dandanplay client init failed", "err", err)
-		os.Exit(1)
-	}
-	defer dandanClient.Close()
 	dandanplayHandlers := dandanplay.NewHandlers(q, dandanClient, bangumiClient)
 
 	// G4 — global per-IP rate limiter for /api/*.  Express applied

--- a/go-api/internal/dandanplay/episode_title_text.go
+++ b/go-api/internal/dandanplay/episode_title_text.go
@@ -1,0 +1,133 @@
+// Package dandanplay — splitting one dandanplay `episodeTitle` string into
+// the two columns anime_episode_titles actually has.
+//
+// /api/v2/bangumi/bgmtv/:bgmId returns a single field per episode,
+// `episodeTitle`, shaped as a Chinese ordinal prefix followed by a body:
+//
+//	第1话 燃烧吧，狂犬                          body is Chinese
+//	第2话 サムライ・ジュニア                     body is Japanese
+//	第3话 宇宙は数学という言語で書かれている        body is Japanese
+//	第1话 慢郎中跟急惊风 &amp; 大雄的新娘         body is Chinese, and escaped
+//	第2话 FIRE                                 body is Latin
+//
+// The destination has two columns — name_cn and name — and the detail page
+// renders them under two different labels, "Chinese title" and "original
+// title".  So the one field has to be split before anything is written, and
+// that split is the whole job of this file.
+//
+// Getting it wrong does not fail loudly.  It writes a Japanese string into
+// name_cn, and the page then renders Japanese under a label that promises a
+// translation, on a route that is public and indexed.  Both columns are
+// nullable and the primary key is (anime_id, episode), so there is also
+// nothing in the schema that stops a row consisting of two NULLs from being
+// inserted; see the empty-body rule below for who has to prevent that.
+
+package dandanplay
+
+import (
+	"html"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// episodeOrdinalPrefixRe matches the leading "第<N>话" / "第<N>話" / "第<N>集"
+// ordinal, with ASCII or full-width (U+FF10–U+FF19) digits.  Both digit
+// forms appear in the feed, so accepting only ASCII would leave the prefix
+// glued to the front of an otherwise good title.
+//
+// Anchored deliberately.  Bodies contain the very same character sequence —
+// "第16话 第十六次星月相交之日" — and an unanchored strip would chew into the
+// title itself.  Here the kanji-numeral body happens to survive because the
+// digit class holds digits only, but the anchor is what makes that a rule
+// rather than a coincidence, and the next body that spells its ordinal with
+// ASCII digits mid-string would not be so lucky.
+//
+// No trailing separator is required.  The body is trimmed after the strip,
+// so a row written as "第4话标题" loses its prefix exactly like a spaced one,
+// and a row with an ideographic space after the prefix loses that too.
+var episodeOrdinalPrefixRe = regexp.MustCompile(`^第[0-9\x{FF10}-\x{FF19}]+[话話集]`)
+
+// NormalizeDandanEpisodeTitle splits one dandanplay episodeTitle into the
+// Chinese and original-language columns of anime_episode_titles.  Exactly one
+// of the two returns is ever non-empty; both are empty when the title carries
+// no storable body at all.
+//
+// Three steps, and the order of the first two is load-bearing.
+//
+// 1. Unescape.  Entity-bearing bodies are real, not hypothetical: the live
+// feed carries values such as "第1话 慢郎中跟急惊风 &amp; 大雄的新娘".  This
+// has to happen before classification, not after, for two separate reasons.
+// The column is read back as text and rendered as text, so a stored "&amp;"
+// shows up verbatim on the page instead of an ampersand; and a numeric entity
+// can decode to kana (&#12354; is あ), which means unescaping after the
+// classification step would let an escaped Japanese title be filed as Chinese.
+//
+// 2. Strip the ordinal prefix.  "第1话" is boilerplate — the site already
+// knows the episode number, because it is the key the title is stored under,
+// and renders its own ordinal beside the name.  Keeping the prefix in the
+// column prints the number twice, and prints dandanplay's numbering rather
+// than the site's wherever the two disagree.  A title with no prefix at all
+// ("FUTURE ENGINE") is still classified and returned; the prefix is tolerated,
+// never required.
+//
+// 3. Classify what is left.  A body with Han characters and no kana is
+// Chinese; everything else non-empty is treated as original-language.  Kana
+// is the decisive signal and it is a NEGATIVE one, because Japanese episode
+// titles routinely contain Han characters too — 宇宙は数学という言語で書かれている
+// is more than half Han — so a "has Han" test on its own would file most of
+// the Japanese catalogue into the Chinese column.  Everything with no Han at
+// all (Latin, kana-only, punctuation) falls to name for the same reason: the
+// one thing name_cn must never receive is text that is not Chinese.
+//
+// An empty body returns ("", ""), which the caller uses to skip the row
+// entirely.  A title that is nothing but its prefix ("第10话") carries no
+// name in either language, and persisting it would put a row with two NULL
+// name columns in front of the page for no gain.
+func NormalizeDandanEpisodeTitle(raw string) (nameCn, name string) {
+	body := html.UnescapeString(raw)
+	body = strings.TrimSpace(body)
+	body = episodeOrdinalPrefixRe.ReplaceAllString(body, "")
+	body = strings.TrimSpace(body)
+
+	if body == "" {
+		return "", ""
+	}
+	if hasHan(body) && !hasKana(body) {
+		return body, ""
+	}
+	return "", body
+}
+
+// hasHan reports whether s contains any Han character.
+//
+// unicode.Han spans every CJK block including the extensions, so this needs
+// no hand-maintained range list and cannot drift out of date as new blocks
+// are assigned.
+func hasHan(s string) bool {
+	for _, r := range s {
+		if unicode.Is(unicode.Han, r) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasKana reports whether s contains hiragana or katakana.
+//
+// The Unicode script tables are used rather than a literal U+3040–U+30FF
+// range because the two disagree at both ends and the tables are right in the
+// case that matters here.  U+30FB (・) and U+30FC (ー) sit inside that range
+// but carry script=Common, so a range test would call a Chinese title that
+// merely uses ・ as a separator Japanese; halfwidth katakana (U+FF66–U+FF9D)
+// sit outside the range but are script=Katakana, so a range test would miss
+// genuinely Japanese text written in the halfwidth forms.  Both errors push a
+// title into the wrong column, and the script tables make neither.
+func hasKana(s string) bool {
+	for _, r := range s {
+		if unicode.In(r, unicode.Hiragana, unicode.Katakana) {
+			return true
+		}
+	}
+	return false
+}

--- a/go-api/internal/dandanplay/episode_title_text_test.go
+++ b/go-api/internal/dandanplay/episode_title_text_test.go
@@ -1,0 +1,86 @@
+package dandanplay
+
+// episode_title_text_test.go — NormalizeDandanEpisodeTitle.
+//
+// The first block of cases is verbatim feed data, kept as such: the shape of
+// `episodeTitle` is not documented anywhere by dandanplay, it was measured,
+// and a table of invented strings would only test the assumptions rather than
+// the input.  The blocks after it are the edges those values imply — the two
+// other ordinal characters, full-width digits, an absent separator, an absent
+// prefix — plus the classification boundaries the doc comment claims to hold.
+//
+// Every case also asserts the invariant that at most one column comes back
+// non-empty.  A row with a name in both columns would render the same title
+// twice under two different labels, and nothing downstream checks for it.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeDandanEpisodeTitle(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		wantNameCn string
+		wantName   string
+	}{
+		// ---- values observed on the live feed ----
+		{"feed: chinese body", "第1话 燃烧吧，狂犬", "燃烧吧，狂犬", ""},
+		{"feed: katakana body", "第2话 サムライ・ジュニア", "", "サムライ・ジュニア"},
+		{"feed: japanese body carrying han", "第3话 宇宙は数学という言語で書かれている", "", "宇宙は数学という言語で書かれている"},
+		{"feed: chinese body with an html entity", "第1话 慢郎中跟急惊风 &amp; 大雄的新娘", "慢郎中跟急惊风 & 大雄的新娘", ""},
+		{"feed: latin body", "第2话 FIRE", "", "FIRE"},
+		{"feed: chinese body opening with a kanji numeral", "第16话 第十六次星月相交之日", "第十六次星月相交之日", ""},
+
+		// ---- prefix variants ----
+		{"full-width digit prefix", "第１话 燃烧吧，狂犬", "燃烧吧，狂犬", ""},
+		{"traditional 話 prefix", "第10話 タイトル", "", "タイトル"},
+		{"集 prefix", "第10集 标题", "标题", ""},
+		{"prefix with no trailing space", "第4话标题", "标题", ""},
+		{"prefix followed by an ideographic space", "第9话　标题", "标题", ""},
+		{"surrounding whitespace is trimmed", "  第5话 标题  ", "标题", ""},
+
+		// ---- nothing to store ----
+		{"prefix only", "第10话", "", ""},
+		{"full-width prefix only, trailing space", "第１０话  ", "", ""},
+		{"empty string", "", "", ""},
+		{"whitespace only", "   ", "", ""},
+
+		// ---- no prefix at all ----
+		{"no prefix, latin", "FUTURE ENGINE", "", "FUTURE ENGINE"},
+		{"no prefix, chinese", "燃烧吧，狂犬", "燃烧吧，狂犬", ""},
+
+		// ---- classification boundaries ----
+		// Han is present here too; kana is what decides, and it decides
+		// against nameCn.  This is the case a "has Han" test would misfile.
+		{"mixed han and kana lands in name", "第8话 魔法少女まどか", "", "魔法少女まどか"},
+		{"kana only lands in name", "第7话 ひとり", "", "ひとり"},
+		// Halfwidth katakana is script=Katakana but sits outside U+3040–U+30FF,
+		// so a literal range test would call this Chinese-eligible.  It has no
+		// Han, so it would still land in name — the case is here to pin the
+		// signal, not just the outcome.
+		{"halfwidth katakana counts as kana", "第6话 ｻﾑﾗｲ", "", "ｻﾑﾗｲ"},
+		// ・ (U+30FB) is script=Common despite living in the katakana block.
+		// A literal range test would read this Chinese title as Japanese.
+		{"middle dot does not make a chinese title japanese", "第5话 少年・少女", "少年・少女", ""},
+		// Unescaping has to precede classification: read raw, "&#12354;宇宙"
+		// has Han and no kana and would be filed as Chinese; decoded, its
+		// leading rune is あ.
+		{"numeric entity decoding to kana is classified after unescaping", "第1话 &#12354;宇宙", "", "あ宇宙"},
+		// No Han, no kana, still non-empty — the rule sends anything that is
+		// not demonstrably Chinese to the original-language column.
+		{"punctuation-only body lands in name", "第9话 ？！", "", "？！"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotNameCn, gotName := NormalizeDandanEpisodeTitle(tc.raw)
+			assert.Equal(t, tc.wantNameCn, gotNameCn, "nameCn for %q", tc.raw)
+			assert.Equal(t, tc.wantName, gotName, "name for %q", tc.raw)
+			assert.False(t, gotNameCn != "" && gotName != "",
+				"both columns filled for %q — a title belongs to exactly one language column", tc.raw)
+		})
+	}
+}

--- a/go-api/internal/db/gen/admin.sql.go
+++ b/go-api/internal/db/gen/admin.sql.go
@@ -949,6 +949,16 @@ SET
                                      THEN NULL ELSE episodes_bgm_outcome END,
     episodes_bgm_reason       = CASE WHEN (SELECT yes FROM rebound)
                                      THEN NULL ELSE episodes_bgm_reason END,
+    -- Same move as episodes_bgm_attempted_at above, for the sweep added in
+    -- 0029.  cleared_titles has just deleted this row's episode titles, and
+    -- the stamp beside them records an attempt made against the binding that
+    -- was replaced -- so leaving it would tell the airing sweep this row was
+    -- recently handled and keep it out of the candidate set for another 26
+    -- hours, with the page showing no titles for the whole window.  Nulling it
+    -- puts the row at the front of ListReleasingEpisodeTitleCandidates, which
+    -- orders NULLS FIRST for exactly this case.
+    episode_titles_at         = CASE WHEN (SELECT yes FROM rebound)
+                                     THEN NULL ELSE episode_titles_at END,
     updated_at    = now()
 WHERE anilist_id = $4::integer
 RETURNING

--- a/go-api/internal/db/gen/anime_cache.sql.go
+++ b/go-api/internal/db/gen/anime_cache.sql.go
@@ -3190,23 +3190,45 @@ func (q *Queries) UpsertEpisodeTitle(ctx context.Context, animeID int32, episode
 }
 
 const upsertEpisodeTitleSourced = `-- name: UpsertEpisodeTitleSourced :execrows
+WITH incoming AS (
+    -- The trim set is explicit, and every character in it is here because
+    -- bare btrim(text) does NOT strip it.  btrim's default set is the ASCII
+    -- space and nothing else, so a value of a single tab, newline or -- the
+    -- one that makes this reachable rather than theoretical -- U+3000
+    -- IDEOGRAPHIC SPACE survives NULLIF and lands as a row.
+    --
+    -- U+3000 is the ordinary space in Japanese and Chinese text and both
+    -- upstreams feeding this table are CJK sources, so "whitespace only"
+    -- arrives in that form routinely.  A row that lands that way is worse
+    -- than a blank one: it renders as an empty title AND claims the column at
+    -- its source's precedence, so the next pass carrying the real name is
+    -- scored against a claimed column and a lower-ranked source loses to
+    -- nothing at all.
+    --
+    -- An explicit set rather than a regexp character class because
+    -- [[:space:]] resolves through the database's ctype, which makes the
+    -- behaviour of this guard depend on how the cluster was initialised.
+    -- U+00A0 and U+FEFF are included for the same reason as U+3000: they
+    -- survive a naive trim and arrive from scraped upstreams.
+    SELECT
+        NULLIF(btrim($5::text, E' \t\n\r\u3000\u00a0\ufeff'), '') AS name_cn,
+        NULLIF(btrim($6::text,    E' \t\n\r\u3000\u00a0\ufeff'), '') AS name
+)
 INSERT INTO anime_episode_titles (
     anime_id, episode, name_cn, name, name_cn_source, name_source
 )
 SELECT
     ac.anilist_id,
     $1::int,
-    NULLIF(btrim($2::text), ''),
-    NULLIF(btrim($3::text), ''),
-    CASE WHEN NULLIF(btrim($2::text), '') IS NULL
-         THEN NULL ELSE $4::text END,
-    CASE WHEN NULLIF(btrim($3::text), '') IS NULL
-         THEN NULL ELSE $4::text END
+    i.name_cn,
+    i.name,
+    CASE WHEN i.name_cn IS NULL THEN NULL ELSE $2::text END,
+    CASE WHEN i.name    IS NULL THEN NULL ELSE $2::text END
 FROM anime_cache ac
-WHERE ac.anilist_id = $5::int
-  AND ac.bgm_id     = $6::int
-  AND (NULLIF(btrim($2::text), '') IS NOT NULL
-       OR NULLIF(btrim($3::text), '') IS NOT NULL)
+CROSS JOIN incoming i
+WHERE ac.anilist_id = $3::int
+  AND ac.bgm_id     = $4::int
+  AND (i.name_cn IS NOT NULL OR i.name IS NOT NULL)
 ON CONFLICT (anime_id, episode) DO UPDATE SET
     name_cn = CASE
         WHEN excluded.name_cn IS NULL THEN anime_episode_titles.name_cn
@@ -3240,11 +3262,11 @@ ON CONFLICT (anime_id, episode) DO UPDATE SET
 
 type UpsertEpisodeTitleSourcedParams struct {
 	Episode int32  `json:"episode"`
-	NameCn  string `json:"nameCn"`
-	Name    string `json:"name"`
 	Source  string `json:"source"`
 	AnimeID int32  `json:"animeId"`
 	BgmID   int32  `json:"bgmId"`
+	NameCn  string `json:"nameCn"`
+	Name    string `json:"name"`
 }
 
 // Write one episode title, honouring both precedence and the binding it was
@@ -3290,11 +3312,11 @@ type UpsertEpisodeTitleSourcedParams struct {
 func (q *Queries) UpsertEpisodeTitleSourced(ctx context.Context, arg UpsertEpisodeTitleSourcedParams) (int64, error) {
 	result, err := q.db.Exec(ctx, upsertEpisodeTitleSourced,
 		arg.Episode,
-		arg.NameCn,
-		arg.Name,
 		arg.Source,
 		arg.AnimeID,
 		arg.BgmID,
+		arg.NameCn,
+		arg.Name,
 	)
 	if err != nil {
 		return 0, err

--- a/go-api/internal/db/gen/anime_cache.sql.go
+++ b/go-api/internal/db/gen/anime_cache.sql.go
@@ -101,6 +101,73 @@ func (q *Queries) ApplyHantTitleBatch(ctx context.Context, anilistIds []int32, t
 	return result.RowsAffected(), nil
 }
 
+const clearEpisodeTitlesBySourceOutside = `-- name: ClearEpisodeTitlesBySourceOutside :many
+UPDATE anime_episode_titles t
+   SET name_cn        = CASE WHEN t.name_cn_source = $1::text
+                             THEN NULL ELSE t.name_cn END,
+       name_cn_source = CASE WHEN t.name_cn_source = $1::text
+                             THEN NULL ELSE t.name_cn_source END,
+       name           = CASE WHEN t.name_source = $1::text
+                             THEN NULL ELSE t.name END,
+       name_source    = CASE WHEN t.name_source = $1::text
+                             THEN NULL ELSE t.name_source END
+ WHERE t.anime_id = $2::int
+   AND cardinality($3::int[]) > 0
+   AND NOT (t.episode = ANY($3::int[]))
+   AND (t.name_cn_source = $1::text
+        OR t.name_source = $1::text)
+RETURNING t.episode
+`
+
+// Half of the snapshot semantics an upsert cannot provide on its own.
+//
+// Upserting a fetch writes the episodes the upstream returned and says nothing
+// about the ones it no longer returns.  So an entry bound to the wrong subject
+// keeps every stale row the old binding left behind, and the new, correct rows
+// simply overwrite the first few.  On a three-episode ONA bound to a full
+// series that is three corrected rows in front of hundreds of wrong ones.
+//
+// The retraction is scoped to ONE SOURCE, and that scope is what makes it safe
+// to run automatically.  A writer may withdraw what it previously said; it may
+// not touch a column another source filled, and it may not delete a row
+// outright, because the row may hold a manual correction or the other
+// upstream's value in the other column.  Clearing per field and removing only
+// what is left empty afterwards is the same conservatism the precedence rule
+// above encodes, applied to removal.
+//
+// The cardinality guard is load-bearing, not defensive dressing.  With an
+// empty kept-set every row is "outside" it, so a fetch that came back with no
+// usable episodes -- a transient upstream blip, a subject mid-edit -- would
+// retract this source's entire contribution for the anime.  Callers are
+// specified to treat an empty result as 'empty' and never reach this query,
+// but that is a convention, and a convention is the wrong place for the
+// difference between "nothing changed" and "everything erased".
+//
+// Returns the episode numbers it touched so the caller can hand exactly those
+// to DeleteEmptyEpisodeTitles.  The pairing is deliberately two statements: a
+// data-modifying CTE cannot see its own effects, so a DELETE in the same
+// statement would test the pre-UPDATE values and delete rows that still hold
+// another source's title.
+func (q *Queries) ClearEpisodeTitlesBySourceOutside(ctx context.Context, source string, animeID int32, kept []int32) ([]int32, error) {
+	rows, err := q.db.Query(ctx, clearEpisodeTitlesBySourceOutside, source, animeID, kept)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []int32{}
+	for rows.Next() {
+		var episode int32
+		if err := rows.Scan(&episode); err != nil {
+			return nil, err
+		}
+		items = append(items, episode)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const countAnimeCacheLocal = `-- name: CountAnimeCacheLocal :one
 SELECT count(*)
 FROM anime_cache
@@ -229,6 +296,32 @@ DELETE FROM anime_studios WHERE anime_id = $1
 func (q *Queries) DeleteAnimeStudios(ctx context.Context, animeID int32) error {
 	_, err := q.db.Exec(ctx, deleteAnimeStudios, animeID)
 	return err
+}
+
+const deleteEmptyEpisodeTitles = `-- name: DeleteEmptyEpisodeTitles :execrows
+DELETE FROM anime_episode_titles
+ WHERE anime_id = $1::int
+   AND episode = ANY($2::int[])
+   AND name_cn IS NULL
+   AND name IS NULL
+`
+
+// Remove rows that ClearEpisodeTitlesBySourceOutside emptied.
+//
+// Scoped to the episode numbers that query returned rather than to "every
+// empty row for this anime" on purpose.  The table already holds a large
+// population of rows whose two payload columns were NULL from the day they
+// were written; they are invisible to the reader, but they are the only record
+// that an episode number exists at all for entries whose catalogue episode
+// count is unknown, where the grid infers its size from the highest episode
+// number it holds.  Sweeping them here would quietly shorten those grids as a
+// side effect of an unrelated retraction.
+func (q *Queries) DeleteEmptyEpisodeTitles(ctx context.Context, animeID int32, episodes []int32) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteEmptyEpisodeTitles, animeID, episodes)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const getAbsoluteEpisodeOffset = `-- name: GetAbsoluteEpisodeOffset :one
@@ -2316,6 +2409,61 @@ func (q *Queries) ListEpisodesBgmCandidates(ctx context.Context, arg ListEpisode
 	return items, nil
 }
 
+const listReleasingEpisodeTitleCandidates = `-- name: ListReleasingEpisodeTitleCandidates :many
+SELECT
+    ac.anilist_id,
+    ac.bgm_id
+FROM anime_cache ac
+WHERE ac.status = 'RELEASING'
+  AND ac.bgm_id IS NOT NULL
+  AND (ac.episode_titles_at IS NULL
+       OR ac.episode_titles_at < now() - $1::interval)
+ORDER BY ac.episode_titles_at NULLS FIRST, ac.anilist_id
+LIMIT $2
+`
+
+type ListReleasingEpisodeTitleCandidatesRow struct {
+	AnilistID int32  `json:"anilistId"`
+	BgmID     *int32 `json:"bgmId"`
+}
+
+// The airing shows whose episode titles are due another look.
+//
+// Anchored on status = 'RELEASING' because that is the population whose titles
+// are still being written upstream: episode 9's name appears in the week
+// episode 9 airs, so one enrichment pass can never finish the job for a show
+// mid-broadcast.  Finished shows are settled and are served by the one-off
+// backfill instead; keeping them out of this predicate is what lets the sweep
+// run on a single timestamp with no outcome bookkeeping (0029, section C).
+//
+// The freshness interval is a parameter rather than a literal because it has
+// to stay above the client's episode-response cache TTL.  Asking again sooner
+// than that returns the cached body, writes nothing new, and stamps the row as
+// attempted -- a pass that consumes a slot and cannot make progress.
+//
+// ORDER BY matches the partial index (0029) so the scan reads a prefix and
+// stops: never-swept rows first, then oldest-swept, with the recently-swept
+// rows the freshness arm rejects sorting last.
+func (q *Queries) ListReleasingEpisodeTitleCandidates(ctx context.Context, staleAfter pgtype.Interval, rowLimit int32) ([]ListReleasingEpisodeTitleCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listReleasingEpisodeTitleCandidates, staleAfter, rowLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListReleasingEpisodeTitleCandidatesRow{}
+	for rows.Next() {
+		var i ListReleasingEpisodeTitleCandidatesRow
+		if err := rows.Scan(&i.AnilistID, &i.BgmID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSitemapShard = `-- name: ListSitemapShard :many
 SELECT
     anilist_id,
@@ -2670,6 +2818,29 @@ func (q *Queries) SearchAnimeCacheLocal(ctx context.Context, arg SearchAnimeCach
 	return items, nil
 }
 
+const touchEpisodeTitlesAt = `-- name: TouchEpisodeTitlesAt :execrows
+UPDATE anime_cache
+   SET episode_titles_at = now()
+ WHERE anilist_id = $1::int
+   AND bgm_id     = $2::int
+`
+
+// Stamp the attempt, pinned to the binding the attempt was made against.
+//
+// Written on every pass regardless of what the pass produced -- that is what
+// moves a row to the back of the queue and keeps a show whose upstream has
+// nothing from starving the ones that do.  The bgm_id predicate means a row
+// re-bound during the fetch is not stamped, so the next pass re-asks under the
+// binding it now holds instead of resting on an attempt made against the old
+// one.
+func (q *Queries) TouchEpisodeTitlesAt(ctx context.Context, anilistID int32, bgmID int32) (int64, error) {
+	result, err := q.db.Exec(ctx, touchEpisodeTitlesAt, anilistID, bgmID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const updateAnimeCharacterCN = `-- name: UpdateAnimeCharacterCN :exec
 UPDATE anime_characters
 SET name_cn               = $3,
@@ -3016,4 +3187,117 @@ func (q *Queries) UpsertEpisodeTitle(ctx context.Context, animeID int32, episode
 		name,
 	)
 	return err
+}
+
+const upsertEpisodeTitleSourced = `-- name: UpsertEpisodeTitleSourced :execrows
+INSERT INTO anime_episode_titles (
+    anime_id, episode, name_cn, name, name_cn_source, name_source
+)
+SELECT
+    ac.anilist_id,
+    $1::int,
+    NULLIF(btrim($2::text), ''),
+    NULLIF(btrim($3::text), ''),
+    CASE WHEN NULLIF(btrim($2::text), '') IS NULL
+         THEN NULL ELSE $4::text END,
+    CASE WHEN NULLIF(btrim($3::text), '') IS NULL
+         THEN NULL ELSE $4::text END
+FROM anime_cache ac
+WHERE ac.anilist_id = $5::int
+  AND ac.bgm_id     = $6::int
+  AND (NULLIF(btrim($2::text), '') IS NOT NULL
+       OR NULLIF(btrim($3::text), '') IS NOT NULL)
+ON CONFLICT (anime_id, episode) DO UPDATE SET
+    name_cn = CASE
+        WHEN excluded.name_cn IS NULL THEN anime_episode_titles.name_cn
+        WHEN coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], excluded.name_cn_source), 0)
+             >= coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], anime_episode_titles.name_cn_source), 0)
+             THEN excluded.name_cn
+        ELSE anime_episode_titles.name_cn
+    END,
+    name_cn_source = CASE
+        WHEN excluded.name_cn IS NULL THEN anime_episode_titles.name_cn_source
+        WHEN coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], excluded.name_cn_source), 0)
+             >= coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], anime_episode_titles.name_cn_source), 0)
+             THEN excluded.name_cn_source
+        ELSE anime_episode_titles.name_cn_source
+    END,
+    name = CASE
+        WHEN excluded.name IS NULL THEN anime_episode_titles.name
+        WHEN coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], excluded.name_source), 0)
+             >= coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], anime_episode_titles.name_source), 0)
+             THEN excluded.name
+        ELSE anime_episode_titles.name
+    END,
+    name_source = CASE
+        WHEN excluded.name IS NULL THEN anime_episode_titles.name_source
+        WHEN coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], excluded.name_source), 0)
+             >= coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], anime_episode_titles.name_source), 0)
+             THEN excluded.name_source
+        ELSE anime_episode_titles.name_source
+    END
+`
+
+type UpsertEpisodeTitleSourcedParams struct {
+	Episode int32  `json:"episode"`
+	NameCn  string `json:"nameCn"`
+	Name    string `json:"name"`
+	Source  string `json:"source"`
+	AnimeID int32  `json:"animeId"`
+	BgmID   int32  `json:"bgmId"`
+}
+
+// Write one episode title, honouring both precedence and the binding it was
+// fetched under.  This is the query every episode-title writer is expected to
+// use; UpsertEpisodeTitle above is the pre-0029 shape, kept only until its
+// last caller moves over.
+//
+// Three guarantees live in this statement rather than in Go, because a rule
+// enforced by the query is inherited by a new writer and a rule enforced by a
+// helper function is only inherited by a writer who remembers to call it.
+//
+//  1. THE BINDING IS PINNED.  The INSERT sources its anime_id from anime_cache
+//     with `bgm_id = @bgm_id`, so a re-binding that landed between the fetch and
+//     this write produces zero rows instead of filing one upstream's episode
+//     names under another's subject.  Same move UpdateEpisodesBgm and
+//     UpdateDescriptionCn make, for the same reason -- the Go-side re-read
+//     closes most of that window, this closes the rest, and the race becomes an
+//     observable zero-row result rather than wrong data.
+//
+//  2. AN EMPTY VALUE NEVER LANDS.  btrim + NULLIF turn ” and whitespace into
+//     NULL on the way in, the WHERE refuses a call where BOTH fields are empty,
+//     and the DO UPDATE arms keep the existing value whenever the incoming one
+//     is NULL.  Roughly a third of this table is rows whose two payload columns
+//     are both NULL -- written, before 0029, by a transform with no name check
+//     and an upsert with no COALESCE.  They render exactly like a missing row,
+//     so they cost the reader nothing, but they made "does this anime have
+//     titles" unanswerable by counting rows.  New writes cannot add to them.
+//
+//  3. PRECEDENCE IS PER FIELD.  manual outranks ddp outranks bangumi, scored by
+//     position in the array literal; an absent source scores 0, so any real
+//     source may fill a column nobody has claimed.  The comparison is >= rather
+//     than >, deliberately: a source must be able to correct itself on a later
+//     pass, which is the whole mechanism by which an airing show's titles fill
+//     in.  Each field is compared against ITS OWN source column, because one
+//     row routinely holds a name from one upstream beside a name_cn from
+//     another -- see 0029's section A.
+//
+// Value and source are always assigned in the same arm of the same CASE.  A
+// row whose name_cn was replaced while name_cn_source was left behind would
+// wear a label that licenses the next writer to overwrite the wrong thing, and
+// no constraint can catch it: a CHECK sees the row after the write, not the
+// transition.
+func (q *Queries) UpsertEpisodeTitleSourced(ctx context.Context, arg UpsertEpisodeTitleSourcedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, upsertEpisodeTitleSourced,
+		arg.Episode,
+		arg.NameCn,
+		arg.Name,
+		arg.Source,
+		arg.AnimeID,
+		arg.BgmID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/go-api/internal/db/gen/querier.go
+++ b/go-api/internal/db/gen/querier.go
@@ -90,6 +90,36 @@ type Querier interface {
 	// social/notification edges between the two users. Repeating the request is
 	// idempotent and still cleans up any stale edges.
 	BlockUser(ctx context.Context, blockerID uuid.UUID, blockedID uuid.UUID) (BlockUserRow, error)
+	// Half of the snapshot semantics an upsert cannot provide on its own.
+	//
+	// Upserting a fetch writes the episodes the upstream returned and says nothing
+	// about the ones it no longer returns.  So an entry bound to the wrong subject
+	// keeps every stale row the old binding left behind, and the new, correct rows
+	// simply overwrite the first few.  On a three-episode ONA bound to a full
+	// series that is three corrected rows in front of hundreds of wrong ones.
+	//
+	// The retraction is scoped to ONE SOURCE, and that scope is what makes it safe
+	// to run automatically.  A writer may withdraw what it previously said; it may
+	// not touch a column another source filled, and it may not delete a row
+	// outright, because the row may hold a manual correction or the other
+	// upstream's value in the other column.  Clearing per field and removing only
+	// what is left empty afterwards is the same conservatism the precedence rule
+	// above encodes, applied to removal.
+	//
+	// The cardinality guard is load-bearing, not defensive dressing.  With an
+	// empty kept-set every row is "outside" it, so a fetch that came back with no
+	// usable episodes -- a transient upstream blip, a subject mid-edit -- would
+	// retract this source's entire contribution for the anime.  Callers are
+	// specified to treat an empty result as 'empty' and never reach this query,
+	// but that is a convention, and a convention is the wrong place for the
+	// difference between "nothing changed" and "everything erased".
+	//
+	// Returns the episode numbers it touched so the caller can hand exactly those
+	// to DeleteEmptyEpisodeTitles.  The pairing is deliberately two statements: a
+	// data-modifying CTE cannot see its own effects, so a DELETE in the same
+	// statement would test the pre-UPDATE values and delete rows that still hold
+	// another source's title.
+	ClearEpisodeTitlesBySourceOutside(ctx context.Context, source string, animeID int32, kept []int32) ([]int32, error)
 	// Logout's DB write: ends the session the CALLER actually holds, and only
 	// that one.
 	//
@@ -208,6 +238,17 @@ type Querier interface {
 	DeleteComment(ctx context.Context, id uuid.UUID) error
 	DeleteCommentReaction(ctx context.Context, commentID uuid.UUID, userID uuid.UUID) (DeleteCommentReactionRow, error)
 	DeleteCommentReactionOnly(ctx context.Context, commentID uuid.UUID, userID uuid.UUID) (int64, error)
+	// Remove rows that ClearEpisodeTitlesBySourceOutside emptied.
+	//
+	// Scoped to the episode numbers that query returned rather than to "every
+	// empty row for this anime" on purpose.  The table already holds a large
+	// population of rows whose two payload columns were NULL from the day they
+	// were written; they are invisible to the reader, but they are the only record
+	// that an episode number exists at all for entries whose catalogue episode
+	// count is unknown, where the grid infers its size from the highest episode
+	// number it holds.  Sweeping them here would quietly shorten those grids as a
+	// side effect of an unrelated retraction.
+	DeleteEmptyEpisodeTitles(ctx context.Context, animeID int32, episodes []int32) (int64, error)
 	// DELETE /api/users/:username/follow.  Returns affected row count;
 	// the handler always returns 200 { following: false } regardless of
 	// whether a row was deleted (matches Express's findOneAndDelete which
@@ -1177,6 +1218,24 @@ type Querier interface {
 	// Express; the join is the same shape as the subscriptions list query
 	// but only returns the cardview projection.
 	ListProfileWatching(ctx context.Context, userID uuid.UUID) ([]ListProfileWatchingRow, error)
+	// The airing shows whose episode titles are due another look.
+	//
+	// Anchored on status = 'RELEASING' because that is the population whose titles
+	// are still being written upstream: episode 9's name appears in the week
+	// episode 9 airs, so one enrichment pass can never finish the job for a show
+	// mid-broadcast.  Finished shows are settled and are served by the one-off
+	// backfill instead; keeping them out of this predicate is what lets the sweep
+	// run on a single timestamp with no outcome bookkeeping (0029, section C).
+	//
+	// The freshness interval is a parameter rather than a literal because it has
+	// to stay above the client's episode-response cache TTL.  Asking again sooner
+	// than that returns the cached body, writes nothing new, and stamps the row as
+	// attempted -- a pass that consumes a slot and cannot make progress.
+	//
+	// ORDER BY matches the partial index (0029) so the scan reads a prefix and
+	// stops: never-swept rows first, then oldest-swept, with the recently-swept
+	// rows the freshness arm rejects sorting last.
+	ListReleasingEpisodeTitleCandidates(ctx context.Context, staleAfter pgtype.Interval, rowLimit int32) ([]ListReleasingEpisodeTitleCandidatesRow, error)
 	// Passing NULL report_status returns the entire moderation queue.
 	ListReports(ctx context.Context, reportStatus *string, pageOffset int32, pageLimit int32) ([]ListReportsRow, error)
 	// One modulo slice of the whole catalogue, for /api/anime/sitemap.
@@ -1593,6 +1652,15 @@ type Querier interface {
 	// The profile header remains resolvable so existing profile links do not turn
 	// into misleading 404s; the social handler redacts the watching list instead.
 	SetUserPublic(ctx context.Context, iD uuid.UUID, isPublic bool) error
+	// Stamp the attempt, pinned to the binding the attempt was made against.
+	//
+	// Written on every pass regardless of what the pass produced -- that is what
+	// moves a row to the back of the queue and keeps a show whose upstream has
+	// nothing from starving the ones that do.  The bgm_id predicate means a row
+	// re-bound during the fetch is not stamped, so the next pass re-asks under the
+	// binding it now holds instead of resting on an attempt made against the old
+	// one.
+	TouchEpisodeTitlesAt(ctx context.Context, anilistID int32, bgmID int32) (int64, error)
 	// Aggregate-only counters keep product telemetry useful without retaining a
 	// per-user browsing history.  The handler owns the event/target allowlist;
 	// matching CHECK constraints make that contract durable at the database edge.
@@ -1920,6 +1988,47 @@ type Querier interface {
 	// we upsert per episode so a re-enrich refreshes names in place. ON CONFLICT
 	// overwrites so corrected Bangumi data wins on the next pass.
 	UpsertEpisodeTitle(ctx context.Context, animeID int32, episode int32, nameCn *string, name *string) error
+	// Write one episode title, honouring both precedence and the binding it was
+	// fetched under.  This is the query every episode-title writer is expected to
+	// use; UpsertEpisodeTitle above is the pre-0029 shape, kept only until its
+	// last caller moves over.
+	//
+	// Three guarantees live in this statement rather than in Go, because a rule
+	// enforced by the query is inherited by a new writer and a rule enforced by a
+	// helper function is only inherited by a writer who remembers to call it.
+	//
+	// 1. THE BINDING IS PINNED.  The INSERT sources its anime_id from anime_cache
+	//    with `bgm_id = @bgm_id`, so a re-binding that landed between the fetch and
+	//    this write produces zero rows instead of filing one upstream's episode
+	//    names under another's subject.  Same move UpdateEpisodesBgm and
+	//    UpdateDescriptionCn make, for the same reason -- the Go-side re-read
+	//    closes most of that window, this closes the rest, and the race becomes an
+	//    observable zero-row result rather than wrong data.
+	//
+	// 2. AN EMPTY VALUE NEVER LANDS.  btrim + NULLIF turn '' and whitespace into
+	//    NULL on the way in, the WHERE refuses a call where BOTH fields are empty,
+	//    and the DO UPDATE arms keep the existing value whenever the incoming one
+	//    is NULL.  Roughly a third of this table is rows whose two payload columns
+	//    are both NULL -- written, before 0029, by a transform with no name check
+	//    and an upsert with no COALESCE.  They render exactly like a missing row,
+	//    so they cost the reader nothing, but they made "does this anime have
+	//    titles" unanswerable by counting rows.  New writes cannot add to them.
+	//
+	// 3. PRECEDENCE IS PER FIELD.  manual outranks ddp outranks bangumi, scored by
+	//    position in the array literal; an absent source scores 0, so any real
+	//    source may fill a column nobody has claimed.  The comparison is >= rather
+	//    than >, deliberately: a source must be able to correct itself on a later
+	//    pass, which is the whole mechanism by which an airing show's titles fill
+	//    in.  Each field is compared against ITS OWN source column, because one
+	//    row routinely holds a name from one upstream beside a name_cn from
+	//    another -- see 0029's section A.
+	//
+	// Value and source are always assigned in the same arm of the same CASE.  A
+	// row whose name_cn was replaced while name_cn_source was left behind would
+	// wear a label that licenses the next writer to overwrite the wrong thing, and
+	// no constraint can catch it: a CHECK sees the row after the write, not the
+	// transition.
+	UpsertEpisodeTitleSourced(ctx context.Context, arg UpsertEpisodeTitleSourcedParams) (int64, error)
 	// ==================== Follow CRUD ====================
 	// POST /api/users/:username/follow.  ON CONFLICT DO NOTHING — re-follow
 	// is idempotent (Express used findOneAndUpdate with upsert; same effect).

--- a/go-api/internal/db/queries/admin.sql
+++ b/go-api/internal/db/queries/admin.sql
@@ -335,6 +335,16 @@ SET
                                      THEN NULL ELSE episodes_bgm_outcome END,
     episodes_bgm_reason       = CASE WHEN (SELECT yes FROM rebound)
                                      THEN NULL ELSE episodes_bgm_reason END,
+    -- Same move as episodes_bgm_attempted_at above, for the sweep added in
+    -- 0029.  cleared_titles has just deleted this row's episode titles, and
+    -- the stamp beside them records an attempt made against the binding that
+    -- was replaced -- so leaving it would tell the airing sweep this row was
+    -- recently handled and keep it out of the candidate set for another 26
+    -- hours, with the page showing no titles for the whole window.  Nulling it
+    -- puts the row at the front of ListReleasingEpisodeTitleCandidates, which
+    -- orders NULLS FIRST for exactly this case.
+    episode_titles_at         = CASE WHEN (SELECT yes FROM rebound)
+                                     THEN NULL ELSE episode_titles_at END,
     updated_at    = now()
 WHERE anilist_id = sqlc.arg('anilist_id')::integer
 RETURNING

--- a/go-api/internal/db/queries/anime_cache.sql
+++ b/go-api/internal/db/queries/anime_cache.sql
@@ -1507,3 +1507,197 @@ WHERE title_romaji  ILIKE sqlc.arg(contains)::text
    OR title_chinese ILIKE sqlc.arg(contains)::text
    OR title_hant    ILIKE sqlc.arg(contains)::text
    OR title_hant    ILIKE sqlc.arg(contains_folded)::text;
+
+-- name: UpsertEpisodeTitleSourced :execrows
+-- Write one episode title, honouring both precedence and the binding it was
+-- fetched under.  This is the query every episode-title writer is expected to
+-- use; UpsertEpisodeTitle above is the pre-0029 shape, kept only until its
+-- last caller moves over.
+--
+-- Three guarantees live in this statement rather than in Go, because a rule
+-- enforced by the query is inherited by a new writer and a rule enforced by a
+-- helper function is only inherited by a writer who remembers to call it.
+--
+-- 1. THE BINDING IS PINNED.  The INSERT sources its anime_id from anime_cache
+--    with `bgm_id = @bgm_id`, so a re-binding that landed between the fetch and
+--    this write produces zero rows instead of filing one upstream's episode
+--    names under another's subject.  Same move UpdateEpisodesBgm and
+--    UpdateDescriptionCn make, for the same reason -- the Go-side re-read
+--    closes most of that window, this closes the rest, and the race becomes an
+--    observable zero-row result rather than wrong data.
+--
+-- 2. AN EMPTY VALUE NEVER LANDS.  btrim + NULLIF turn '' and whitespace into
+--    NULL on the way in, the WHERE refuses a call where BOTH fields are empty,
+--    and the DO UPDATE arms keep the existing value whenever the incoming one
+--    is NULL.  Roughly a third of this table is rows whose two payload columns
+--    are both NULL -- written, before 0029, by a transform with no name check
+--    and an upsert with no COALESCE.  They render exactly like a missing row,
+--    so they cost the reader nothing, but they made "does this anime have
+--    titles" unanswerable by counting rows.  New writes cannot add to them.
+--
+-- 3. PRECEDENCE IS PER FIELD.  manual outranks ddp outranks bangumi, scored by
+--    position in the array literal; an absent source scores 0, so any real
+--    source may fill a column nobody has claimed.  The comparison is >= rather
+--    than >, deliberately: a source must be able to correct itself on a later
+--    pass, which is the whole mechanism by which an airing show's titles fill
+--    in.  Each field is compared against ITS OWN source column, because one
+--    row routinely holds a name from one upstream beside a name_cn from
+--    another -- see 0029's section A.
+--
+-- Value and source are always assigned in the same arm of the same CASE.  A
+-- row whose name_cn was replaced while name_cn_source was left behind would
+-- wear a label that licenses the next writer to overwrite the wrong thing, and
+-- no constraint can catch it: a CHECK sees the row after the write, not the
+-- transition.
+INSERT INTO anime_episode_titles (
+    anime_id, episode, name_cn, name, name_cn_source, name_source
+)
+SELECT
+    ac.anilist_id,
+    sqlc.arg(episode)::int,
+    NULLIF(btrim(sqlc.arg(name_cn)::text), ''),
+    NULLIF(btrim(sqlc.arg(name)::text), ''),
+    CASE WHEN NULLIF(btrim(sqlc.arg(name_cn)::text), '') IS NULL
+         THEN NULL ELSE sqlc.arg(source)::text END,
+    CASE WHEN NULLIF(btrim(sqlc.arg(name)::text), '') IS NULL
+         THEN NULL ELSE sqlc.arg(source)::text END
+FROM anime_cache ac
+WHERE ac.anilist_id = sqlc.arg(anime_id)::int
+  AND ac.bgm_id     = sqlc.arg(bgm_id)::int
+  AND (NULLIF(btrim(sqlc.arg(name_cn)::text), '') IS NOT NULL
+       OR NULLIF(btrim(sqlc.arg(name)::text), '') IS NOT NULL)
+ON CONFLICT (anime_id, episode) DO UPDATE SET
+    name_cn = CASE
+        WHEN excluded.name_cn IS NULL THEN anime_episode_titles.name_cn
+        WHEN coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], excluded.name_cn_source), 0)
+             >= coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], anime_episode_titles.name_cn_source), 0)
+             THEN excluded.name_cn
+        ELSE anime_episode_titles.name_cn
+    END,
+    name_cn_source = CASE
+        WHEN excluded.name_cn IS NULL THEN anime_episode_titles.name_cn_source
+        WHEN coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], excluded.name_cn_source), 0)
+             >= coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], anime_episode_titles.name_cn_source), 0)
+             THEN excluded.name_cn_source
+        ELSE anime_episode_titles.name_cn_source
+    END,
+    name = CASE
+        WHEN excluded.name IS NULL THEN anime_episode_titles.name
+        WHEN coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], excluded.name_source), 0)
+             >= coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], anime_episode_titles.name_source), 0)
+             THEN excluded.name
+        ELSE anime_episode_titles.name
+    END,
+    name_source = CASE
+        WHEN excluded.name IS NULL THEN anime_episode_titles.name_source
+        WHEN coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], excluded.name_source), 0)
+             >= coalesce(array_position(ARRAY['bangumi','ddp','manual']::text[], anime_episode_titles.name_source), 0)
+             THEN excluded.name_source
+        ELSE anime_episode_titles.name_source
+    END;
+
+-- name: ClearEpisodeTitlesBySourceOutside :many
+-- Half of the snapshot semantics an upsert cannot provide on its own.
+--
+-- Upserting a fetch writes the episodes the upstream returned and says nothing
+-- about the ones it no longer returns.  So an entry bound to the wrong subject
+-- keeps every stale row the old binding left behind, and the new, correct rows
+-- simply overwrite the first few.  On a three-episode ONA bound to a full
+-- series that is three corrected rows in front of hundreds of wrong ones.
+--
+-- The retraction is scoped to ONE SOURCE, and that scope is what makes it safe
+-- to run automatically.  A writer may withdraw what it previously said; it may
+-- not touch a column another source filled, and it may not delete a row
+-- outright, because the row may hold a manual correction or the other
+-- upstream's value in the other column.  Clearing per field and removing only
+-- what is left empty afterwards is the same conservatism the precedence rule
+-- above encodes, applied to removal.
+--
+-- The cardinality guard is load-bearing, not defensive dressing.  With an
+-- empty kept-set every row is "outside" it, so a fetch that came back with no
+-- usable episodes -- a transient upstream blip, a subject mid-edit -- would
+-- retract this source's entire contribution for the anime.  Callers are
+-- specified to treat an empty result as 'empty' and never reach this query,
+-- but that is a convention, and a convention is the wrong place for the
+-- difference between "nothing changed" and "everything erased".
+--
+-- Returns the episode numbers it touched so the caller can hand exactly those
+-- to DeleteEmptyEpisodeTitles.  The pairing is deliberately two statements: a
+-- data-modifying CTE cannot see its own effects, so a DELETE in the same
+-- statement would test the pre-UPDATE values and delete rows that still hold
+-- another source's title.
+UPDATE anime_episode_titles t
+   SET name_cn        = CASE WHEN t.name_cn_source = sqlc.arg(source)::text
+                             THEN NULL ELSE t.name_cn END,
+       name_cn_source = CASE WHEN t.name_cn_source = sqlc.arg(source)::text
+                             THEN NULL ELSE t.name_cn_source END,
+       name           = CASE WHEN t.name_source = sqlc.arg(source)::text
+                             THEN NULL ELSE t.name END,
+       name_source    = CASE WHEN t.name_source = sqlc.arg(source)::text
+                             THEN NULL ELSE t.name_source END
+ WHERE t.anime_id = sqlc.arg(anime_id)::int
+   AND cardinality(sqlc.arg(kept)::int[]) > 0
+   AND NOT (t.episode = ANY(sqlc.arg(kept)::int[]))
+   AND (t.name_cn_source = sqlc.arg(source)::text
+        OR t.name_source = sqlc.arg(source)::text)
+RETURNING t.episode;
+
+-- name: DeleteEmptyEpisodeTitles :execrows
+-- Remove rows that ClearEpisodeTitlesBySourceOutside emptied.
+--
+-- Scoped to the episode numbers that query returned rather than to "every
+-- empty row for this anime" on purpose.  The table already holds a large
+-- population of rows whose two payload columns were NULL from the day they
+-- were written; they are invisible to the reader, but they are the only record
+-- that an episode number exists at all for entries whose catalogue episode
+-- count is unknown, where the grid infers its size from the highest episode
+-- number it holds.  Sweeping them here would quietly shorten those grids as a
+-- side effect of an unrelated retraction.
+DELETE FROM anime_episode_titles
+ WHERE anime_id = sqlc.arg(anime_id)::int
+   AND episode = ANY(sqlc.arg(episodes)::int[])
+   AND name_cn IS NULL
+   AND name IS NULL;
+
+-- name: ListReleasingEpisodeTitleCandidates :many
+-- The airing shows whose episode titles are due another look.
+--
+-- Anchored on status = 'RELEASING' because that is the population whose titles
+-- are still being written upstream: episode 9's name appears in the week
+-- episode 9 airs, so one enrichment pass can never finish the job for a show
+-- mid-broadcast.  Finished shows are settled and are served by the one-off
+-- backfill instead; keeping them out of this predicate is what lets the sweep
+-- run on a single timestamp with no outcome bookkeeping (0029, section C).
+--
+-- The freshness interval is a parameter rather than a literal because it has
+-- to stay above the client's episode-response cache TTL.  Asking again sooner
+-- than that returns the cached body, writes nothing new, and stamps the row as
+-- attempted -- a pass that consumes a slot and cannot make progress.
+--
+-- ORDER BY matches the partial index (0029) so the scan reads a prefix and
+-- stops: never-swept rows first, then oldest-swept, with the recently-swept
+-- rows the freshness arm rejects sorting last.
+SELECT
+    ac.anilist_id,
+    ac.bgm_id
+FROM anime_cache ac
+WHERE ac.status = 'RELEASING'
+  AND ac.bgm_id IS NOT NULL
+  AND (ac.episode_titles_at IS NULL
+       OR ac.episode_titles_at < now() - sqlc.arg(stale_after)::interval)
+ORDER BY ac.episode_titles_at NULLS FIRST, ac.anilist_id
+LIMIT sqlc.arg(row_limit);
+
+-- name: TouchEpisodeTitlesAt :execrows
+-- Stamp the attempt, pinned to the binding the attempt was made against.
+--
+-- Written on every pass regardless of what the pass produced -- that is what
+-- moves a row to the back of the queue and keeps a show whose upstream has
+-- nothing from starving the ones that do.  The bgm_id predicate means a row
+-- re-bound during the fetch is not stamped, so the next pass re-asks under the
+-- binding it now holds instead of resting on an attempt made against the old
+-- one.
+UPDATE anime_cache
+   SET episode_titles_at = now()
+ WHERE anilist_id = sqlc.arg(anilist_id)::int
+   AND bgm_id     = sqlc.arg(bgm_id)::int;

--- a/go-api/internal/db/queries/anime_cache.sql
+++ b/go-api/internal/db/queries/anime_cache.sql
@@ -1549,23 +1549,45 @@ WHERE title_romaji  ILIKE sqlc.arg(contains)::text
 -- wear a label that licenses the next writer to overwrite the wrong thing, and
 -- no constraint can catch it: a CHECK sees the row after the write, not the
 -- transition.
+WITH incoming AS (
+    -- The trim set is explicit, and every character in it is here because
+    -- bare btrim(text) does NOT strip it.  btrim's default set is the ASCII
+    -- space and nothing else, so a value of a single tab, newline or -- the
+    -- one that makes this reachable rather than theoretical -- U+3000
+    -- IDEOGRAPHIC SPACE survives NULLIF and lands as a row.
+    --
+    -- U+3000 is the ordinary space in Japanese and Chinese text and both
+    -- upstreams feeding this table are CJK sources, so "whitespace only"
+    -- arrives in that form routinely.  A row that lands that way is worse
+    -- than a blank one: it renders as an empty title AND claims the column at
+    -- its source's precedence, so the next pass carrying the real name is
+    -- scored against a claimed column and a lower-ranked source loses to
+    -- nothing at all.
+    --
+    -- An explicit set rather than a regexp character class because
+    -- [[:space:]] resolves through the database's ctype, which makes the
+    -- behaviour of this guard depend on how the cluster was initialised.
+    -- U+00A0 and U+FEFF are included for the same reason as U+3000: they
+    -- survive a naive trim and arrive from scraped upstreams.
+    SELECT
+        NULLIF(btrim(sqlc.arg(name_cn)::text, E' \t\n\r\u3000\u00a0\ufeff'), '') AS name_cn,
+        NULLIF(btrim(sqlc.arg(name)::text,    E' \t\n\r\u3000\u00a0\ufeff'), '') AS name
+)
 INSERT INTO anime_episode_titles (
     anime_id, episode, name_cn, name, name_cn_source, name_source
 )
 SELECT
     ac.anilist_id,
     sqlc.arg(episode)::int,
-    NULLIF(btrim(sqlc.arg(name_cn)::text), ''),
-    NULLIF(btrim(sqlc.arg(name)::text), ''),
-    CASE WHEN NULLIF(btrim(sqlc.arg(name_cn)::text), '') IS NULL
-         THEN NULL ELSE sqlc.arg(source)::text END,
-    CASE WHEN NULLIF(btrim(sqlc.arg(name)::text), '') IS NULL
-         THEN NULL ELSE sqlc.arg(source)::text END
+    i.name_cn,
+    i.name,
+    CASE WHEN i.name_cn IS NULL THEN NULL ELSE sqlc.arg(source)::text END,
+    CASE WHEN i.name    IS NULL THEN NULL ELSE sqlc.arg(source)::text END
 FROM anime_cache ac
+CROSS JOIN incoming i
 WHERE ac.anilist_id = sqlc.arg(anime_id)::int
   AND ac.bgm_id     = sqlc.arg(bgm_id)::int
-  AND (NULLIF(btrim(sqlc.arg(name_cn)::text), '') IS NOT NULL
-       OR NULLIF(btrim(sqlc.arg(name)::text), '') IS NOT NULL)
+  AND (i.name_cn IS NOT NULL OR i.name IS NOT NULL)
 ON CONFLICT (anime_id, episode) DO UPDATE SET
     name_cn = CASE
         WHEN excluded.name_cn IS NULL THEN anime_episode_titles.name_cn

--- a/go-api/internal/episodetitles/apply.go
+++ b/go-api/internal/episodetitles/apply.go
@@ -1,0 +1,171 @@
+// Package episodetitles holds the write sequence that turns a dandanplay
+// episode list into anime_episode_titles rows.
+//
+// It exists as its own package for one reason: two callers need the identical
+// sequence and they cannot import each other.  cmd/bgmbackfill drains the
+// backlog once, from a shell, under a human's eye; internal/queue re-asks the
+// airing slice on a timer.  A CLI cannot import internal/queue without pulling
+// river into a one-shot binary, and internal/queue has no business importing a
+// command.  So the sequence lives below both.
+//
+// The alternative was to let each keep its own copy, and that is precisely the
+// state internal/queue/episode_titles_write.go was created to end: two workers
+// with the same five-line loop that had already drifted in their logging.
+// Writing the second copy on the same day the first was removed would have
+// been a strange thing to do.
+//
+// The dependencies are deliberately thin — pgx, the generated queries, and the
+// dandanplay types.  Nothing here knows about river, HTTP, or flags, so both
+// callers pay only for what they use.
+package episodetitles
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/dandanplay"
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+// Source is the provenance label every row written through this package
+// carries.  Migration 0029 defines the vocabulary and the precedence order;
+// this is the only place the dandanplay path names its own position in it.
+const Source = "ddp"
+
+// Title is one normalised episode ready to be written.  Exactly one of NameCn
+// and Name is non-empty — see dandanplay.NormalizeDandanEpisodeTitle, which
+// decides which.
+type Title struct {
+	Episode int32
+	NameCn  string
+	Name    string
+}
+
+// Usable keeps the entries that are both a main episode and carry something
+// storable.
+//
+// Main-episode detection is strconv.Atoi on rawEpisodeNumber, NOT
+// dandanplay.BuildEpisodeMap.  That function exists to match a local file to a
+// danmaku track: it deliberately maps O1/S2 specials ONTO ordinary episode
+// numbers, and falls back to the entire list when no pure-numeric entry
+// exists.  Both behaviours are correct there and wrong here, where a special
+// must not be written into an ordinary episode's slot.  A failed Atoi IS the
+// filter, and it rejects fractional numbering ("1.5") for the same reason: the
+// destination keys on an integer episode and a half-episode has no slot.
+//
+// An entry whose title normalises to nothing on both sides is dropped rather
+// than written.  A row of two NULLs renders exactly like no row at all, so it
+// helps no reader, while making "how many titles do we hold for this anime"
+// unanswerable by counting rows — a question this table has already lost the
+// ability to answer for roughly a third of its contents.
+func Usable(eps []dandanplay.DandanEpisode) []Title {
+	out := make([]Title, 0, len(eps))
+	for _, e := range eps {
+		n, err := strconv.Atoi(e.RawEpisodeNumber)
+		if err != nil || n <= 0 {
+			continue
+		}
+		cn, name := dandanplay.NormalizeDandanEpisodeTitle(e.Title)
+		if cn == "" && name == "" {
+			continue
+		}
+		out = append(out, Title{Episode: int32(n), NameCn: cn, Name: name})
+	}
+	return out
+}
+
+// CountMain counts main entries whether or not they carried a usable title.
+//
+// Kept separate from Usable because the two answer different questions and a
+// caller wants both: Usable says what can be written, CountMain says how long
+// upstream thinks the season is.  Compared against anime_cache.episodes the
+// latter is the scope-mismatch signal — a three-episode ONA bound to a
+// full-series subject reports hundreds here — which nothing in this package
+// acts on, and which callers are expected to record so the question can later
+// be decided from a distribution rather than a guessed threshold.
+func CountMain(eps []dandanplay.DandanEpisode) int {
+	n := 0
+	for _, e := range eps {
+		if v, err := strconv.Atoi(e.RawEpisodeNumber); err == nil && v > 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// Apply writes one anime's titles as a single transaction.
+//
+// The four statements are one unit and a partial application is worse than not
+// having run at all:
+//
+//	upsert     states what this source now holds
+//	clear      withdraws what it used to hold and no longer does
+//	delete     removes the rows the withdrawal emptied
+//	touch      records the attempt so the sweep moves on
+//
+// Titles without the withdrawal leave a stale tail in place under fresh rows;
+// a withdrawal without the stamp re-does the whole anime on the next pass.
+//
+// A zero-row upsert aborts the whole anime rather than continuing.  Zero rows
+// can only mean the query's bgm_id predicate did not match, i.e. the binding
+// changed between the fetch and this transaction — so every remaining title in
+// the slice describes a subject this row no longer holds, and writing the tail
+// of that list is the exact failure the predicate exists to prevent.
+func Apply(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	q *dbgen.Queries,
+	anilistID, bgmID int32,
+	titles []Title,
+) (written, retracted int, err error) {
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("episodetitles: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	qtx := q.WithTx(tx)
+
+	kept := make([]int32, 0, len(titles))
+	for _, t := range titles {
+		n, err := qtx.UpsertEpisodeTitleSourced(ctx, dbgen.UpsertEpisodeTitleSourcedParams{
+			Episode: t.Episode,
+			NameCn:  t.NameCn,
+			Name:    t.Name,
+			Source:  Source,
+			AnimeID: anilistID,
+			BgmID:   bgmID,
+		})
+		if err != nil {
+			return 0, 0, fmt.Errorf("episodetitles: upsert ep %d: %w", t.Episode, err)
+		}
+		if n == 0 {
+			return 0, 0, fmt.Errorf(
+				"episodetitles: binding moved during write (anilist=%d bgm=%d)", anilistID, bgmID)
+		}
+		written++
+		kept = append(kept, t.Episode)
+	}
+
+	cleared, err := qtx.ClearEpisodeTitlesBySourceOutside(ctx, Source, anilistID, kept)
+	if err != nil {
+		return 0, 0, fmt.Errorf("episodetitles: clear outside: %w", err)
+	}
+	if len(cleared) > 0 {
+		if _, err := qtx.DeleteEmptyEpisodeTitles(ctx, anilistID, cleared); err != nil {
+			return 0, 0, fmt.Errorf("episodetitles: delete emptied: %w", err)
+		}
+	}
+	retracted = len(cleared)
+
+	if _, err := qtx.TouchEpisodeTitlesAt(ctx, anilistID, bgmID); err != nil {
+		return 0, 0, fmt.Errorf("episodetitles: touch: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, 0, fmt.Errorf("episodetitles: commit: %w", err)
+	}
+	return written, retracted, nil
+}

--- a/go-api/internal/queue/args.go
+++ b/go-api/internal/queue/args.go
@@ -340,3 +340,35 @@ func (DescriptionBackfillScanArgs) Kind() string { return "description_backfill_
 func (DescriptionBackfillScanArgs) InsertOpts() river.InsertOpts {
 	return river.InsertOpts{Queue: DescriptionBackfillQueueName}
 }
+
+// episodeTitlesUniqueStates collapses a second episode-title sweep into the one
+// already in flight.  Two concurrent passes would race on the same attempt
+// stamps and spend the shared dandanplay budget twice for one pass worth of
+// progress.
+var episodeTitlesUniqueStates = []rivertype.JobState{
+	rivertype.JobStateAvailable,
+	rivertype.JobStatePending,
+	rivertype.JobStateRetryable,
+	rivertype.JobStateRunning,
+	rivertype.JobStateScheduled,
+}
+
+// EpisodeTitlesArgs is the periodic top-up for shows still airing.  No fields:
+// the candidate query reads anime_cache directly, so the job is a pure trigger.
+// See episode_titles_releasing.go for why only airing shows.
+type EpisodeTitlesArgs struct{}
+
+// Kind returns the river job kind for the airing episode-title sweep.
+func (EpisodeTitlesArgs) Kind() string { return "episode_titles_releasing" }
+
+// InsertOpts pins the sweep to its own queue and collapses duplicates.  See
+// EpisodeTitlesQueueName for why the queue is separate.
+func (EpisodeTitlesArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue: EpisodeTitlesQueueName,
+		UniqueOpts: river.UniqueOpts{
+			ByArgs:  true,
+			ByState: episodeTitlesUniqueStates,
+		},
+	}
+}

--- a/go-api/internal/queue/bangumi_episodes.go
+++ b/go-api/internal/queue/bangumi_episodes.go
@@ -487,7 +487,7 @@ func (w *EpisodesBgmWorker) Work(ctx context.Context, job *river.Job[EpisodesBgm
 	// Episode titles are best-effort, matching the stance V2 takes on the same
 	// write: the count has already committed, and failing the job here would
 	// re-spend two upstream requests to retry an optional column.
-	written, failures := w.writeTitles(ctx, anilistID, titles)
+	written, failures := writeEpisodeTitles(ctx, w.db, anilistID, titles)
 	if failures > 0 {
 		slog.WarnContext(ctx, "episodes_bgm title write failures",
 			"anilistId", anilistID, "bgmId", bgmID,
@@ -555,19 +555,6 @@ func (w *EpisodesBgmWorker) fetch(ctx context.Context, bgmID int) (*bangumi.Subj
 		episodes = &bangumi.EpisodesResponse{}
 	}
 	return subject, episodes, nil
-}
-
-// writeTitles upserts the normalised episode titles, returning how many landed
-// and how many failed.
-func (w *EpisodesBgmWorker) writeTitles(ctx context.Context, anilistID int32, titles []epTitle) (written, failures int) {
-	for _, t := range titles {
-		if err := w.db.UpsertEpisodeTitle(ctx, anilistID, t.episode, t.nameCN, t.name); err != nil {
-			failures++
-			continue
-		}
-		written++
-	}
-	return written, failures
 }
 
 // stamp records a decided non-'ok' outcome so the sweep can move past the row.

--- a/go-api/internal/queue/bangumi_v2.go
+++ b/go-api/internal/queue/bangumi_v2.go
@@ -348,14 +348,8 @@ func (w *BangumiV2Worker) Work(ctx context.Context, job *river.Job[BangumiV2Args
 		}
 	} else if episodes != nil {
 		titles := normalizeEpisodeTitles(episodes.Eps)
-		epFailures := 0
-		for _, t := range titles {
-			if err := w.db.UpsertEpisodeTitle(ctx, anilistID, t.episode, t.nameCN, t.name); err != nil {
-				epFailures++
-				continue
-			}
-			epTitlesWritten++
-		}
+		var epFailures int
+		epTitlesWritten, epFailures = writeEpisodeTitles(ctx, w.db, anilistID, titles)
 		if epFailures > 0 {
 			slog.WarnContext(ctx, "bangumi_v2 episode title write failures",
 				"anilistId", anilistID, "bgmId", bgmID,

--- a/go-api/internal/queue/control.go
+++ b/go-api/internal/queue/control.go
@@ -100,6 +100,20 @@ const HantBackfillQueueName = "hant_backfill"
 // later" has to be one call and not a deploy.
 const EpisodesBgmQueueName = "episodes_bgm"
 
+// EpisodeTitlesQueueName isolates the airing-show episode-title top-up.
+//
+// Its own queue for two reasons.  One pass can run for minutes -- one upstream
+// request per candidate through a shared 800ms bucket -- and on the default
+// queue that would hold the single worker slot away from the V1/V2 enrichment
+// a page load is waiting on.
+//
+// The other is the kill switch.  EPISODE_TITLES_SWEEP_ENABLED gates the worker
+// but only takes effect on restart; a queue of its own means river's runtime
+// pause can stop this sweep, and only this sweep, without a deploy.  Same
+// argument EpisodesBgmQueueName makes above, and for the same kind of output:
+// rows that render on a public, indexed page.
+const EpisodeTitlesQueueName = "episode_titles"
+
 // Stats is the response shape for Status — the admin endpoint
 // marshals this to JSON.  Mirrors the relevant subset of Express
 // getQueueStatus() (which also reported in-memory queue depths from

--- a/go-api/internal/queue/episode_titles_releasing.go
+++ b/go-api/internal/queue/episode_titles_releasing.go
@@ -1,0 +1,308 @@
+// episode_titles_releasing.go — the periodic top-up for shows still airing.
+//
+// # Why only airing shows
+//
+// A finished show's episode titles are settled: filling them is a backlog, and
+// a backlog is drained once, by `bgmbackfill --heal-episode-titles`, where a
+// human can read the classification before anything is written.  What a
+// one-shot pass structurally cannot finish is a show mid-broadcast — episode
+// 9's name appears upstream in the week episode 9 airs — so that slice, and
+// only that slice, needs a timer behind it.
+//
+// Restricting the candidate set to status='RELEASING' is also what lets this
+// sweep run on a single timestamp with no outcome bookkeeping.  Migrations
+// 0015 and 0023 both had to add attempt/outcome columns because their sweeps
+// scanned the whole catalogue and decided candidacy on "the value is still
+// missing", so a row that could never produce a value held the front of every
+// batch forever.  Neither ingredient is present here: candidacy is the attempt
+// stamp, which is written whether or not the pass produced anything, and the
+// candidate set shrinks on its own as AniList sync flips shows to FINISHED.
+// 0029's section C records the argument and the guard on it.
+//
+// # Why the freshness window is longer than the interval
+//
+// The dandanplay client caches an episode response for 24h.  Re-asking sooner
+// than that returns the cached body, writes nothing new, and stamps the row as
+// attempted — a pass that consumes a slot and cannot make progress.  So the
+// candidate query's window (26h) is deliberately longer than the cache TTL,
+// and the fire interval (6h) is shorter than the window: the sweep wakes often
+// enough to spread its work and to pick up rows whose stamp has just aged out,
+// while no individual row is asked about more than once a day.
+//
+// # Two ways to stop it
+//
+// EPISODE_TITLES_SWEEP_ENABLED is read at WORK time, not at registration time.
+// Gating registration alone would leave any job already enqueued to run
+// anyway, so the flag would not describe the running system.  Reading it here
+// means a restart with the flag off silences the sweep completely, including
+// anything river had queued.
+//
+// The flag still needs a restart to change, so the sweep also gets its own
+// queue.  That makes river's runtime pause apply to it alone — the same
+// mechanism the admin surface already uses to freeze heal-CN without touching
+// enrichment — and a queue pause needs no deploy.  The env flag is the switch
+// you set before a release; the queue pause is the one you reach for at 3am.
+package queue
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/dandanplay"
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+	"github.com/lawrenceli0228/animego/go-api/internal/episodetitles"
+)
+
+// episodeTitlesInterval is how often the sweep fires.  Shorter than the
+// per-row freshness window on purpose: it spreads a day's work over four
+// wake-ups instead of one and picks up rows as their stamps age out, without
+// any row being asked about more than once a day.
+const episodeTitlesInterval = 6 * time.Hour
+
+// episodeTitlesStaleAfter is how old a row's attempt stamp must be before it
+// is offered again.  MUST stay above the dandanplay client's 24h episode cache
+// TTL; below it the sweep re-reads its own cached response and burns a pass.
+const episodeTitlesStaleAfter = 26 * time.Hour
+
+// episodeTitlesBatch caps one pass.  The airing slice of the catalogue is
+// small — tens of rows, not thousands — so this is a ceiling against an
+// unexpected status flood rather than a throttle in normal operation.
+const episodeTitlesBatch int32 = 200
+
+// episodeTitlesWorkTimeout bounds the whole pass.  One row costs one upstream
+// request through the shared 800ms bucket, so a full batch is a few minutes;
+// the timeout is set well above that because being cut off mid-batch is
+// harmless — every row this pass did not reach is still a candidate on the
+// next one.
+const episodeTitlesWorkTimeout = 10 * time.Minute
+
+// episodeTitlesEnabledEnv gates the sweep.  Absent or falsey means the worker
+// returns immediately; see the file comment for why this is read per job
+// rather than at registration.
+const episodeTitlesEnabledEnv = "EPISODE_TITLES_SWEEP_ENABLED"
+
+// EpisodeTitlesReader is the read surface the sweep needs.
+type EpisodeTitlesReader interface {
+	ListReleasingEpisodeTitleCandidates(ctx context.Context, staleAfter pgtype.Interval, rowLimit int32) ([]dbgen.ListReleasingEpisodeTitleCandidatesRow, error)
+	LookupBgmIdMap(ctx context.Context, anilistID int32) (int32, error)
+}
+
+// EpisodeTitlesClient is the upstream surface the sweep needs.
+type EpisodeTitlesClient interface {
+	FetchEpisodesByBgmID(ctx context.Context, bgmID int32) (*dandanplay.EpisodeData, error)
+}
+
+// EpisodeTitlesWorker re-asks dandanplay about airing shows.
+//
+// It holds the pool and the concrete *dbgen.Queries because the write is a
+// four-statement transaction shared with the CLI (internal/episodetitles), and
+// that sequence is the thing that must not be reimplemented per caller.  The
+// consequence is that this worker is exercised by the integration suite rather
+// than by an in-memory double, which is the right trade for a job whose entire
+// behaviour is database state.
+type EpisodeTitlesWorker struct {
+	river.WorkerDefaults[EpisodeTitlesArgs]
+	pool   *pgxpool.Pool
+	q      *dbgen.Queries
+	db     EpisodeTitlesReader
+	client EpisodeTitlesClient
+}
+
+// NewEpisodeTitlesWorker builds the worker.
+func NewEpisodeTitlesWorker(pool *pgxpool.Pool, q *dbgen.Queries, client EpisodeTitlesClient) *EpisodeTitlesWorker {
+	return &EpisodeTitlesWorker{pool: pool, q: q, db: q, client: client}
+}
+
+// Timeout bounds one pass.
+func (w *EpisodeTitlesWorker) Timeout(*river.Job[EpisodeTitlesArgs]) time.Duration {
+	return episodeTitlesWorkTimeout
+}
+
+// Work runs one pass over the airing slice.
+//
+// Per-row failures are logged and counted, never returned.  A pass that
+// returns an error is retried by river with an exponential backoff measured in
+// days, which for a sweep that re-fires every six hours is strictly worse than
+// simply letting the next pass pick the row up — and the rows this one did
+// reach have already committed.
+func (w *EpisodeTitlesWorker) Work(ctx context.Context, _ *river.Job[EpisodeTitlesArgs]) error {
+	if !episodeTitlesSweepEnabled() {
+		slog.InfoContext(ctx, "episode_titles sweep disabled", "env", episodeTitlesEnabledEnv)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, episodeTitlesWorkTimeout)
+	defer cancel()
+	start := time.Now()
+
+	rows, err := w.db.ListReleasingEpisodeTitleCandidates(
+		ctx,
+		pgtype.Interval{Microseconds: int64(episodeTitlesStaleAfter / time.Microsecond), Valid: true},
+		episodeTitlesBatch,
+	)
+	if err != nil {
+		return fmt.Errorf("episode_titles list candidates: %w", err)
+	}
+	if len(rows) == 0 {
+		slog.InfoContext(ctx, "episode_titles nothing due")
+		return nil
+	}
+
+	var accepted, written, retracted, rejected, empty, failed int
+	for _, row := range rows {
+		if row.BgmID == nil {
+			continue // the query's predicate guarantees this
+		}
+		res := w.sweepOne(ctx, row.AnilistID, *row.BgmID)
+		switch res.class {
+		case sweepWritten:
+			accepted++
+			written += res.written
+			retracted += res.retracted
+		case sweepRejected:
+			rejected++
+		case sweepEmpty:
+			empty++
+		default:
+			failed++
+		}
+	}
+
+	slog.InfoContext(ctx, "episode_titles pass done",
+		"candidates", len(rows),
+		"accepted", accepted,
+		"titlesWritten", written,
+		"rowsRetracted", retracted,
+		"rejected", rejected,
+		"empty", empty,
+		"failed", failed,
+		"duration", time.Since(start))
+	return nil
+}
+
+type sweepClass int
+
+const (
+	sweepWritten sweepClass = iota
+	sweepRejected
+	sweepEmpty
+	sweepFailed
+)
+
+type sweepResult struct {
+	class     sweepClass
+	written   int
+	retracted int
+}
+
+// sweepOne handles a single anime, applying the same identity rule the CLI
+// uses: bgm_id_map decides wherever it has an entry, and dandanplay's
+// cross-link is consulted only where the map is silent.  Keeping the two in
+// step matters because they write the same rows through the same source label;
+// if they disagreed about which bindings are trustworthy, each pass would
+// partially undo the other's judgement.
+func (w *EpisodeTitlesWorker) sweepOne(ctx context.Context, anilistID, bgmID int32) sweepResult {
+	mapBgm, mapErr := w.db.LookupBgmIdMap(ctx, anilistID)
+	mapSpeaks := mapErr == nil
+	if mapErr != nil && mapErr != pgx.ErrNoRows {
+		slog.WarnContext(ctx, "episode_titles id-map lookup failed",
+			"anilistId", anilistID, "err", mapErr)
+		return sweepResult{class: sweepFailed}
+	}
+	if mapSpeaks && mapBgm != bgmID {
+		// The authoritative map contradicts the stored binding.  Nothing is
+		// written and no upstream request is spent; re-binding is the admin
+		// surface's job, not this sweep's.
+		return sweepResult{class: sweepRejected}
+	}
+
+	data, err := w.client.FetchEpisodesByBgmID(ctx, bgmID)
+	if err != nil {
+		slog.WarnContext(ctx, "episode_titles fetch failed",
+			"anilistId", anilistID, "bgmId", bgmID, "err", err)
+		return sweepResult{class: sweepFailed}
+	}
+	if data == nil {
+		return sweepResult{class: sweepEmpty}
+	}
+	if !mapSpeaks && data.AniListID != anilistID {
+		// Includes AniListID == 0, i.e. dandanplay published no cross-link:
+		// nothing vouches for this binding, so nothing is written.  Absence of
+		// evidence, kept distinct from evidence of absence.
+		return sweepResult{class: sweepRejected}
+	}
+
+	titles := episodetitles.Usable(data.Episodes)
+	if len(titles) == 0 {
+		return sweepResult{class: sweepEmpty}
+	}
+
+	written, retracted, err := episodetitles.Apply(ctx, w.pool, w.q, anilistID, bgmID, titles)
+	if err != nil {
+		slog.WarnContext(ctx, "episode_titles apply failed",
+			"anilistId", anilistID, "bgmId", bgmID, "err", err)
+		return sweepResult{class: sweepFailed}
+	}
+	return sweepResult{class: sweepWritten, written: written, retracted: retracted}
+}
+
+// episodeTitlesSweepEnabled reads the kill switch.
+//
+// Accepts the shapes an operator actually types.  Anything unparseable is
+// treated as OFF: a typo in a variable that gates writes against production
+// should fail closed.
+func episodeTitlesSweepEnabled() bool {
+	v := os.Getenv(episodeTitlesEnabledEnv)
+	if v == "" {
+		return false
+	}
+	on, err := strconv.ParseBool(v)
+	return err == nil && on
+}
+
+// PeriodicEpisodeTitlesJob returns the river PeriodicJob for the sweep.
+//
+// RunOnStart is true, and the attempt stamp is what makes that safe.  river's
+// open-source pilot does not persist periodic schedules — nextRunAt is
+// recomputed at every Start — so a service that deploys more often than the
+// interval would otherwise never sweep at all (the failure
+// PeriodicHantBackfillJob records for its quarterly timer).  Firing on boot
+// removes that dependency, and a redeploy ten minutes later costs nothing:
+// every row the previous pass touched carries a stamp inside the 26h window
+// and is no longer a candidate.
+func PeriodicEpisodeTitlesJob() *river.PeriodicJob {
+	return river.NewPeriodicJob(
+		river.PeriodicInterval(episodeTitlesInterval),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return EpisodeTitlesArgs{}, nil
+		},
+		&river.PeriodicJobOpts{RunOnStart: true},
+	)
+}
+
+// AddEpisodeTitlesWorker registers the sweep on an existing bundle.
+//
+// Separate from the bundle builder for the same reason AddHantBackfillWorker
+// and AddEpisodesBgmWorkers are: it needs the dandanplay client, which no
+// other worker holds, and none of V12DB, which every other worker does.
+//
+// The client is passed in rather than constructed here so the sweep draws from
+// the SAME 800ms token bucket as user-facing /match and danmaku lookups.  A
+// second client would open a second bucket and double the real rate against
+// one AppId — the same argument the comment above WorkersWithBangumiAndNormalizer
+// makes for sharing the Bangumi client.
+func AddEpisodeTitlesWorker(w *river.Workers, pool *pgxpool.Pool, q *dbgen.Queries, client EpisodeTitlesClient) {
+	river.AddWorker(w, NewEpisodeTitlesWorker(pool, q, client))
+}
+
+// Compile-time guard: the worker must satisfy river.Worker for its args.
+var _ river.Worker[EpisodeTitlesArgs] = (*EpisodeTitlesWorker)(nil)

--- a/go-api/internal/queue/episode_titles_write.go
+++ b/go-api/internal/queue/episode_titles_write.go
@@ -1,0 +1,60 @@
+// episode_titles_write.go — the single loop that turns normalised episode
+// titles into anime_episode_titles rows.
+//
+// Two workers write this table from the Bangumi side: BangumiV2Worker, as the
+// last step of a full enrichment run, and EpisodesBgmWorker, after its identity
+// gate accepts a binding.  Until this file they each carried their own copy of
+// the same five-line loop — same signature, same best-effort stance, same
+// failure counting — and the copies had already started to drift in their log
+// wording.  A third writer was about to make it three.
+//
+// The stance the loop encodes, and the reason it is worth naming once rather
+// than three times:
+//
+//	Individual row failures are counted, not returned.  Both callers reach
+//	this point AFTER their authoritative write has already committed — V2 has
+//	written the subject and characters, the sweep has written the inferred
+//	episode count — and both deliberately treat per-episode names as the
+//	optional tail of that work.  Returning an error here would fail a job
+//	whose real work succeeded, and river would then re-spend the upstream
+//	requests that produced it.  So the caller gets a count and decides what to
+//	say about it.
+//
+// What this helper does NOT own is the precedence between sources.  That rule
+// — manual outranks dandanplay outranks Bangumi, and a non-empty value is never
+// overwritten with an empty one — lives in the SQL of the upsert itself, so
+// that every writer inherits it whether or not it routes through this file.
+// Putting it here instead would have made the invariant depend on remembering
+// to call the right Go function, which is exactly the kind of guarantee this
+// table has already lost once.
+package queue
+
+import "context"
+
+// episodeTitleUpserter is the narrow write surface writeEpisodeTitles needs.
+//
+// Declared here rather than reusing V2Writer or EpisodesBgmWriter because the
+// helper genuinely needs one method, and a one-method interface is what lets
+// both of those satisfy it without either importing the other's shape.
+type episodeTitleUpserter interface {
+	UpsertEpisodeTitle(ctx context.Context, animeID int32, episode int32, nameCN *string, name *string) error
+}
+
+// writeEpisodeTitles upserts every title in the slice, returning how many
+// landed and how many failed.  It never returns an error; see the file comment
+// for why that is the contract rather than an oversight.
+func writeEpisodeTitles(
+	ctx context.Context,
+	db episodeTitleUpserter,
+	anilistID int32,
+	titles []epTitle,
+) (written, failures int) {
+	for _, t := range titles {
+		if err := db.UpsertEpisodeTitle(ctx, anilistID, t.episode, t.nameCN, t.name); err != nil {
+			failures++
+			continue
+		}
+		written++
+	}
+	return written, failures
+}

--- a/go-api/migrations/0029_episode_title_source.down.sql
+++ b/go-api/migrations/0029_episode_title_source.down.sql
@@ -1,0 +1,38 @@
+-- Mirror of the up migration, in reverse order: section B's index and column
+-- first, then section A's provenance columns.
+--
+-- The CHECK constraints are dropped with the columns they constrain -- an
+-- explicit DROP CONSTRAINT is not needed and would fail on a partially
+-- applied migration, which is the state a down migration is most likely to
+-- meet.  Same reasoning as 0022 and 0023.
+--
+-- Nothing here touches `name` or `name_cn`.  Rolling back provenance must not
+-- roll back the titles themselves: they are the payload, they predate this
+-- migration, and a public detail page renders them.
+--
+-- What rolling back actually discards, and how expensive each loss is:
+--
+--   name_source / name_cn_source.  The 'bangumi' labels are fully
+--   re-derivable -- re-running the up migration reconstructs them from the
+--   same proof, because Bangumi is still where every pre-0029 value came
+--   from.  A 'ddp' or 'manual' label is NOT: nothing else in the schema
+--   records that a dandanplay split or a human decision produced the string
+--   sitting in the column.  Re-applying afterwards would relabel those rows
+--   'bangumi', which is a wrong claim rather than a missing one, and the
+--   precedence rule in the upsert would then let a Bangumi value overwrite
+--   the better one.  If any non-'bangumi' source has been written by the time
+--   you read this, export the two columns before rolling back.
+--
+--   episode_titles_at.  The sweep's whole memory.  Losing it puts every
+--   RELEASING row back at "never swept", so the next pass re-asks upstream
+--   about all of them at once.  That is a spike in upstream requests, not a
+--   correctness problem -- the sweep converges again after one cycle.
+
+DROP INDEX IF EXISTS idx_anime_cache_episode_titles_pending;
+
+ALTER TABLE anime_cache
+    DROP COLUMN IF EXISTS episode_titles_at;
+
+ALTER TABLE anime_episode_titles
+    DROP COLUMN IF EXISTS name_source,
+    DROP COLUMN IF EXISTS name_cn_source;

--- a/go-api/migrations/0029_episode_title_source.up.sql
+++ b/go-api/migrations/0029_episode_title_source.up.sql
@@ -1,0 +1,244 @@
+-- 0029: per-field provenance for episode titles, plus the one stamp the
+-- RELEASING re-sweep needs to find work.
+--
+-- anime_episode_titles (0001:136) has carried the same four columns since the
+-- schema was created: (anime_id, episode) as the key, `name` and `name_cn` as
+-- the payload.  A row says what an episode is called and is silent about who
+-- decided that.  That was survivable while everything writing the table read
+-- from one upstream.  It stops being survivable the moment a second upstream
+-- arrives, because the upsert then has to answer a question the row does not
+-- contain: may the value already sitting here be replaced by the one I am
+-- holding?  Precedence needs a source to compare, and there is nowhere to
+-- record one.
+--
+-- This migration adds that somewhere, and the timestamp a periodic top-up
+-- needs so it can ask again about shows that are still airing.
+--
+--
+-- ============================================================
+-- A.  Provenance, per FIELD rather than per ROW
+-- ============================================================
+--
+-- Two columns rather than one, and the reason is not symmetry.  The two
+-- payload columns are fed by upstreams with different coverage:
+--
+--   Bangumi's /subject/{id}/ep returns `name` and `name_cn` as separate
+--   fields, so a Bangumi write can fill either, both, or neither.
+--
+--   dandanplay's episode feed returns ONE string per episode.  Its body is
+--   Chinese on some rows and Japanese on others, so a single dandanplay
+--   value lands in name_cn on one episode and in name on the next.
+--
+-- So a single row-level `source` column is not merely coarse, it is unable to
+-- describe states this table will actually hold: name from Bangumi beside a
+-- name_cn from dandanplay, in one row, is the ordinary case rather than the
+-- corner one.  Labelling that row 'bangumi' or 'ddp' would be a false claim
+-- either way, and precedence computed from a false claim overwrites the
+-- better value with the worse one.  Per-field is the smallest granularity
+-- that is not a lie.
+--
+-- Vocabulary, in precedence order:
+--
+--   manual    a human decided.  No path writes this today -- the admin
+--             surface can only DELETE episode titles, never edit them
+--             (admin.sql DeleteAnimeEpisodeTitlesForReset on a full reset,
+--             and the cleared_titles CTE inside UpdateAnimeEnrichmentSelective
+--             on a re-binding) -- and the value is admitted now so that
+--             adding the editor later is a code change, not a migration.
+--   ddp       dandanplay, split out of its single episodeTitle field.
+--   bangumi   bgm.tv, via /subject/{id}/ep.
+--
+-- The CHECK constrains the VOCABULARY only; it says nothing about which
+-- source may overwrite which.  That is the same division of labour 0014 and
+-- 0022 drew, with one difference worth naming: there, precedence was left to
+-- "the writers", spread across whichever jobs happened to write the column.
+-- Here it belongs in the SQL of the upsert itself, so that a new writer
+-- inherits the rule by using the query rather than by remembering it.  A
+-- constraint cannot express precedence anyway -- it sees one row at a time
+-- and precedence is a statement about the transition into that row.
+--
+-- The CHECK is inline rather than in a DO/pg_constraint block as 0014 and
+-- 0022 use.  Those two attached constraints to columns that could already
+-- exist from an earlier partial run, so the constraint had to be added
+-- separately and guarded.  Both columns here are new in this migration: the
+-- column and its CHECK always land together, and ADD COLUMN IF NOT EXISTS
+-- skips both as a unit on a re-run.  Same reasoning as 0023, same shape.
+
+ALTER TABLE anime_episode_titles
+    ADD COLUMN IF NOT EXISTS name_source text
+        CHECK (name_source IS NULL
+               OR name_source IN ('manual', 'ddp', 'bangumi')),
+    ADD COLUMN IF NOT EXISTS name_cn_source text
+        CHECK (name_cn_source IS NULL
+               OR name_cn_source IN ('manual', 'ddp', 'bangumi'));
+
+-- Backfill: every existing value is 'bangumi', and that is provable rather
+-- than assumed.
+--
+-- The table has exactly one INSERT path -- UpsertEpisodeTitle
+-- (db/queries/anime_cache.sql) -- plus the one-time load that created the
+-- rows in the first place.  Enumerated, that is three writers and no fourth:
+--
+--   internal/queue/bangumi_v2.go        BangumiV2Worker, last step of a full
+--                                       enrichment run, from /subject/{id}/ep
+--   internal/queue/bangumi_episodes.go  EpisodesBgmWorker (migration 0023),
+--                                       from the same endpoint, after its
+--                                       identity gate accepts the binding
+--   internal/migrate/transforms/anime_cache.go:428
+--                                       the Mongo -> Postgres transform,
+--                                       reading the `episodeTitles` array the
+--                                       Express Bangumi pipeline had written
+--
+-- All three derive from Bangumi, and the field names survive the whole way
+-- down: Bangumi's name/name_cn are Mongo's name/nameCn are this table's
+-- name/name_cn.  So 'bangumi' is what the data IS, not the safest guess
+-- available.  (Both queue workers now share one write loop in
+-- internal/queue/episode_titles_write.go; that consolidation does not change
+-- the provenance, only how many copies of the loop there are.)
+--
+-- A source is set only where the value it describes is non-NULL.  A NULL
+-- value has no provenance -- nobody decided it, it is the absence of a
+-- decision -- and stamping one would manufacture a claim that a later
+-- precedence check would then honour, blocking the first real value from
+-- being written.
+--
+-- The IS NULL guards on the source columns make the statement re-runnable
+-- rather than merely idempotent-looking.  ADD COLUMN IF NOT EXISTS above
+-- means this file can legitimately be applied twice; without the guard, a
+-- second run would relabel as 'bangumi' every row a writer had since marked
+-- 'ddp' or 'manual' -- silently, and in the direction that loses the better
+-- value.  The same predicates in the WHERE keep the second run from
+-- rewriting any row at all, so it costs nothing and produces no dead tuples.
+UPDATE anime_episode_titles
+   SET name_source    = CASE WHEN name IS NOT NULL AND name_source IS NULL
+                             THEN 'bangumi' ELSE name_source END,
+       name_cn_source = CASE WHEN name_cn IS NOT NULL AND name_cn_source IS NULL
+                             THEN 'bangumi' ELSE name_cn_source END
+ WHERE (name    IS NOT NULL AND name_source    IS NULL)
+    OR (name_cn IS NOT NULL AND name_cn_source IS NULL);
+
+-- No *_source_hash column, and that is a decision rather than a copy of 0022
+-- that got shortened.
+--
+-- 0022 needed a digest because title_hant was DERIVED from another column in
+-- the same row: title_chinese could be rewritten underneath a conversion and
+-- nothing in the schema would notice the conversion had gone stale.  Nothing
+-- here is derived from anything in this database.  name and name_cn are
+-- copied out of an upstream response, and the source label describes which
+-- upstream that was.  There is no input string to digest, so a hash column
+-- would have nothing to put in it.
+--
+-- What the schema still cannot enforce, recorded so it is not rediscovered as
+-- a bug: a value and its source have to be written by the SAME statement.  A
+-- CHECK sees the row after the write and cannot tell whether name_cn was
+-- replaced while name_cn_source was left behind, which would leave a
+-- dandanplay string wearing a 'bangumi' label.  The upsert is where that
+-- pairing has to hold, and it holds by construction only as long as every
+-- writer goes through it.
+
+
+-- ============================================================
+-- B.  The sweep stamp
+-- ============================================================
+--
+-- Episode titles for a show that is still airing are incomplete by
+-- construction: the upstream learns episode 9's name in the week episode 9
+-- airs.  A one-shot enrichment pass therefore cannot finish the job for
+-- anything currently broadcasting, and a periodic re-ask is not an
+-- optimisation but the only way those rows ever fill in.
+--
+-- One column records when a row was last swept.  It is an ATTEMPT stamp, not
+-- a success stamp -- the sweep writes it whether or not the pass produced a
+-- title -- and section C below is about why one clock is enough here when
+-- 0023 needed two.
+ALTER TABLE anime_cache
+    ADD COLUMN IF NOT EXISTS episode_titles_at timestamptz;
+
+-- Partial index for the sweep's candidate query.  The predicate the sweep is
+-- specified to run is:
+--
+--   status = 'RELEASING'
+--   AND bgm_id IS NOT NULL
+--   AND (episode_titles_at IS NULL
+--        OR episode_titles_at < now() - interval '26 hours')
+--
+-- ordered by episode_titles_at NULLS FIRST, anilist_id.
+--
+-- Only the first two conjuncts can go in the index predicate, and that is a
+-- hard limit rather than a preference: an index predicate admits only
+-- IMMUTABLE expressions and now() is STABLE, so the freshness arm cannot
+-- appear in one at all.  0023 hit the same wall for the same reason.
+--
+-- Unlike 0023, though, the excluded arm costs almost nothing here, because it
+-- is on the LEADING KEY COLUMN.  The rows it rejects are exactly the ones the
+-- ordering puts at the BACK: never-swept rows sort first, then oldest-swept,
+-- and the recently-swept rows that fail the freshness test are last.  So an
+-- ordered scan of this index reads its qualifying prefix and stops; it never
+-- walks past the rows the predicate could not describe.  That is the whole
+-- reason to lead on the timestamp instead of merely storing it.
+--
+-- The predicate columns are the two that do not move as the sweep works.  The
+-- sweep writes episode_titles_at and anime_episode_titles rows; it never
+-- writes status or bgm_id, so no row can leave or enter this index because of
+-- its own processing.  status = 'RELEASING' also makes the index small -- the
+-- airing slice of the catalogue, not the catalogue -- and bgm_id IS NOT NULL
+-- narrows it again to rows that have an upstream to ask.  Maintenance cost is
+-- bounded by how often AniList sync rewrites status, which is a handful of
+-- transitions per title per lifetime.
+--
+-- 26 hours rather than 24 is the sweep's constant, not the schema's, but it
+-- is worth recording why the index does not care: any interval longer than
+-- the sweep's own period leaves the qualifying set a prefix of this ordering,
+-- and the exact number only decides how long that prefix is.
+CREATE INDEX IF NOT EXISTS idx_anime_cache_episode_titles_pending
+    ON anime_cache (episode_titles_at NULLS FIRST, anilist_id)
+    WHERE status = 'RELEASING' AND bgm_id IS NOT NULL;
+
+
+-- ============================================================
+-- C.  Why ONE state column here and five in 0023
+-- ============================================================
+--
+-- Stated explicitly, because the two migrations immediately upstream of this
+-- one both concluded the opposite and a reader who knows them will assume the
+-- pattern was forgotten rather than declined.
+--
+-- 0015 and 0023 added attempt/outcome columns to anime_cache to stop a sweep
+-- from stalling.  Both of those sweeps scan the WHOLE CATALOGUE, and both
+-- decided candidacy on "the value is still missing".  A row that can never
+-- produce a value -- a Japanese-only summary in 0015, a binding the identity
+-- gate refuses in 0023 -- therefore stayed true forever, held the front of
+-- every batch under ORDER BY anilist_id, and starved every row behind it.
+-- 0015 works out the arithmetic: lifetime writes converge to p*B/(1-p), a
+-- fraction of the backlog that no batch size can fix.  The extra columns
+-- exist so a decided row can be moved out of the way.
+--
+-- That failure needs two ingredients, and this sweep has neither.
+--
+-- First, candidacy here is not "the value is missing".  It is the attempt
+-- stamp, which the sweep writes on every pass regardless of outcome, so a row
+-- that yields nothing still goes to the back of the queue and every other
+-- candidate gets its turn within one cycle.  A hopeless row costs one request
+-- a day; it does not cost another row its slot.  That is the distinction --
+-- not whether effort is wasted, but whether a row can OCCUPY A SLOT that
+-- another row needs.
+--
+-- Second, the candidate set is anchored on status = 'RELEASING', which
+-- shrinks on its own.  AniList sync flips a show to FINISHED when it ends and
+-- the row leaves the set for good, without this sweep doing anything.  The
+-- set is bounded by how much is airing at once rather than by how large the
+-- catalogue has grown, so there is no backlog to drain and nothing to
+-- accumulate.  0015's and 0023's candidate sets grow monotonically with the
+-- catalogue; this one does not.
+--
+-- Given that, an outcome vocabulary would record a per-row history nobody
+-- queries: there is no cooldown to differentiate, because every candidate
+-- gets the same 26 hours, and there is no "do not retry soon" state to
+-- express, because for an airing show retrying soon is the entire point.
+--
+-- THE GUARD ON THAT ARGUMENT: it holds only while the candidate set stays
+-- anchored on status = 'RELEASING'.  Widening the sweep to backfill finished
+-- shows -- a one-time pass over the catalogue's tail, say -- restores both
+-- ingredients at once, and 0015's arithmetic comes back with them.  Such a
+-- pass needs 0023's attempt/outcome columns, and they must land in the
+-- migration that widens the predicate, not afterwards.

--- a/go-api/test/integration/episode_titles_test.go
+++ b/go-api/test/integration/episode_titles_test.go
@@ -1,0 +1,1108 @@
+//go:build integration
+
+// episode_titles_test.go — the five 0029 episode-title queries against a real
+// Postgres.
+//
+// Migration 0029 moved three rules OUT of Go and INTO the SQL, on the argument
+// that "a rule enforced by the query is inherited by a new writer and a rule
+// enforced by a helper function is only inherited by a writer who remembers to
+// call it".  That trade is only worth making if the SQL is actually right, and
+// every one of these rules is expressed as an ON CONFLICT arm, a CASE ladder,
+// or a WHERE conjunct — the three shapes that most reliably read as correct
+// while being wrong.  A fake DB reports success for all of them.
+//
+// What each group below pins, and what silently breaks without it:
+//
+//	A. PRECEDENCE.  manual > ddp > bangumi > absent, scored by position in an
+//	   array literal.  The comparison is >= rather than >, and that is the
+//	   mechanism by which an airing show's titles get corrected: a source that
+//	   could not overwrite its own earlier value would freeze episode 9's
+//	   placeholder name forever.  A `>` typo passes every "the good source
+//	   wins" test and only fails on the case nobody writes.
+//
+//	B. PER-FIELD precedence.  One row routinely holds a `name` from Bangumi
+//	   beside a `name_cn` from dandanplay, because dandanplay returns ONE
+//	   string per episode whose body is Chinese on some rows and Japanese on
+//	   others.  Comparing either field against a single row-level source would
+//	   overwrite the better value with the worse one.  Each field must be
+//	   compared against ITS OWN source column.
+//
+//	C. EMPTY VALUES.  btrim + NULLIF on the way in, a WHERE that refuses a
+//	   call with both fields blank, and DO UPDATE arms that keep the stored
+//	   value when the incoming one is NULL.  Roughly a third of this table is
+//	   rows whose two payload columns are both NULL, written before 0029 by an
+//	   upsert with no COALESCE; new writes must not add to them.
+//
+//	D. THE BINDING IS PINNED.  The INSERT sources anime_id from anime_cache by
+//	   `bgm_id = @bgm_id`, so a re-binding that lands between the fetch and the
+//	   write produces zero rows instead of filing one upstream's episode names
+//	   under another subject.  The Go-side re-read closes most of that window;
+//	   this closes the rest.  Nothing else in the suite can observe it, because
+//	   the wrong-data outcome and the correct outcome differ only in the
+//	   database.
+//
+//	E. VALUE AND SOURCE MOVE TOGETHER.  A row whose name_cn was replaced while
+//	   name_cn_source was left behind wears a label that licenses the NEXT
+//	   writer to overwrite the wrong thing.  0029 records that no constraint
+//	   can catch this: a CHECK sees the row after the write, not the
+//	   transition into it.  So it has to be caught here.
+//
+//	F. SNAPSHOT RETRACTION.  An upsert says what the upstream returned and
+//	   nothing about what it stopped returning, so a wrongly-bound entry keeps
+//	   every stale row behind the few the new binding overwrites.  The
+//	   retraction is scoped to one source and one anime, and its cardinality
+//	   guard is the difference between "nothing changed" and "this source's
+//	   entire contribution erased" on a transient upstream blip.
+//
+//	G/H. THE SWEEP.  Which airing rows are due another look, in which order,
+//	   and the attempt stamp that moves a row to the back of the queue.  The
+//	   ordering is the part that matters: it is what lets the scan read a
+//	   prefix of the partial index and stop.
+//
+// Run with the command CI uses (.github/workflows/unit-tests.yml), so a failure
+// here reproduces exactly:
+//
+//	go test -tags=integration -count=1 -timeout=600s ./test/integration/...
+package integration
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+	"github.com/lawrenceli0228/animego/go-api/internal/testutil"
+)
+
+// The anilist_id block this file owns.  TruncateAll already isolates each test
+// function, but a distinct block keeps a stray leftover attributable to the
+// file that wrote it rather than to whichever test read it next.
+//
+// etBgmID is the binding every anime here is seeded with unless a case is
+// specifically about the binding not matching.
+const etBgmID = 9111
+
+const (
+	etOldName   = "OLD romaji episode name"
+	etOldNameCn = "旧的中文集名"
+	etNewName   = "NEW romaji episode name"
+	etNewNameCn = "新的中文集名"
+)
+
+// ---------------------------------------------------------------------------
+// Arrange / read helpers
+// ---------------------------------------------------------------------------
+
+// etSeedAnime inserts the anime_cache parent that anime_episode_titles.anime_id
+// references.
+//
+// Every case needs one.  Without the parent row the FK rejects the write, and
+// the upsert would report zero rows for a reason that has nothing to do with
+// the property under test — indistinguishable, from Go, from the binding guard
+// firing correctly.
+func etSeedAnime(t *testing.T, ctx context.Context, pool *pgxpool.Pool, anilistID, bgmID int32) {
+	t.Helper()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO anime_cache (anilist_id, title_romaji, bgm_id)
+		VALUES ($1, $2, $3)`,
+		anilistID, "episode-title fixture", bgmID,
+	)
+	require.NoError(t, err, "seed anime_cache %d", anilistID)
+}
+
+// etSeedUnboundAnime inserts an anime_cache row with bgm_id NULL — an entry
+// nothing upstream has been matched to yet, which is 29% of the catalogue.
+func etSeedUnboundAnime(t *testing.T, ctx context.Context, pool *pgxpool.Pool, anilistID int32) {
+	t.Helper()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO anime_cache (anilist_id, title_romaji, bgm_id)
+		VALUES ($1, $2, NULL)`,
+		anilistID, "unbound episode-title fixture",
+	)
+	require.NoError(t, err, "seed unbound anime_cache %d", anilistID)
+}
+
+// etSeedSweepAnime inserts an anime_cache row carrying the three columns the
+// candidate predicate reads.  bgmID <= 0 seeds bgm_id NULL; sweptAgo is a
+// Postgres interval literal such as "27 hours", or "" for a row never swept.
+//
+// The stamp is computed by the DATABASE rather than in Go on purpose.  The
+// predicate compares episode_titles_at against the server's own now(), so a
+// Go-side time.Now() would put a 25-hour row and a 26-hour threshold at the
+// mercy of clock skew between this process and the container — and the failure
+// would read as a query bug rather than as the environment problem it is.
+func etSeedSweepAnime(t *testing.T, ctx context.Context, pool *pgxpool.Pool,
+	anilistID, bgmID int32, status, sweptAgo string,
+) {
+	t.Helper()
+	var bgm *int32
+	if bgmID > 0 {
+		bgm = &bgmID
+	}
+	var ago *string
+	if sweptAgo != "" {
+		ago = &sweptAgo
+	}
+	// A NULL interval propagates: now() - NULL is NULL, which is exactly the
+	// "never swept" state, so the never-swept case needs no second statement.
+	_, err := pool.Exec(ctx, `
+		INSERT INTO anime_cache (anilist_id, title_romaji, bgm_id, status, episode_titles_at)
+		VALUES ($1, $2, $3, $4, now() - ($5::text)::interval)`,
+		anilistID, "sweep fixture", bgm, status, ago,
+	)
+	require.NoError(t, err, "seed sweep anime_cache %d", anilistID)
+}
+
+// etSeedTitle writes one anime_episode_titles row directly, with whatever
+// per-field provenance a case needs.
+//
+// Direct SQL rather than the upsert under test: an arrange step built out of
+// the query being tested cannot tell "the query wrote what I asked for" apart
+// from "the query is broken in the same direction twice".  It is also the only
+// way to produce the pre-0029 shape — a value with no source at all — which the
+// precedence ladder has to score as 0.
+func etSeedTitle(t *testing.T, ctx context.Context, pool *pgxpool.Pool,
+	animeID, episode int32, nameCn, nameCnSource, name, nameSource *string,
+) {
+	t.Helper()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO anime_episode_titles (
+			anime_id, episode, name_cn, name_cn_source, name, name_source
+		) VALUES ($1, $2, $3, $4, $5, $6)`,
+		animeID, episode, nameCn, nameCnSource, name, nameSource,
+	)
+	require.NoError(t, err, "seed episode title %d/%d", animeID, episode)
+}
+
+// etTitle is one anime_episode_titles row as the assertions read it.  `present`
+// distinguishes an absent row from a row whose four columns are all NULL —
+// which is a real and populous state in this table, and the difference between
+// "the upsert refused to insert" and "the upsert inserted an empty row".
+type etTitle struct {
+	present                                bool
+	nameCn, nameCnSource, name, nameSource *string
+}
+
+func etRead(t *testing.T, ctx context.Context, pool *pgxpool.Pool, animeID, episode int32) etTitle {
+	t.Helper()
+	var r etTitle
+	err := pool.QueryRow(ctx, `
+		SELECT name_cn, name_cn_source, name, name_source
+		FROM anime_episode_titles
+		WHERE anime_id = $1 AND episode = $2`,
+		animeID, episode,
+	).Scan(&r.nameCn, &r.nameCnSource, &r.name, &r.nameSource)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return etTitle{}
+	}
+	require.NoError(t, err, "read episode title %d/%d", animeID, episode)
+	r.present = true
+	return r
+}
+
+// etCountTitles counts the rows one anime holds, so "inserted nothing" is an
+// assertion about the table rather than about one key the test happened to look
+// up.
+func etCountTitles(t *testing.T, ctx context.Context, pool *pgxpool.Pool, animeID int32) int {
+	t.Helper()
+	var n int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT count(*) FROM anime_episode_titles WHERE anime_id = $1`, animeID).Scan(&n))
+	return n
+}
+
+// etAssertField checks a value and ITS OWN source column together.  Empty
+// wantValue / wantSource mean SQL NULL.
+//
+// This is property E, in one place.  Asserting the value alone would pass on a
+// row whose name_cn was replaced while name_cn_source kept the previous
+// upstream's label — a row that then licenses the next writer to overwrite the
+// wrong thing.  Asserting the source alone would pass on the mirror image.  No
+// CHECK constraint can catch either, because a constraint sees the row after
+// the write rather than the transition into it, so the pairing is only ever
+// checked here.
+func etAssertField(t *testing.T, label string, gotValue, gotSource *string, wantValue, wantSource string) {
+	t.Helper()
+	if wantValue == "" {
+		assert.Nil(t, gotValue, "%s: value must be NULL, got %q", label, deref(gotValue))
+	} else if assert.NotNil(t, gotValue, "%s: value must be present", label) {
+		assert.Equal(t, wantValue, *gotValue, "%s: value", label)
+	}
+	if wantSource == "" {
+		assert.Nil(t, gotSource, "%s: a NULL value carries no provenance, got %q", label, deref(gotSource))
+	} else if assert.NotNil(t, gotSource, "%s: source must be present", label) {
+		assert.Equal(t, wantSource, *gotSource,
+			"%s: the source column must name whoever supplied the value standing in the row", label)
+	}
+}
+
+// etUpsert is UpsertEpisodeTitleSourced with the two parameters every case in
+// this file shares spelled once.
+func etUpsert(ctx context.Context, q *dbgen.Queries, animeID, episode int32, nameCn, name, source string) (int64, error) {
+	return q.UpsertEpisodeTitleSourced(ctx, dbgen.UpsertEpisodeTitleSourcedParams{
+		Episode: episode,
+		NameCn:  nameCn,
+		Name:    name,
+		Source:  source,
+		AnimeID: animeID,
+		BgmID:   etBgmID,
+	})
+}
+
+// ---------------------------------------------------------------------------
+// A.  Precedence
+// ---------------------------------------------------------------------------
+
+// TestEpisodeTitleUpsertPrecedence walks the full matrix: what is already in
+// the row × who is writing.
+//
+// Both payload columns are seeded from the same source in each case so the
+// matrix stays a matrix; the case where the two columns disagree is
+// TestEpisodeTitleUpsertPerFieldPrecedence below, and it is the reason the two
+// source columns exist at all.
+func TestEpisodeTitleUpsertPrecedence(t *testing.T) {
+	ctx := testCtx(t)
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+	q := dbgen.New(pool)
+
+	const animeID = 7700100
+	etSeedAnime(t, ctx, pool, animeID, etBgmID)
+
+	cases := []struct {
+		name string
+		// existing is the source already on both columns; "" seeds a value
+		// with no source at all, which is the pre-0029 shape.
+		existing string
+		incoming string
+		wantWin  bool
+		why      string
+	}{
+		{
+			name: "bangumi fills a column nobody has claimed", existing: "", incoming: "bangumi", wantWin: true,
+			why: "an absent source scores 0, so any real upstream may claim it — every row written before 0029 is this shape",
+		},
+		{
+			name: "ddp fills a column nobody has claimed", existing: "", incoming: "ddp", wantWin: true,
+			why: "same rule, and this is the path by which dandanplay first reaches the legacy rows",
+		},
+		{
+			name: "manual fills a column nobody has claimed", existing: "", incoming: "manual", wantWin: true,
+			why: "the top of the ladder is not a special case at the bottom of it",
+		},
+		{
+			name: "★ bangumi overwrites its own earlier value", existing: "bangumi", incoming: "bangumi", wantWin: true,
+			why: "the comparison is >= and not >, deliberately: an airing show's episode 9 gets its real name a week late, and a source that could not correct itself would freeze the placeholder forever",
+		},
+		{
+			name: "ddp outranks bangumi", existing: "bangumi", incoming: "ddp", wantWin: true,
+			why: "ddp is the later, more specific upstream in the vocabulary order",
+		},
+		{
+			name: "manual outranks bangumi", existing: "bangumi", incoming: "manual", wantWin: true,
+			why: "a human decision beats any fetch",
+		},
+		{
+			name: "bangumi cannot overwrite ddp", existing: "ddp", incoming: "bangumi", wantWin: false,
+			why: "the nightly bangumi pass must not undo what dandanplay filled in — this is the arm that makes precedence worth having",
+		},
+		{
+			name: "★ ddp overwrites its own earlier value", existing: "ddp", incoming: "ddp", wantWin: true,
+			why: "same >= as above, on the source that re-fetches most often",
+		},
+		{
+			name: "manual outranks ddp", existing: "ddp", incoming: "manual", wantWin: true,
+			why: "a human decision beats any fetch",
+		},
+		{
+			name: "bangumi cannot overwrite manual", existing: "manual", incoming: "bangumi", wantWin: false,
+			why: "no automated pass may undo a human correction; nothing writes 'manual' today, and this is why the value was admitted early",
+		},
+		{
+			name: "ddp cannot overwrite manual", existing: "manual", incoming: "ddp", wantWin: false,
+			why: "same, for the other upstream",
+		},
+		{
+			name: "★ manual overwrites its own earlier value", existing: "manual", incoming: "manual", wantWin: true,
+			why: "a second human correction must land; > instead of >= would make the first edit permanent",
+		},
+	}
+
+	for i, c := range cases {
+		c := c
+		episode := int32(i + 1)
+		t.Run(c.name, func(t *testing.T) {
+			var src *string
+			if c.existing != "" {
+				src = ptr(c.existing)
+			}
+			etSeedTitle(t, ctx, pool, animeID, episode, ptr(etOldNameCn), src, ptr(etOldName), src)
+
+			rows, err := etUpsert(ctx, q, animeID, episode, etNewNameCn, etNewName, c.incoming)
+			require.NoError(t, err)
+
+			// One row, whether or not the values changed.  ON CONFLICT DO
+			// UPDATE reports the row as visited, so a caller must never read
+			// this count as "the write won" — the precedence CASE runs inside
+			// an UPDATE that has already been counted.
+			assert.Equal(t, int64(1), rows,
+				"a conflicting upsert always reports one affected row; rows-affected is not the precedence verdict")
+
+			got := etRead(t, ctx, pool, animeID, episode)
+			require.True(t, got.present, "the row must still exist")
+
+			wantName, wantNameCn, wantSource := etOldName, etOldNameCn, c.existing
+			if c.wantWin {
+				wantName, wantNameCn, wantSource = etNewName, etNewNameCn, c.incoming
+			}
+			etAssertField(t, "name_cn ("+c.why+")", got.nameCn, got.nameCnSource, wantNameCn, wantSource)
+			etAssertField(t, "name ("+c.why+")", got.name, got.nameSource, wantName, wantSource)
+		})
+	}
+
+	t.Run("an episode nobody has written yet is inserted with its source", func(t *testing.T) {
+		// The INSERT arm, which the twelve cases above never reach: they all
+		// conflict.  A ladder that scored correctly but a SELECT list that
+		// dropped a source column would pass all of them and fail here.
+		const episode = 90
+		rows, err := etUpsert(ctx, q, animeID, episode, etNewNameCn, etNewName, "ddp")
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), rows)
+
+		got := etRead(t, ctx, pool, animeID, episode)
+		require.True(t, got.present, "a first write must create the row")
+		etAssertField(t, "name_cn", got.nameCn, got.nameCnSource, etNewNameCn, "ddp")
+		etAssertField(t, "name", got.name, got.nameSource, etNewName, "ddp")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// B.  Per-field independence
+// ---------------------------------------------------------------------------
+
+// TestEpisodeTitleUpsertPerFieldPrecedence is the property a single row-level
+// source column could not express.
+//
+// dandanplay returns ONE string per episode and its body is Chinese on some
+// rows and Japanese on others, so one dandanplay value lands in name_cn on one
+// episode and in name on the next.  Beside a Bangumi pass that fills both, the
+// ordinary steady state of this table is a row whose two columns come from two
+// different upstreams.  Labelling such a row 'ddp' or 'bangumi' would be a
+// false claim either way, and precedence computed from a false claim overwrites
+// the better value with the worse one — which is the bug this test exists to
+// make impossible.
+func TestEpisodeTitleUpsertPerFieldPrecedence(t *testing.T) {
+	ctx := testCtx(t)
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+	q := dbgen.New(pool)
+
+	const animeID = 7700200
+	etSeedAnime(t, ctx, pool, animeID, etBgmID)
+
+	t.Run("bangumi corrects the bangumi field and leaves the ddp field alone", func(t *testing.T) {
+		const episode = 1
+		etSeedTitle(t, ctx, pool, animeID, episode,
+			ptr(etOldNameCn), ptr("ddp"), // Chinese title came from dandanplay
+			ptr(etOldName), ptr("bangumi"), // Japanese title came from Bangumi
+		)
+
+		rows, err := etUpsert(ctx, q, animeID, episode, etNewNameCn, etNewName, "bangumi")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rows)
+
+		got := etRead(t, ctx, pool, animeID, episode)
+		require.True(t, got.present)
+		etAssertField(t, "name_cn: ddp outranks the incoming bangumi and must survive",
+			got.nameCn, got.nameCnSource, etOldNameCn, "ddp")
+		etAssertField(t, "name: bangumi may correct its own earlier value",
+			got.name, got.nameSource, etNewName, "bangumi")
+	})
+
+	t.Run("ddp corrects the bangumi field and leaves the manual field alone", func(t *testing.T) {
+		// The mirror image, so a pass is not an artefact of which column
+		// happened to be the loser.  If the two fields were ever compared
+		// against one shared source column, exactly one of these two subtests
+		// would fail whichever column that column was.
+		const episode = 2
+		etSeedTitle(t, ctx, pool, animeID, episode,
+			ptr(etOldNameCn), ptr("bangumi"),
+			ptr(etOldName), ptr("manual"),
+		)
+
+		rows, err := etUpsert(ctx, q, animeID, episode, etNewNameCn, etNewName, "ddp")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rows)
+
+		got := etRead(t, ctx, pool, animeID, episode)
+		require.True(t, got.present)
+		etAssertField(t, "name_cn: ddp outranks bangumi",
+			got.nameCn, got.nameCnSource, etNewNameCn, "ddp")
+		etAssertField(t, "name: a human correction stands",
+			got.name, got.nameSource, etOldName, "manual")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// C.  Empty values
+// ---------------------------------------------------------------------------
+
+// TestEpisodeTitleUpsertRejectsEmptyValues pins the btrim + NULLIF gate.
+//
+// Roughly a third of anime_episode_titles is rows whose two payload columns are
+// both NULL — written before 0029 by a transform with no name check and an
+// upsert with no COALESCE.  They render exactly like a missing row, so they
+// cost the reader nothing, but they made "does this anime have titles?"
+// unanswerable by counting rows.  Every case here is about new writes being
+// unable to add to that population, or to erase a real value with a blank one.
+func TestEpisodeTitleUpsertRejectsEmptyValues(t *testing.T) {
+	ctx := testCtx(t)
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+	q := dbgen.New(pool)
+
+	const animeID = 7700300
+	etSeedAnime(t, ctx, pool, animeID, etBgmID)
+
+	t.Run("an empty name_cn leaves the stored value AND its source alone", func(t *testing.T) {
+		const episode = 1
+		etSeedTitle(t, ctx, pool, animeID, episode,
+			ptr(etOldNameCn), ptr("bangumi"),
+			ptr(etOldName), ptr("bangumi"),
+		)
+
+		// A dandanplay row whose single string was Japanese: name is filled,
+		// name_cn is not.  ddp outranks bangumi, so if the empty value were
+		// allowed through it would win the comparison and blank the column.
+		rows, err := etUpsert(ctx, q, animeID, episode, "", etNewName, "ddp")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rows)
+
+		got := etRead(t, ctx, pool, animeID, episode)
+		etAssertField(t, "name_cn must keep both its value and its bangumi label",
+			got.nameCn, got.nameCnSource, etOldNameCn, "bangumi")
+		etAssertField(t, "name is the field the call actually carried",
+			got.name, got.nameSource, etNewName, "ddp")
+	})
+
+	t.Run("both fields empty affects no rows and inserts nothing", func(t *testing.T) {
+		const episode = 2
+		rows, err := etUpsert(ctx, q, animeID, episode, "", "", "ddp")
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), rows, "the WHERE must refuse a call carrying no value at all")
+		assert.False(t, etRead(t, ctx, pool, animeID, episode).present,
+			"no row may appear: an all-NULL row is invisible to the reader and permanent in the table")
+	})
+
+	t.Run("both fields empty cannot reach an existing row either", func(t *testing.T) {
+		// The refusal is in the WHERE of the INSERT's SELECT, so the statement
+		// never reaches ON CONFLICT.  Worth its own case because a guard
+		// written into the DO UPDATE arms instead would still count the row.
+		const episode = 3
+		etSeedTitle(t, ctx, pool, animeID, episode,
+			ptr(etOldNameCn), ptr("bangumi"),
+			ptr(etOldName), ptr("bangumi"),
+		)
+
+		rows, err := etUpsert(ctx, q, animeID, episode, "", "", "manual")
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), rows, "an empty call is refused before the conflict is considered")
+
+		got := etRead(t, ctx, pool, animeID, episode)
+		etAssertField(t, "name_cn", got.nameCn, got.nameCnSource, etOldNameCn, "bangumi")
+		etAssertField(t, "name", got.name, got.nameSource, etOldName, "bangumi")
+	})
+
+	t.Run("whitespace is empty: a blank-looking call inserts nothing", func(t *testing.T) {
+		// btrim runs before NULLIF, so "   " is indistinguishable from "".
+		// Upstreams do emit padded strings, and a bare NULLIF(x, '') would let
+		// one through as a real value that renders as an empty episode title.
+		//
+		// Spaces only.  btrim's DEFAULT character set is the ASCII space and
+		// nothing else — see TestEpisodeTitleUpsertNonSpaceWhitespaceLands
+		// below, which is about that gap rather than about this rule.
+		const episode = 4
+		rows, err := etUpsert(ctx, q, animeID, episode, "   ", "     ", "ddp")
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), rows, "whitespace must be treated exactly like empty")
+		assert.False(t, etRead(t, ctx, pool, animeID, episode).present, "no row may appear")
+	})
+
+	t.Run("whitespace cannot blank a stored value", func(t *testing.T) {
+		const episode = 5
+		etSeedTitle(t, ctx, pool, animeID, episode,
+			ptr(etOldNameCn), ptr("bangumi"),
+			ptr(etOldName), ptr("bangumi"),
+		)
+
+		rows, err := etUpsert(ctx, q, animeID, episode, "   ", etNewName, "manual")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rows)
+
+		got := etRead(t, ctx, pool, animeID, episode)
+		etAssertField(t, "name_cn: a whitespace value is no value, even from manual",
+			got.nameCn, got.nameCnSource, etOldNameCn, "bangumi")
+		etAssertField(t, "name: the field that carried something still lands",
+			got.name, got.nameSource, etNewName, "manual")
+	})
+
+	t.Run("surrounding whitespace is trimmed off a value that does land", func(t *testing.T) {
+		// The same btrim that decides emptiness also decides what gets stored,
+		// so this is the other half of the same expression rather than a new
+		// claim.
+		const episode = 6
+		rows, err := etUpsert(ctx, q, animeID, episode, "  "+etNewNameCn+"  ", " "+etNewName+" ", "ddp")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rows)
+
+		got := etRead(t, ctx, pool, animeID, episode)
+		etAssertField(t, "name_cn", got.nameCn, got.nameCnSource, etNewNameCn, "ddp")
+		etAssertField(t, "name", got.name, got.nameSource, etNewName, "ddp")
+	})
+
+	t.Run("the refused calls left the table exactly as large as the writes that landed", func(t *testing.T) {
+		// Three subtests above assert "no row appeared" at one key each.  This
+		// counts, so an insert that landed under some OTHER episode number —
+		// the shape a mis-ordered parameter list produces — is also caught.
+		assert.Equal(t, 4, etCountTitles(t, ctx, pool, animeID),
+			"episodes 1, 3, 5 were seeded and 6 was written; 2 and 4 must not exist")
+	})
+}
+
+// TestEpisodeTitleUpsertNonSpaceWhitespaceLands is EXPECTED TO FAIL, and it is
+// left failing on purpose rather than fixed or deleted.
+//
+// UpsertEpisodeTitleSourced's doc comment states the rule as "btrim + NULLIF
+// turn ” and whitespace into NULL on the way in".  btrim's default character
+// set is the ASCII space U+0020 and nothing else, so the statement implements
+// that rule for "   " only.  Verified directly against the same image this test
+// runs on:
+//
+//	btrim('   ')          -> ''            -> NULLIF -> NULL   (refused)
+//	btrim(E'\t')          -> E'\t'         -> NULLIF -> E'\t'  (LANDS)
+//	btrim(E'\n')          -> E'\n'         -> NULLIF -> E'\n'  (LANDS)
+//	btrim(U&'\3000')      -> U+3000        -> NULLIF -> U+3000 (LANDS)
+//
+// U+3000 IDEOGRAPHIC SPACE is the one that makes this reachable rather than
+// theoretical: it is the ordinary space character in Japanese and Chinese text,
+// and both upstreams feeding this table are CJK sources.  A Bangumi episode
+// whose name_cn is a single U+3000, or a dandanplay episodeTitle that is one
+// stray newline, is written here as a real value with a real source label.  It
+// then (a) renders as a blank episode title rather than as a missing one, and
+// (b) claims the column at its source's precedence, so the next pass carrying
+// the actual name is compared against it rather than against an unclaimed
+// column — and if that next pass is a LOWER source, the blank wins.
+//
+// That is the population 0029 set out to stop growing: rows that "render
+// exactly like a missing row" but are not one.
+//
+// The fix belongs in the query, not here — btrim(x, E' \t\r\n　') or a
+// regexp test — and this file is not allowed to make it.  Delete this test only
+// together with a change to the statement it describes.
+func TestEpisodeTitleUpsertNonSpaceWhitespaceLands(t *testing.T) {
+	ctx := testCtx(t)
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+	q := dbgen.New(pool)
+
+	const animeID = 7700900
+	etSeedAnime(t, ctx, pool, animeID, etBgmID)
+
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{name: "a lone tab", value: "\t"},
+		{name: "a lone newline", value: "\n"},
+		{name: "a lone U+3000 ideographic space", value: "　"},
+	}
+
+	for i, c := range cases {
+		c := c
+		episode := int32(i + 1)
+		t.Run(c.name, func(t *testing.T) {
+			rows, err := etUpsert(ctx, q, animeID, episode, c.value, c.value, "ddp")
+			require.NoError(t, err)
+
+			assert.Equal(t, int64(0), rows,
+				"a value made only of whitespace carries no title and must be refused like ''")
+			got := etRead(t, ctx, pool, animeID, episode)
+			assert.False(t, got.present,
+				"no row may appear: %q lands as a real value wearing a real source label, which is both a blank episode title and a precedence claim against the next writer",
+				c.value)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// D.  The binding is pinned
+// ---------------------------------------------------------------------------
+
+// TestEpisodeTitleUpsertPinsTheBinding is the race guard, and it is the one
+// property in this file that has no observable effect anywhere except the
+// database.
+//
+// A worker reads an anime's bgm_id, fetches that subject's episode list, and
+// writes it back.  If an admin re-binding lands in between, the write is
+// holding one subject's episode names and a row that now points at another.
+// The Go-side re-read closes most of that window; this closes the rest, and it
+// converts the failure from wrong data that nobody will ever notice into a
+// zero-row result the caller can see.
+func TestEpisodeTitleUpsertPinsTheBinding(t *testing.T) {
+	ctx := testCtx(t)
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+	q := dbgen.New(pool)
+
+	const (
+		animeID   = 7700400
+		boundBgm  = 111
+		staleBgm  = 222
+		unboundID = 7700410
+	)
+	etSeedAnime(t, ctx, pool, animeID, boundBgm)
+	etSeedUnboundAnime(t, ctx, pool, unboundID)
+
+	// The two subtests below run in order against the same episode on purpose:
+	// the second is what proves the first failed for the right reason.  A
+	// mis-typed column name would also produce zero rows, and only a call that
+	// then SUCCEEDS distinguishes the guard from a broken statement.
+	const episode = 1
+
+	t.Run("a write carrying a stale binding lands nothing", func(t *testing.T) {
+		rows, err := q.UpsertEpisodeTitleSourced(ctx, dbgen.UpsertEpisodeTitleSourcedParams{
+			Episode: episode, NameCn: etNewNameCn, Name: etNewName,
+			Source: "bangumi", AnimeID: animeID, BgmID: staleBgm,
+		})
+		require.NoError(t, err, "a lost race is a zero-row result, not an error")
+		assert.Equal(t, int64(0), rows,
+			"bgm_id 222 does not match the row's 111, so the INSERT's SELECT returns no row to insert")
+		assert.False(t, etRead(t, ctx, pool, animeID, episode).present,
+			"nothing may be filed under a subject the anime is no longer bound to")
+		assert.Equal(t, 0, etCountTitles(t, ctx, pool, animeID),
+			"and not under any other episode number either")
+	})
+
+	t.Run("the same write under the row's actual binding lands", func(t *testing.T) {
+		rows, err := q.UpsertEpisodeTitleSourced(ctx, dbgen.UpsertEpisodeTitleSourcedParams{
+			Episode: episode, NameCn: etNewNameCn, Name: etNewName,
+			Source: "bangumi", AnimeID: animeID, BgmID: boundBgm,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), rows, "the guard must admit the binding the row actually holds")
+
+		got := etRead(t, ctx, pool, animeID, episode)
+		require.True(t, got.present)
+		etAssertField(t, "name_cn", got.nameCn, got.nameCnSource, etNewNameCn, "bangumi")
+		etAssertField(t, "name", got.name, got.nameSource, etNewName, "bangumi")
+	})
+
+	t.Run("an anime with no binding at all cannot be written to", func(t *testing.T) {
+		// `ac.bgm_id = $n` against NULL is NULL, not false, and NULL does not
+		// qualify a row — so an unbound entry is unreachable through this
+		// query.  That is correct (nothing upstream has been matched to it),
+		// and worth pinning because a future `coalesce(ac.bgm_id, ...)` written
+		// to "handle" NULL would open exactly the door this guard closes.
+		rows, err := q.UpsertEpisodeTitleSourced(ctx, dbgen.UpsertEpisodeTitleSourcedParams{
+			Episode: 1, NameCn: etNewNameCn, Name: etNewName,
+			Source: "ddp", AnimeID: unboundID, BgmID: 0,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), rows)
+		assert.Equal(t, 0, etCountTitles(t, ctx, pool, unboundID))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// E.  Value and source move together
+// ---------------------------------------------------------------------------
+
+// TestEpisodeTitleUpsertMovesValueAndSourceTogether isolates the pairing 0029
+// records as unenforceable by the schema: "a CHECK sees the row after the
+// write and cannot tell whether name_cn was replaced while name_cn_source was
+// left behind, which would leave a dandanplay string wearing a 'bangumi'
+// label."
+//
+// The damage is not the wrong label itself.  It is that the label is read by
+// the NEXT write's precedence comparison, so a fresh ddp value labelled
+// 'bangumi' invites the following bangumi pass to overwrite it — one mislabel
+// silently demotes the value forever after.
+func TestEpisodeTitleUpsertMovesValueAndSourceTogether(t *testing.T) {
+	ctx := testCtx(t)
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+	q := dbgen.New(pool)
+
+	const animeID = 7700500
+	etSeedAnime(t, ctx, pool, animeID, etBgmID)
+
+	t.Run("a landed value is relabelled to whoever supplied it", func(t *testing.T) {
+		const episode = 1
+		etSeedTitle(t, ctx, pool, animeID, episode,
+			ptr(etOldNameCn), ptr("bangumi"),
+			ptr(etOldName), ptr("bangumi"),
+		)
+
+		rows, err := etUpsert(ctx, q, animeID, episode, etNewNameCn, etNewName, "ddp")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rows)
+
+		got := etRead(t, ctx, pool, animeID, episode)
+		etAssertField(t, "name_cn", got.nameCn, got.nameCnSource, etNewNameCn, "ddp")
+		etAssertField(t, "name", got.name, got.nameSource, etNewName, "ddp")
+	})
+
+	t.Run("a rejected write leaves both the value and its old label", func(t *testing.T) {
+		// The mirror: the source column must not advance on a write whose
+		// value did not. A 'manual' row relabelled 'ddp' while keeping the
+		// human's text would be quietly demoted to overwritable.
+		const episode = 2
+		etSeedTitle(t, ctx, pool, animeID, episode,
+			ptr(etOldNameCn), ptr("manual"),
+			ptr(etOldName), ptr("manual"),
+		)
+
+		rows, err := etUpsert(ctx, q, animeID, episode, etNewNameCn, etNewName, "ddp")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rows)
+
+		got := etRead(t, ctx, pool, animeID, episode)
+		etAssertField(t, "name_cn", got.nameCn, got.nameCnSource, etOldNameCn, "manual")
+		etAssertField(t, "name", got.name, got.nameSource, etOldName, "manual")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// F.  Snapshot retraction
+// ---------------------------------------------------------------------------
+
+// TestEpisodeTitleSnapshotRetraction covers the pair of statements that give an
+// upsert-shaped write snapshot semantics.
+//
+// Upserting a fetch writes the episodes the upstream returned and says nothing
+// about the ones it stopped returning.  An entry bound to the wrong subject
+// therefore keeps every stale row the old binding left behind, with the few
+// correct new rows sitting in front of them — on a three-episode ONA bound to a
+// full series, three corrected rows in front of hundreds of wrong ones.
+//
+// The retraction is scoped to one source because a writer may withdraw what it
+// said and may not touch what another source filled in; the deletion is scoped
+// to the episodes the retraction actually touched because this table's
+// long-standing all-NULL rows are the only record that an episode number exists
+// at all for entries whose catalogue episode count is unknown.
+func TestEpisodeTitleSnapshotRetraction(t *testing.T) {
+	ctx := testCtx(t)
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+	q := dbgen.New(pool)
+
+	const (
+		wholeSourceID = 7700600 // five ddp episodes, two kept
+		mixedID       = 7700610 // one mixed row beside a ddp-only one
+		guardID       = 7700620 // the empty-kept-set case
+	)
+	etSeedAnime(t, ctx, pool, wholeSourceID, etBgmID)
+	etSeedAnime(t, ctx, pool, mixedID, etBgmID)
+	etSeedAnime(t, ctx, pool, guardID, etBgmID)
+
+	t.Run("episodes outside the kept set lose this source's fields", func(t *testing.T) {
+		for ep := int32(1); ep <= 5; ep++ {
+			etSeedTitle(t, ctx, pool, wholeSourceID, ep,
+				ptr(etOldNameCn), ptr("ddp"),
+				ptr(etOldName), ptr("ddp"),
+			)
+		}
+
+		cleared, err := q.ClearEpisodeTitlesBySourceOutside(ctx, "ddp", wholeSourceID, []int32{1, 2})
+		require.NoError(t, err)
+		// ElementsMatch, not Equal: RETURNING from an UPDATE has no ORDER BY,
+		// so the order is whatever the scan produced.
+		assert.ElementsMatch(t, []int32{3, 4, 5}, cleared,
+			"the caller feeds this straight to DeleteEmptyEpisodeTitles, so it must be exactly the rows that were emptied")
+
+		for _, ep := range []int32{3, 4, 5} {
+			got := etRead(t, ctx, pool, wholeSourceID, ep)
+			require.True(t, got.present, "episode %d must still exist — retraction empties, it does not delete", ep)
+			etAssertField(t, "retracted name_cn", got.nameCn, got.nameCnSource, "", "")
+			etAssertField(t, "retracted name", got.name, got.nameSource, "", "")
+		}
+		for _, ep := range []int32{1, 2} {
+			got := etRead(t, ctx, pool, wholeSourceID, ep)
+			require.True(t, got.present)
+			etAssertField(t, "kept name_cn", got.nameCn, got.nameCnSource, etOldNameCn, "ddp")
+			etAssertField(t, "kept name", got.name, got.nameSource, etOldName, "ddp")
+		}
+	})
+
+	// The next two subtests are one story told in two steps against mixedID:
+	// the retraction, then the deletion that consumes its result.  Episode 1
+	// holds a name_cn from dandanplay beside a name from Bangumi; episode 3
+	// holds only dandanplay values; episode 2 is kept.
+	var mixedCleared []int32
+
+	t.Run("a field owned by another source survives the retraction", func(t *testing.T) {
+		etSeedTitle(t, ctx, pool, mixedID, 1,
+			ptr(etOldNameCn), ptr("ddp"),
+			ptr(etOldName), ptr("bangumi"),
+		)
+		etSeedTitle(t, ctx, pool, mixedID, 2,
+			ptr(etOldNameCn), ptr("ddp"),
+			ptr(etOldName), ptr("ddp"),
+		)
+		etSeedTitle(t, ctx, pool, mixedID, 3,
+			ptr(etOldNameCn), ptr("ddp"),
+			ptr(etOldName), ptr("ddp"),
+		)
+
+		var err error
+		mixedCleared, err = q.ClearEpisodeTitlesBySourceOutside(ctx, "ddp", mixedID, []int32{2})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []int32{1, 3}, mixedCleared,
+			"a row is touched if EITHER of its fields belongs to the retracting source")
+
+		mixed := etRead(t, ctx, pool, mixedID, 1)
+		require.True(t, mixed.present)
+		etAssertField(t, "the retracting source's own field goes",
+			mixed.nameCn, mixed.nameCnSource, "", "")
+		etAssertField(t, "the other source's field is none of dandanplay's business",
+			mixed.name, mixed.nameSource, etOldName, "bangumi")
+	})
+
+	t.Run("DeleteEmptyEpisodeTitles removes only the rows left fully empty", func(t *testing.T) {
+		require.NotEmpty(t, mixedCleared, "the retraction step must have run first")
+
+		deleted, err := q.DeleteEmptyEpisodeTitles(ctx, mixedID, mixedCleared)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), deleted, "only episode 3 was left with nothing in either column")
+
+		assert.False(t, etRead(t, ctx, pool, mixedID, 3).present,
+			"a row emptied by the retraction carries no information and goes")
+
+		survivor := etRead(t, ctx, pool, mixedID, 1)
+		require.True(t, survivor.present,
+			"a row still holding another source's title must NOT be deleted — this is why the pair is two statements rather than one CTE, which would test the pre-UPDATE values")
+		etAssertField(t, "the surviving Bangumi name", survivor.name, survivor.nameSource, etOldName, "bangumi")
+
+		kept := etRead(t, ctx, pool, mixedID, 2)
+		require.True(t, kept.present, "an episode inside the kept set was never a candidate for deletion")
+		etAssertField(t, "kept name_cn", kept.nameCn, kept.nameCnSource, etOldNameCn, "ddp")
+	})
+
+	t.Run("★ an empty kept set retracts nothing", func(t *testing.T) {
+		// The cardinality guard.  Without it, every row is "outside" an empty
+		// kept set, so one upstream blip — a transient error, a subject
+		// mid-edit — erases this source's entire contribution for the anime.
+		// Callers are specified never to reach the query with an empty
+		// snapshot, but a convention is the wrong place to keep the difference
+		// between "nothing changed" and "everything erased".
+		for ep := int32(1); ep <= 2; ep++ {
+			etSeedTitle(t, ctx, pool, guardID, ep,
+				ptr(etOldNameCn), ptr("ddp"),
+				ptr(etOldName), ptr("ddp"),
+			)
+		}
+
+		cleared, err := q.ClearEpisodeTitlesBySourceOutside(ctx, "ddp", guardID, []int32{})
+		require.NoError(t, err)
+		assert.Empty(t, cleared, "an empty snapshot must retract nothing at all")
+
+		for ep := int32(1); ep <= 2; ep++ {
+			got := etRead(t, ctx, pool, guardID, ep)
+			require.True(t, got.present, "episode %d must survive", ep)
+			etAssertField(t, "untouched name_cn", got.nameCn, got.nameCnSource, etOldNameCn, "ddp")
+			etAssertField(t, "untouched name", got.name, got.nameSource, etOldName, "ddp")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// G.  The candidate query
+// ---------------------------------------------------------------------------
+
+// TestEpisodeTitleReleasingCandidates pins the sweep's predicate and its order.
+//
+// The order is not cosmetic.  0029's partial index leads on episode_titles_at
+// NULLS FIRST precisely so an ordered scan reads its qualifying prefix and
+// stops; the rows the freshness arm rejects — which cannot appear in an index
+// predicate at all, because now() is STABLE and index predicates admit only
+// IMMUTABLE expressions — sort last, behind everything the sweep wants.  Lose
+// NULLS FIRST and the query still returns the right SET while walking past the
+// whole recently-swept tail, and the shows that have never been swept at all go
+// to the back of the queue.
+func TestEpisodeTitleReleasingCandidates(t *testing.T) {
+	ctx := testCtx(t)
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+	q := dbgen.New(pool)
+
+	const (
+		// Deliberately the LOWEST id in the set: it is stamped, so it must
+		// still sort last.  Ordering by anilist_id alone would put it first,
+		// which is the arrangement that tells a working NULLS FIRST apart from
+		// one that only looks right on ascending ids.
+		stampedStale = 7700701
+		neverSweptA  = 7700702
+		neverSweptB  = 7700703
+		stampedFresh = 7700704
+		finished     = 7700705
+		unbound      = 7700706
+	)
+
+	etSeedSweepAnime(t, ctx, pool, stampedStale, 5001, "RELEASING", "27 hours")
+	etSeedSweepAnime(t, ctx, pool, neverSweptA, 5002, "RELEASING", "")
+	etSeedSweepAnime(t, ctx, pool, neverSweptB, 5003, "RELEASING", "")
+	etSeedSweepAnime(t, ctx, pool, stampedFresh, 5004, "RELEASING", "25 hours")
+	etSeedSweepAnime(t, ctx, pool, finished, 5005, "FINISHED", "")
+	etSeedSweepAnime(t, ctx, pool, unbound, 0, "RELEASING", "")
+
+	// The sweep's own constant.  Constructed per call because pgtype.Interval
+	// is a mutable struct, matching internal/queue/bangumi_episodes.go.
+	staleAfter := func() pgtype.Interval {
+		return pgtype.Interval{Microseconds: (26 * time.Hour).Microseconds(), Valid: true}
+	}
+
+	t.Run("the predicate admits exactly the airing, bound, stale rows", func(t *testing.T) {
+		rows, err := q.ListReleasingEpisodeTitleCandidates(ctx, staleAfter(), 10)
+		require.NoError(t, err)
+
+		got := make([]int32, 0, len(rows))
+		for _, r := range rows {
+			got = append(got, r.AnilistID)
+		}
+		// Equal, not ElementsMatch: the order IS the property.
+		assert.Equal(t, []int32{neverSweptA, neverSweptB, stampedStale}, got,
+			"never-swept rows first (by id among themselves), then the stale-stamped one — even though the stamped row has the lowest id")
+
+		assert.NotContains(t, got, int32(stampedFresh),
+			"25 hours is inside a 26-hour window: re-asking that soon returns the client's cached body, writes nothing, and burns the row's slot for the day")
+		assert.NotContains(t, got, int32(finished),
+			"a finished show's titles are settled; the one-off backfill owns those, and keeping them out is what lets this sweep run on one timestamp with no outcome bookkeeping")
+		assert.NotContains(t, got, int32(unbound),
+			"there is no upstream subject to ask about")
+
+		require.Len(t, rows, 3)
+		for _, r := range rows {
+			require.NotNil(t, r.BgmID,
+				"bgm_id must come back non-NULL for id %d — the caller fetches with it and the predicate already promised it exists", r.AnilistID)
+		}
+		assert.Equal(t, int32(5002), *rows[0].BgmID, "each row must carry ITS OWN binding")
+		assert.Equal(t, int32(5001), *rows[2].BgmID)
+	})
+
+	t.Run("rowLimit truncates the ordered prefix", func(t *testing.T) {
+		// The batch bound is what keeps one pass from taking the whole airing
+		// slice at once; it must cut from the BACK of the order, so a smaller
+		// limit is a prefix of the larger result rather than a different set.
+		rows, err := q.ListReleasingEpisodeTitleCandidates(ctx, staleAfter(), 2)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+		assert.Equal(t, int32(neverSweptA), rows[0].AnilistID)
+		assert.Equal(t, int32(neverSweptB), rows[1].AnilistID)
+	})
+
+	t.Run("a wider staleness window admits the recently-swept row", func(t *testing.T) {
+		// Proves stampedFresh was excluded by the interval PARAMETER rather
+		// than by something else about the row — without this, a query that
+		// ignored stale_after entirely and hard-coded a threshold would pass
+		// the first subtest.
+		wide := pgtype.Interval{Microseconds: (1 * time.Hour).Microseconds(), Valid: true}
+		rows, err := q.ListReleasingEpisodeTitleCandidates(ctx, wide, 10)
+		require.NoError(t, err)
+
+		got := make([]int32, 0, len(rows))
+		for _, r := range rows {
+			got = append(got, r.AnilistID)
+		}
+		assert.Equal(t, []int32{neverSweptA, neverSweptB, stampedStale, stampedFresh}, got,
+			"never-swept first, then OLDEST-swept: the ordering is ascending on the timestamp, so the row swept 27 hours ago is served before the one swept 25 hours ago")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// H.  The attempt stamp
+// ---------------------------------------------------------------------------
+
+// etReadStamp returns anime_cache.episode_titles_at plus whether the DATABASE
+// considers it recent.
+//
+// Freshness is evaluated inside Postgres, against the same now() the stamp was
+// written from, rather than by comparing to a Go-side time.Now(): the two
+// clocks are not the same clock, and a skewed container would fail this for a
+// reason that has nothing to do with the statement under test.
+func etReadStamp(t *testing.T, ctx context.Context, pool *pgxpool.Pool, anilistID int32) (pgtype.Timestamptz, bool) {
+	t.Helper()
+	var stamp pgtype.Timestamptz
+	var fresh *bool
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT episode_titles_at,
+		       episode_titles_at > now() - interval '1 minute'
+		FROM anime_cache
+		WHERE anilist_id = $1`, anilistID).Scan(&stamp, &fresh),
+		"read episode_titles_at for %d", anilistID)
+	return stamp, fresh != nil && *fresh
+}
+
+// TestEpisodeTitleTouchStamp covers the write that makes the sweep terminate.
+//
+// The stamp is an ATTEMPT stamp, not a success stamp: it is written whether or
+// not the pass produced a title, and that is precisely what stops a show whose
+// upstream has nothing from holding the front of every batch and starving the
+// rows behind it (0029 section C, and 0015's arithmetic before it).  The
+// binding predicate is the same race guard as the upsert's: a row re-bound
+// during the fetch must NOT be stamped, so the next pass re-asks under the
+// binding it now holds rather than resting on an attempt made against the old
+// one.
+func TestEpisodeTitleTouchStamp(t *testing.T) {
+	ctx := testCtx(t)
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+	q := dbgen.New(pool)
+
+	const (
+		stampedID = 7700800
+		reboundID = 7700810
+		boundBgm  = 4321
+		otherBgm  = 8765
+	)
+
+	t.Run("a matching binding stamps the row", func(t *testing.T) {
+		etSeedSweepAnime(t, ctx, pool, stampedID, boundBgm, "RELEASING", "")
+		before, _ := etReadStamp(t, ctx, pool, stampedID)
+		require.False(t, before.Valid, "the fixture starts never-swept, or the assertion below proves nothing")
+
+		rows, err := q.TouchEpisodeTitlesAt(ctx, stampedID, boundBgm)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), rows)
+
+		after, fresh := etReadStamp(t, ctx, pool, stampedID)
+		assert.True(t, after.Valid, "episode_titles_at must no longer be NULL")
+		assert.True(t, fresh, "the stamp must be now(), not some inherited value (got %v)", after.Time)
+	})
+
+	t.Run("a row re-bound during the fetch is not stamped", func(t *testing.T) {
+		// Seeded with an OLD stamp rather than NULL: NULL over NULL is
+		// indistinguishable from a no-op, so a statement that dropped its
+		// bgm_id predicate would still pass against a never-swept fixture only
+		// by luck.  Here a stray write would visibly move the clock.
+		etSeedSweepAnime(t, ctx, pool, reboundID, boundBgm, "RELEASING", "30 days")
+		before, beforeFresh := etReadStamp(t, ctx, pool, reboundID)
+		require.True(t, before.Valid)
+		require.False(t, beforeFresh, "the fixture's stamp must start stale")
+
+		rows, err := q.TouchEpisodeTitlesAt(ctx, reboundID, otherBgm)
+		require.NoError(t, err, "a lost race is a zero-row result, not an error")
+		assert.Equal(t, int64(0), rows, "the binding no longer matches, so there is nothing to stamp")
+
+		after, afterFresh := etReadStamp(t, ctx, pool, reboundID)
+		assert.False(t, afterFresh, "the column must not have been advanced to now()")
+		assert.True(t, after.Time.Equal(before.Time),
+			"the stamp must be byte-for-byte what it was (%v -> %v)", before.Time, after.Time)
+	})
+}


### PR DESCRIPTION
## What

Episode titles are written by exactly one thing today — the V2 enrichment worker — and V2 runs **at most once per anime, ever**. `bangumi_version` is a one-way ratchet and every V1 producer filters on `version = 0`, so the moment V2 finishes a row it leaves every scan that could reach it again. A row whose episodes fetch failed, or that was enriched before its show had aired, keeps whatever it got that one time.

Measured on production: **1,784 rows hold a binding and zero episode titles, and 1,522 of those are unreachable by any automatic job.** Site-wide, 53.9% of episode slots show any title at all and 28.9% show a Chinese one.

This adds a second source (dandanplay, which we already call and are already authenticated for) and two ways to use it.

## How

The gap is a **backlog plus a stream**, and they get different machinery.

**Backlog** — `bgmbackfill --heal-episode-titles`, read-only unless combined with `--apply`. The gate is the point rather than caution theatre: the pass decides whether a binding is trustworthy from two external sources that can disagree, and the cost of deciding wrong is deleting correct titles from a public, indexed page. The default mode makes every decision and writes nothing, producing a per-row classification a human reads first.

**Stream** — shows still broadcasting, whose episode 9 gets its name in the week episode 9 airs. A river sweep over `status='RELEASING'` only. Anchoring there is what lets it run on a single timestamp with no outcome vocabulary: 0015 and 0023 needed attempt/outcome columns because their whole-catalogue sweeps decided candidacy on "the value is missing" and stalled on rows that could never produce one. Here candidacy **is** the attempt stamp, and the candidate set shrinks on its own as AniList flips shows to FINISHED.

**Identity** follows the posture the repo already had: `bgm_id_map` decides wherever it has an entry, and dandanplay's anilist cross-link — which arrives in the same response as the episodes, so it costs nothing — is consulted only where the map is silent. On production 9,407 of 12,720 bound rows are map-confirmed with zero conflicts.

**Precedence** is per field (`manual > ddp > bangumi`) and lives in the upsert's SQL rather than in Go, so a new writer inherits the rule by using the query instead of by remembering it.

## Measured effect

42-anime sample, filtered through the actual write gate: episodes showing **any** title 65% → 92%; showing **Chinese** 33% → 38%. The Chinese number is the honest one — neither dandanplay nor AniZip can move it much further; that belongs to the localisation track.

## Not in this PR

- Widening the episode grid for genuine overflow (blocked: `id-map` agreement does not rule out scope mismatch — see TODOS.md).
- Making V2 retry a failed episodes fetch. `bangumi_version` remains a ratchet with no repair path; this PR works around it rather than fixing it, and that is recorded in TODOS.md.
- Bindings with no `bgm_id` at all, and the dead `bgm_id`s stuck at `version=1`.

## Test plan

- [x] `go test ./...` — 34 packages, 0 failures
- [x] `go vet -tags=integration ./test/integration/...`
- [x] `go test -tags=integration ./test/integration/...` — full suite green
- [x] 39 new integration subtests over a real Postgres: full 4×3 precedence matrix (including the three same-source cases that prove `>=` lets a source correct itself), per-field independence in both directions, the `bgm_id` race guard returning zero rows, snapshot retraction touching only its own source, the empty-kept-set refusal, candidate ordering/freshness, and the stamp's binding pin
- [x] 24 new unit cases for the title splitter, including U+3000 handling, halfwidth katakana, and a numeric entity that decodes to kana
- [ ] `--heal-episode-titles` report run against production (read-only) — to be reviewed before any `--apply`

The integration tests earned their place: they caught a real bug in the upsert. Bare `btrim()` only strips the ASCII space, so a tab, a newline, or **U+3000 IDEOGRAPHIC SPACE** — the ordinary space in CJK text, from two CJK upstreams — survived the guard and landed as a row that renders blank *and* claims the column at its source's precedence, so a later real title from a lower-ranked source would lose to nothing at all. Fixed with an explicit trim set.

## Rollout

The sweep ships **off**. `EPISODE_TITLES_SWEEP_ENABLED` is read at work time, so a restart with it off also silences anything river had queued, and the sweep has its own river queue so it can be paused at runtime without a deploy.
