### PR TITLE
Write episode titles through the sourced upsert, and repair what the old one broke

### DIFF
--- a/go-api/internal/db/gen/anime_cache.sql.go
+++ b/go-api/internal/db/gen/anime_cache.sql.go
@@ -3167,28 +3167,6 @@ func (q *Queries) UpsertAnimeCache(ctx context.Context, arg UpsertAnimeCachePara
 	return err
 }
 
-const upsertEpisodeTitle = `-- name: UpsertEpisodeTitle :exec
-INSERT INTO anime_episode_titles (anime_id, episode, name_cn, name)
-VALUES ($1, $2, $3, $4)
-ON CONFLICT (anime_id, episode) DO UPDATE
-  SET name_cn = EXCLUDED.name_cn,
-      name    = EXCLUDED.name
-`
-
-// Written by the Bangumi V2 worker (the Phase-4 enrichment analog) after
-// fetching /subject/{bgmId}/ep.  Express set the whole episodeTitles array;
-// we upsert per episode so a re-enrich refreshes names in place. ON CONFLICT
-// overwrites so corrected Bangumi data wins on the next pass.
-func (q *Queries) UpsertEpisodeTitle(ctx context.Context, animeID int32, episode int32, nameCn *string, name *string) error {
-	_, err := q.db.Exec(ctx, upsertEpisodeTitle,
-		animeID,
-		episode,
-		nameCn,
-		name,
-	)
-	return err
-}
-
 const upsertEpisodeTitleSourced = `-- name: UpsertEpisodeTitleSourced :execrows
 WITH incoming AS (
     -- The trim set is explicit, and every character in it is here because
@@ -3271,8 +3249,9 @@ type UpsertEpisodeTitleSourcedParams struct {
 
 // Write one episode title, honouring both precedence and the binding it was
 // fetched under.  This is the query every episode-title writer is expected to
-// use; UpsertEpisodeTitle above is the pre-0029 shape, kept only until its
-// last caller moves over.
+// use.  It replaced a pre-0029 statement that set the two value columns and
+// left the source columns untouched, which let one source's value end up
+// wearing another's label; migration 0030 repairs the rows that produced.
 //
 // Three guarantees live in this statement rather than in Go, because a rule
 // enforced by the query is inherited by a new writer and a rule enforced by a

--- a/go-api/internal/db/gen/querier.go
+++ b/go-api/internal/db/gen/querier.go
@@ -1983,15 +1983,11 @@ type Querier interface {
 	// Persist a dandanplay lookup result (title, or NULL for a confirmed miss)
 	// keyed by bgm_id.
 	UpsertDdpTitle(ctx context.Context, bgmID int32, animeTitle *string) error
-	// Written by the Bangumi V2 worker (the Phase-4 enrichment analog) after
-	// fetching /subject/{bgmId}/ep.  Express set the whole episodeTitles array;
-	// we upsert per episode so a re-enrich refreshes names in place. ON CONFLICT
-	// overwrites so corrected Bangumi data wins on the next pass.
-	UpsertEpisodeTitle(ctx context.Context, animeID int32, episode int32, nameCn *string, name *string) error
 	// Write one episode title, honouring both precedence and the binding it was
 	// fetched under.  This is the query every episode-title writer is expected to
-	// use; UpsertEpisodeTitle above is the pre-0029 shape, kept only until its
-	// last caller moves over.
+	// use.  It replaced a pre-0029 statement that set the two value columns and
+	// left the source columns untouched, which let one source's value end up
+	// wearing another's label; migration 0030 repairs the rows that produced.
 	//
 	// Three guarantees live in this statement rather than in Go, because a rule
 	// enforced by the query is inherited by a new writer and a rule enforced by a

--- a/go-api/internal/db/queries/anime_cache.sql
+++ b/go-api/internal/db/queries/anime_cache.sql
@@ -845,17 +845,6 @@ FROM anime_episode_titles
 WHERE anime_id = $1
 ORDER BY episode;
 
--- name: UpsertEpisodeTitle :exec
--- Written by the Bangumi V2 worker (the Phase-4 enrichment analog) after
--- fetching /subject/{bgmId}/ep.  Express set the whole episodeTitles array;
--- we upsert per episode so a re-enrich refreshes names in place. ON CONFLICT
--- overwrites so corrected Bangumi data wins on the next pass.
-INSERT INTO anime_episode_titles (anime_id, episode, name_cn, name)
-VALUES ($1, $2, $3, $4)
-ON CONFLICT (anime_id, episode) DO UPDATE
-  SET name_cn = EXCLUDED.name_cn,
-      name    = EXCLUDED.name;
-
 -- name: UpdateDescriptionCn :exec
 -- Store a Chinese description harvested from Bangumi's Subject.Summary.
 --
@@ -1511,8 +1500,9 @@ WHERE title_romaji  ILIKE sqlc.arg(contains)::text
 -- name: UpsertEpisodeTitleSourced :execrows
 -- Write one episode title, honouring both precedence and the binding it was
 -- fetched under.  This is the query every episode-title writer is expected to
--- use; UpsertEpisodeTitle above is the pre-0029 shape, kept only until its
--- last caller moves over.
+-- use.  It replaced a pre-0029 statement that set the two value columns and
+-- left the source columns untouched, which let one source's value end up
+-- wearing another's label; migration 0030 repairs the rows that produced.
 --
 -- Three guarantees live in this statement rather than in Go, because a rule
 -- enforced by the query is inherited by a new writer and a rule enforced by a

--- a/go-api/internal/queue/bangumi_episodes.go
+++ b/go-api/internal/queue/bangumi_episodes.go
@@ -259,7 +259,7 @@ func episodesBgmEnqueuerFrom(enq Enqueuer) EpisodesBgmEnqueuer {
 
 // EpisodesBgmWriter is everything the per-row worker touches.
 //
-// UpsertEpisodeTitle is shared with V2Writer on purpose: the episode titles
+// UpsertEpisodeTitleSourced is shared with V2Writer on purpose: the episode titles
 // arrive in the same response body as the count, and growing a second
 // normalise-then-write path for them would be two implementations of one
 // mapping.
@@ -267,7 +267,7 @@ type EpisodesBgmWriter interface {
 	GetEpisodesBgmGateInputs(ctx context.Context, anilistID int32) (dbgen.GetEpisodesBgmGateInputsRow, error)
 	UpdateEpisodesBgm(ctx context.Context, episodesBgm *int32, anilistID int32, bgmID *int32) (int64, error)
 	MarkEpisodesBgmAttempted(ctx context.Context, outcome string, reason *string, anilistID int32, bgmID *int32) (int64, error)
-	UpsertEpisodeTitle(ctx context.Context, animeID int32, episode int32, nameCN *string, name *string) error
+	UpsertEpisodeTitleSourced(ctx context.Context, arg dbgen.UpsertEpisodeTitleSourcedParams) (int64, error)
 }
 
 // EpisodesBgmSubjectClient is the upstream surface: the subject (for the
@@ -487,7 +487,7 @@ func (w *EpisodesBgmWorker) Work(ctx context.Context, job *river.Job[EpisodesBgm
 	// Episode titles are best-effort, matching the stance V2 takes on the same
 	// write: the count has already committed, and failing the job here would
 	// re-spend two upstream requests to retry an optional column.
-	written, failures := writeEpisodeTitles(ctx, w.db, anilistID, titles)
+	written, failures := writeEpisodeTitles(ctx, w.db, anilistID, int32(bgmID), titles)
 	if failures > 0 {
 		slog.WarnContext(ctx, "episodes_bgm title write failures",
 			"anilistId", anilistID, "bgmId", bgmID,

--- a/go-api/internal/queue/bangumi_episodes_test.go
+++ b/go-api/internal/queue/bangumi_episodes_test.go
@@ -221,15 +221,16 @@ func (f *fakeEpisodesBgmDB) MarkEpisodesBgmAttempted(ctx context.Context, outcom
 	return fn(ctx, outcome, reason, anilistID, bgmID)
 }
 
-func (f *fakeEpisodesBgmDB) UpsertEpisodeTitle(ctx context.Context, animeID int32, episode int32, nameCN, name *string) error {
+func (f *fakeEpisodesBgmDB) UpsertEpisodeTitleSourced(ctx context.Context, arg dbgen.UpsertEpisodeTitleSourcedParams) (int64, error) {
+	nameCN, name := epStrPtr(arg.NameCn), epStrPtr(arg.Name)
 	f.mu.Lock()
-	f.titles = append(f.titles, episodeTitleWrite{animeID: animeID, episode: episode, nameCN: nameCN, name: name})
+	f.titles = append(f.titles, episodeTitleWrite{animeID: arg.AnimeID, episode: arg.Episode, nameCN: nameCN, name: name})
 	fn := f.titleFn
 	f.mu.Unlock()
 	if fn == nil {
-		return nil
+		return 1, nil
 	}
-	return fn(ctx, animeID, episode, nameCN, name)
+	return 1, fn(ctx, arg.AnimeID, arg.Episode, nameCN, name)
 }
 
 // --- the surface this worker must never touch ---
@@ -1125,8 +1126,8 @@ func (noopEpisodesBgmDB) MarkEpisodesBgmAttempted(_ context.Context, _ string, _
 	return 0, nil
 }
 
-func (noopEpisodesBgmDB) UpsertEpisodeTitle(_ context.Context, _ int32, _ int32, _ *string, _ *string) error {
-	return nil
+func (noopEpisodesBgmDB) UpsertEpisodeTitleSourced(_ context.Context, _ dbgen.UpsertEpisodeTitleSourcedParams) (int64, error) {
+	return 1, nil
 }
 
 // A double that is a valid Enqueuer but does NOT carry the episode-count

--- a/go-api/internal/queue/bangumi_v2.go
+++ b/go-api/internal/queue/bangumi_v2.go
@@ -59,6 +59,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/lawrenceli0228/animego/go-api/internal/bangumi"
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
 )
 
 // v2WorkTimeout bounds the worker's total budget for Subject +
@@ -110,13 +111,14 @@ type BangumiV2Client interface {
 //     title_chinese) on anime_cache.
 //   - UpdateAnimeCharacterCN updates one row of anime_characters
 //     matched by (anime_id, name_en).
-//   - UpsertEpisodeTitle fills per-episode names.
+//   - UpsertEpisodeTitleSourced fills per-episode names, labelled
+//     'bangumi' and pinned to the binding they were fetched under.
 //   - UpdateDescriptionCn stores the Chinese synopsis carried by the
 //     same Subject payload (see persistDescriptionCn).
 type V2Writer interface {
 	UpdateBangumiV2(ctx context.Context, anilistID int32, bangumiScore *float64, bangumiVotes *int32, titleChinese *string) error
 	UpdateAnimeCharacterCN(ctx context.Context, animeID int32, nameEn *string, nameCN *string, voiceActorCN *string, voiceActorImageURL *string) error
-	UpsertEpisodeTitle(ctx context.Context, animeID int32, episode int32, nameCN *string, name *string) error
+	UpsertEpisodeTitleSourced(ctx context.Context, arg dbgen.UpsertEpisodeTitleSourcedParams) (int64, error)
 	UpdateDescriptionCn(ctx context.Context, descriptionCn *string, anilistID int32, bgmID *int32) error
 }
 
@@ -349,7 +351,7 @@ func (w *BangumiV2Worker) Work(ctx context.Context, job *river.Job[BangumiV2Args
 	} else if episodes != nil {
 		titles := normalizeEpisodeTitles(episodes.Eps)
 		var epFailures int
-		epTitlesWritten, epFailures = writeEpisodeTitles(ctx, w.db, anilistID, titles)
+		epTitlesWritten, epFailures = writeEpisodeTitles(ctx, w.db, anilistID, int32(bgmID), titles)
 		if epFailures > 0 {
 			slog.WarnContext(ctx, "bangumi_v2 episode title write failures",
 				"anilistId", anilistID, "bgmId", bgmID,
@@ -477,7 +479,7 @@ func persistDescriptionCn(ctx context.Context, db descriptionCnWriter, phase str
 	return true
 }
 
-// epTitle is a normalized episode-title row ready for UpsertEpisodeTitle.
+// epTitle is a normalized episode-title row ready for the sourced upsert.
 type epTitle struct {
 	episode int32
 	nameCN  *string

--- a/go-api/internal/queue/bangumi_v2_test.go
+++ b/go-api/internal/queue/bangumi_v2_test.go
@@ -106,12 +106,19 @@ type v2CharCall struct {
 	voiceActorImageURL *string
 }
 
-// v2EpTitleCall snapshots one UpsertEpisodeTitle invocation.
+// v2EpTitleCall snapshots one UpsertEpisodeTitleSourced invocation.
+//
+// source and bgmID are recorded because they are the two halves of the fix in
+// 0030: the source is what makes the value's provenance survive the write, and
+// the bgm id is the binding the query pins to.  A worker that stopped supplying
+// either would keep passing every assertion about names.
 type v2EpTitleCall struct {
 	animeID int32
 	episode int32
 	nameCN  *string
 	name    *string
+	source  string
+	bgmID   int32
 }
 
 // v2DescCnCall snapshots one UpdateDescriptionCn invocation.
@@ -175,16 +182,28 @@ func (f *fakeV2DB) UpdateAnimeCharacterCN(ctx context.Context, animeID int32, na
 	return fn(ctx, call)
 }
 
-func (f *fakeV2DB) UpsertEpisodeTitle(ctx context.Context, animeID int32, episode int32, nameCN *string, name *string) error {
-	call := v2EpTitleCall{animeID: animeID, episode: episode, nameCN: nameCN, name: name}
+func (f *fakeV2DB) UpsertEpisodeTitleSourced(ctx context.Context, arg dbgen.UpsertEpisodeTitleSourcedParams) (int64, error) {
+	call := v2EpTitleCall{animeID: arg.AnimeID, episode: arg.Episode, nameCN: epStrPtr(arg.NameCn), name: epStrPtr(arg.Name), source: arg.Source, bgmID: arg.BgmID}
 	f.mu.Lock()
 	f.upsertEpCalls = append(f.upsertEpCalls, call)
 	fn := f.upsertEpFn
 	f.mu.Unlock()
+	// 1 row affected is the success shape; the real query returns 0 when the
+	// binding moved, which the worker counts as a failure.
 	if fn == nil {
+		return 1, nil
+	}
+	return 1, fn(ctx, call)
+}
+
+// epStrPtr turns the plain strings UpsertEpisodeTitleSourcedParams carries back
+// into the nil-able form the recorded call shapes use, so assertions written
+// against the pre-0029 signature keep meaning the same thing.
+func epStrPtr(s string) *string {
+	if s == "" {
 		return nil
 	}
-	return fn(ctx, call)
+	return &s
 }
 
 // UpdateDescriptionCn records the Chinese-description write.  Note the
@@ -1144,4 +1163,53 @@ func TestBangumiV2_SubjectUpdateError_SkipsDescriptionCn(t *testing.T) {
 	require.Error(t, runV2(t, b, db, 1234, 9999))
 	assert.Empty(t, db.snapshotDescCnCalls(),
 		"primary write failed → don't attempt the optional one")
+}
+
+// TestBangumiV2_EpisodeTitlesCarryBangumiProvenance pins the half of the write
+// that has no visible effect until a second source exists.
+//
+// The regression it guards is not hypothetical.  For one release V2 wrote
+// through the pre-0029 statement, which set the two value columns and left the
+// source columns untouched; the hourly episodes_bgm sweep then passed over rows
+// cmd/bgmbackfill had labelled 'ddp' and replaced their values -- often with
+// NULL -- while the 'ddp' label stayed behind.  1,966 production rows ended up
+// claiming a source for a column that held nothing, and because the sourced
+// upsert scores precedence against that label, every automatic writer was then
+// refused on those episodes.
+//
+// TestBangumiV2_WritesEpisodeTitles above passes just as happily without a
+// source or a binding pin, which is exactly why the bug survived a release.
+// This one does not.
+func TestBangumiV2_EpisodeTitlesCarryBangumiProvenance(t *testing.T) {
+	b := &fakeBangumiV2{
+		subjectFn: func(_ context.Context, id int) (*bangumi.Subject, error) {
+			return makeSubject(id, "中文名", 80, 100), nil
+		},
+		episodesFn: func(_ context.Context, _ int) (*bangumi.EpisodesResponse, error) {
+			return &bangumi.EpisodesResponse{Eps: []bangumi.Episode{
+				{Sort: 1, Type: 0, Name: "E1", NameCN: "第一集"},
+				{Sort: 2, Type: 0, Name: "E2"},
+			}}, nil
+		},
+	}
+	d := &fakeV2DB{}
+	if err := runV2(t, b, d, 100, 555); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	eps := d.snapshotEpTitleCalls()
+	if len(eps) != 2 {
+		t.Fatalf("want 2 episode-title writes, got %d", len(eps))
+	}
+	for _, e := range eps {
+		if e.source != "bangumi" {
+			t.Fatalf("episode %d written with source %q, want \"bangumi\": a value "+
+				"labelled by nobody is unclaimed, and one wearing another source's "+
+				"label blocks the writer that could fill it", e.episode, e.source)
+		}
+		if e.bgmID != 555 {
+			t.Fatalf("episode %d written with bgmID %d, want 555: the query cannot "+
+				"refuse a write whose subject moved if the caller does not say which "+
+				"subject it fetched", e.episode, e.bgmID)
+		}
+	}
 }

--- a/go-api/internal/queue/description_backfill_test.go
+++ b/go-api/internal/queue/description_backfill_test.go
@@ -287,11 +287,8 @@ func (f *fakeBackfillDB) UpdateAnimeCharacterCN(_ context.Context, _ int32, _ *s
 	return nil
 }
 
-func (f *fakeBackfillDB) UpsertEpisodeTitle(_ context.Context, _ int32, _ int32, _ *string, _ *string) error {
-	f.mu.Lock()
-	f.epCalls++
-	f.mu.Unlock()
-	return nil
+func (f *fakeBackfillDB) UpsertEpisodeTitleSourced(_ context.Context, _ dbgen.UpsertEpisodeTitleSourcedParams) (int64, error) {
+	return 1, nil
 }
 
 func (f *fakeBackfillDB) snapshotDescCalls() []backfillDescCall {

--- a/go-api/internal/queue/episode_titles_write.go
+++ b/go-api/internal/queue/episode_titles_write.go
@@ -3,33 +3,67 @@
 //
 // Two workers write this table from the Bangumi side: BangumiV2Worker, as the
 // last step of a full enrichment run, and EpisodesBgmWorker, after its identity
-// gate accepts a binding.  Until this file they each carried their own copy of
+// gate accepts a binding.  Before this file they each carried their own copy of
 // the same five-line loop — same signature, same best-effort stance, same
 // failure counting — and the copies had already started to drift in their log
-// wording.  A third writer was about to make it three.
+// wording.
 //
-// The stance the loop encodes, and the reason it is worth naming once rather
-// than three times:
+// # Why this writes through the SOURCED upsert
 //
-//	Individual row failures are counted, not returned.  Both callers reach
-//	this point AFTER their authoritative write has already committed — V2 has
-//	written the subject and characters, the sweep has written the inferred
-//	episode count — and both deliberately treat per-episode names as the
-//	optional tail of that work.  Returning an error here would fail a job
-//	whose real work succeeded, and river would then re-spend the upstream
-//	requests that produced it.  So the caller gets a count and decides what to
-//	say about it.
+// Migration 0029 gave the table per-field provenance, and a second writer
+// (dandanplay, via cmd/bgmbackfill and the airing sweep) now labels its rows
+// 'ddp'.  For one release this loop still used the pre-0029 statement, which
+// sets `name` and `name_cn` and does not touch the source columns at all.  That
+// is not a cosmetic gap: overwriting a 'ddp' row with a Bangumi value leaves
+// the VALUE from one source wearing the LABEL of another, and the next writer
+// then scores its precedence against a claim that is not true.
 //
-// What this helper does NOT own is the precedence between sources.  That rule
-// — manual outranks dandanplay outranks Bangumi, and a non-empty value is never
-// overwritten with an empty one — lives in the SQL of the upsert itself, so
-// that every writer inherits it whether or not it routes through this file.
-// Putting it here instead would have made the invariant depend on remembering
-// to call the right Go function, which is exactly the kind of guarantee this
-// table has already lost once.
+// It is also not hypothetical — it happened.  A production run left 2,010 rows
+// in exactly that shape, 1,966 of them holding a 'ddp' label over two NULL
+// values, written by the hourly episodes_bgm sweep passing over rows the
+// dandanplay backfill had just filled.  Migration 0030 repairs those rows;
+// this file is what stops them being made again.
+//
+// 0029's own comment names the invariant and why the schema cannot hold it: a
+// CHECK sees the row after the write, not the transition, so it cannot tell a
+// value that was replaced alongside its source from one that was replaced
+// without it.  The only place that pairing can be guaranteed is the statement
+// doing the writing, which means every writer has to use the same one.
+//
+// # The binding pin arrives with it
+//
+// UpsertEpisodeTitleSourced resolves anime_id through anime_cache with
+// `bgm_id = @bgm_id`, so a write whose binding moved between the fetch and the
+// upsert affects zero rows instead of filing one subject's episode names under
+// another.  Both callers already hold the id they fetched with, and both
+// already re-read it once before getting here; this closes the remainder of
+// that window.  A zero-row result is counted as a failure — it is one, just a
+// silent kind — and the caller logs it with the rest.
+//
+// # Why failures are counted and not returned
+//
+// Both callers reach this point AFTER their authoritative write has already
+// committed: V2 has written the subject and characters, the sweep has written
+// the inferred episode count.  Both deliberately treat per-episode names as the
+// optional tail of that work.  Returning an error here would fail a job whose
+// real work succeeded, and river would then re-spend the upstream requests that
+// produced it.  So the caller gets a count and decides what to say about it.
 package queue
 
-import "context"
+import (
+	"context"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+// episodeTitleSourceBangumi is the provenance label both callers write under.
+//
+// A constant rather than a parameter on purpose: every caller of this function
+// reads from Bangumi's /subject/{id}/ep, and a source argument would invite a
+// future writer to pass its own label through a loop whose normalisation and
+// numbering are Bangumi-shaped.  A dandanplay writer already exists and
+// deliberately does not route through here — see internal/episodetitles.
+const episodeTitleSourceBangumi = "bangumi"
 
 // episodeTitleUpserter is the narrow write surface writeEpisodeTitles needs.
 //
@@ -37,24 +71,54 @@ import "context"
 // helper genuinely needs one method, and a one-method interface is what lets
 // both of those satisfy it without either importing the other's shape.
 type episodeTitleUpserter interface {
-	UpsertEpisodeTitle(ctx context.Context, animeID int32, episode int32, nameCN *string, name *string) error
+	UpsertEpisodeTitleSourced(ctx context.Context, arg dbgen.UpsertEpisodeTitleSourcedParams) (int64, error)
 }
 
-// writeEpisodeTitles upserts every title in the slice, returning how many
-// landed and how many failed.  It never returns an error; see the file comment
-// for why that is the contract rather than an oversight.
+// writeEpisodeTitles upserts every title in the slice under the 'bangumi'
+// source, returning how many landed and how many failed.  It never returns an
+// error; see the file comment for why that is the contract rather than an
+// oversight.
+//
+// bgmID is the binding the titles were fetched under.  It is not decoration:
+// the query refuses to write when anime_cache no longer holds it.
 func writeEpisodeTitles(
 	ctx context.Context,
 	db episodeTitleUpserter,
-	anilistID int32,
+	anilistID, bgmID int32,
 	titles []epTitle,
 ) (written, failures int) {
 	for _, t := range titles {
-		if err := db.UpsertEpisodeTitle(ctx, anilistID, t.episode, t.nameCN, t.name); err != nil {
+		n, err := db.UpsertEpisodeTitleSourced(ctx, dbgen.UpsertEpisodeTitleSourcedParams{
+			Episode: t.episode,
+			NameCn:  derefOrEmpty(t.nameCN),
+			Name:    derefOrEmpty(t.name),
+			Source:  episodeTitleSourceBangumi,
+			AnimeID: anilistID,
+			BgmID:   bgmID,
+		})
+		// n == 0 means the binding moved underneath this write, or the row
+		// carried nothing storable.  Neither is an error the job should fail
+		// on, and both are worth the caller's failure count: a run whose
+		// writes silently affect no rows looks identical to a run that did
+		// nothing, which is the one thing this counter exists to distinguish.
+		if err != nil || n == 0 {
 			failures++
 			continue
 		}
 		written++
 	}
 	return written, failures
+}
+
+// derefOrEmpty flattens the nil-able strings normalizeEpisodeTitles produces
+// into the plain strings the sourced upsert takes.
+//
+// The query does its own trimming and its own emptiness test — btrim over an
+// explicit character set, then NULLIF — so passing "" is exactly equivalent to
+// passing NULL and the distinction does not need to survive this boundary.
+func derefOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }

--- a/go-api/internal/queue/worker_test.go
+++ b/go-api/internal/queue/worker_test.go
@@ -336,8 +336,8 @@ func (noopV12DB) UpdateAnimeCharacterCN(_ context.Context, _ int32, _ *string, _
 	return nil
 }
 
-func (noopV12DB) UpsertEpisodeTitle(_ context.Context, _ int32, _ int32, _ *string, _ *string) error {
-	return nil
+func (noopV12DB) UpsertEpisodeTitleSourced(_ context.Context, _ dbgen.UpsertEpisodeTitleSourcedParams) (int64, error) {
+	return 1, nil
 }
 
 // UpdateDescriptionCn satisfies V2Writer + V3Writer.  Registration tests

--- a/go-api/migrations/0030_repair_episode_title_provenance.down.sql
+++ b/go-api/migrations/0030_repair_episode_title_provenance.down.sql
@@ -1,0 +1,23 @@
+-- Deliberately empty of DDL, and that is the honest answer rather than a
+-- missing one.
+--
+-- 0030 is a data repair, not a schema change: it adds nothing to drop and
+-- alters no column definition.  What it changed is the CONTENT of two source
+-- columns, and that change is not invertible.
+--
+-- Un-doing step A would mean putting a label back on a column that holds no
+-- value, and there is nothing recorded anywhere that says which label each row
+-- had -- 'ddp' for most of them, but the migration does not distinguish, and
+-- restoring the wrong one is worse than restoring none.  Un-doing step B would
+-- mean stripping 'bangumi' from values that demonstrably came from Bangumi.
+--
+-- Both directions would also be restoring a state the schema's own invariant
+-- calls invalid.  A down migration whose job is to reintroduce corruption is
+-- not a rollback, so this one does nothing and says why.
+--
+-- If a rollback is genuinely needed, the payload columns were never touched:
+-- `name` and `name_cn` are byte-identical before and after, so a restore of
+-- the provenance columns from a pre-0030 dump of anime_episode_titles is the
+-- only correct route.
+
+SELECT 1;

--- a/go-api/migrations/0030_repair_episode_title_provenance.up.sql
+++ b/go-api/migrations/0030_repair_episode_title_provenance.up.sql
@@ -1,0 +1,81 @@
+-- 0030: repair rows whose episode title and its source label disagree.
+--
+-- 0029 added name_source / name_cn_source and stated the invariant they rest
+-- on: a value and its source have to be written by the SAME statement, because
+-- a CHECK sees the row after the write and cannot tell a value that was
+-- replaced alongside its source from one that was replaced without it.
+--
+-- For one release that invariant was not held.  The sourced upsert shipped and
+-- cmd/bgmbackfill used it, but the two queue writers -- BangumiV2Worker and
+-- EpisodesBgmWorker -- were still calling the pre-0029 statement, which set
+-- `name` and `name_cn` and never touched the source columns at all.  So when
+-- the hourly episodes_bgm sweep passed over a row the dandanplay backfill had
+-- just written, the VALUE became Bangumi's (often NULL, because Bangumi had no
+-- name for that episode) while the LABEL stayed 'ddp'.
+--
+-- Measured on production before this migration:
+--
+--   1,966  name_source = 'ddp'  with BOTH value columns NULL
+--      41  name_cn_source set   with name_cn NULL
+--       3  name non-NULL        with name_source NULL
+--
+-- Why it matters beyond tidiness.  The sourced upsert scores precedence
+-- against the source column, so a label with no value behind it is not inert:
+-- it makes an empty column look CLAIMED at that source's rank, and a later
+-- writer of equal or lower rank is then refused.  1,966 episodes would have
+-- been permanently unfillable by anything ranked at or below 'ddp' -- which is
+-- every automatic writer there is.  A label without a value is worse than no
+-- label, because the precedence rule believes it.
+--
+-- The repair is in two directions and each is decided by the VALUE, which is
+-- the only half of the pair that is not in question.  Nothing here reads or
+-- writes `name` / `name_cn`: the payload is what it is, this migration only
+-- corrects what the row claims about where it came from.
+
+-- A. A source with no value behind it is retracted.
+--
+-- No attempt is made to work out what the value "should" have been.  The row
+-- is simply back to unclaimed, which is what it was before a writer overwrote
+-- the value without clearing the label, and which lets the next pass -- from
+-- any source -- fill it normally.
+UPDATE anime_episode_titles
+   SET name_source    = CASE WHEN name    IS NULL THEN NULL ELSE name_source    END,
+       name_cn_source = CASE WHEN name_cn IS NULL THEN NULL ELSE name_cn_source END
+ WHERE (name    IS NULL AND name_source    IS NOT NULL)
+    OR (name_cn IS NULL AND name_cn_source IS NOT NULL);
+
+-- B. A value with no source is labelled 'bangumi'.
+--
+-- Same proof 0029 used for its own backfill, narrowed to the window that
+-- produced these rows: the only writers that can leave a value with no source
+-- are the two queue workers on the pre-0029 statement, and both read
+-- /subject/{id}/ep.  cmd/bgmbackfill cannot produce this shape -- its statement
+-- writes value and source in one CASE pair -- so 'bangumi' is what the data IS
+-- rather than the safest guess available.
+--
+-- Only 3 rows on production, and the count is expected to stay small: this
+-- shape needs a row whose value column was NULL before the offending write,
+-- which is rarer than overwriting an existing one.
+UPDATE anime_episode_titles
+   SET name_source    = CASE WHEN name    IS NOT NULL AND name_source    IS NULL
+                             THEN 'bangumi' ELSE name_source    END,
+       name_cn_source = CASE WHEN name_cn IS NOT NULL AND name_cn_source IS NULL
+                             THEN 'bangumi' ELSE name_cn_source END
+ WHERE (name    IS NOT NULL AND name_source    IS NULL)
+    OR (name_cn IS NOT NULL AND name_cn_source IS NULL);
+
+-- Both statements are re-runnable: their WHERE clauses describe exactly the
+-- rows their SET clauses change, so a second application matches nothing.
+--
+-- Rows left fully empty by step A are NOT deleted.  They are indistinguishable
+-- from the ~35k rows that have held two NULLs since before 0029, and those are
+-- the only record that an episode number exists at all for entries whose
+-- catalogue episode count is unknown -- where the detail grid infers its size
+-- from the highest episode number it holds.  Sweeping them here would quietly
+-- shorten those grids as a side effect of a provenance repair.
+--
+-- This migration fixes the damage; it does not stop it recurring.  That is
+-- internal/queue/episode_titles_write.go moving both queue writers onto
+-- UpsertEpisodeTitleSourced, which ships in the same change.  Applying this
+-- file against a server still running the old code would leave the rows to be
+-- corrupted again on the next sweep pass.

--- a/go-api/test/integration/episode_title_provenance_repair_test.go
+++ b/go-api/test/integration/episode_title_provenance_repair_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+// episode_title_provenance_repair_test.go — migration 0030 against a real
+// Postgres, run over rows shaped like the ones it was written for.
+//
+// The migration has already been applied by the time this test starts, so
+// asserting on production-shaped rows would prove nothing.  Instead the test
+// seeds the two broken shapes AFTER migration, then executes 0030's own file
+// off disk and checks what it did.  Reading the file rather than restating its
+// SQL is the point: a copy in the test would keep passing after someone edited
+// the migration.
+//
+// What the shapes mean, and why the repair direction is what it is:
+//
+//	name_source set, name NULL      a writer replaced the value and left the
+//	                                label. The label is the lie -- retract it.
+//	name set, name_source NULL      a writer set the value through the
+//	                                pre-0029 statement, which never touched
+//	                                source columns. The value is real; only
+//	                                Bangumi-backed writers can produce this
+//	                                shape, so 'bangumi' is a fact rather than
+//	                                a guess.
+//
+// A label with no value behind it is not inert.  UpsertEpisodeTitleSourced
+// scores precedence against the source column, so an empty column wearing a
+// 'ddp' label reads as CLAIMED at that rank and refuses every automatic writer
+// ranked at or below it.  That is what made 1,966 production episodes
+// permanently unfillable, and it is the property the last subtest pins.
+package integration
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const provRepairMigration = "../../migrations/0030_repair_episode_title_provenance.up.sql"
+
+func TestEpisodeTitleProvenanceRepair(t *testing.T) {
+	ctx := context.Background()
+	pool := newPGPool(t, ctx)
+
+	const animeID = 990301
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO anime_cache (anilist_id, title_romaji, bgm_id)
+		VALUES ($1, 'Provenance Repair Fixture', 990301)
+		ON CONFLICT (anilist_id) DO NOTHING`, animeID)
+	require.NoError(t, err, "seed anime_cache")
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM anime_episode_titles WHERE anime_id = $1`, animeID)
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM anime_cache WHERE anilist_id = $1`, animeID)
+	})
+
+	// Episode 1 — the 1,966-row shape: a 'ddp' claim over two empty columns.
+	// Episode 2 — the mirror on the Chinese column only, with a real Japanese
+	//             name beside it, so the repair must touch one half and not
+	//             the other.
+	// Episode 3 — a value with no label at all.
+	// Episode 4 — already correct; must come out untouched.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO anime_episode_titles (anime_id, episode, name, name_cn, name_source, name_cn_source)
+		VALUES ($1, 1, NULL,     NULL,   'ddp',     NULL),
+		       ($1, 2, 'サムライ', NULL,   'bangumi', 'ddp'),
+		       ($1, 3, 'Orphan',  NULL,   NULL,      NULL),
+		       ($1, 4, 'Kept',    '保留', 'ddp',     'ddp')`, animeID)
+	require.NoError(t, err, "seed broken rows")
+
+	sqlBytes, err := os.ReadFile(provRepairMigration)
+	require.NoError(t, err, "read migration 0030 off disk")
+	_, err = pool.Exec(ctx, string(sqlBytes))
+	require.NoError(t, err, "apply migration 0030")
+
+	type row struct {
+		name, nameCn, nameSrc, nameCnSrc *string
+	}
+	read := func(t *testing.T, ep int32) row {
+		t.Helper()
+		var r row
+		err := pool.QueryRow(ctx, `
+			SELECT name, name_cn, name_source, name_cn_source
+			FROM anime_episode_titles WHERE anime_id = $1 AND episode = $2`,
+			animeID, ep).Scan(&r.name, &r.nameCn, &r.nameSrc, &r.nameCnSrc)
+		require.NoError(t, err)
+		return r
+	}
+
+	t.Run("a label with no value is retracted", func(t *testing.T) {
+		r := read(t, 1)
+		assert.Nil(t, r.nameSrc, "'ddp' claimed a column holding nothing; the claim is what was false")
+		assert.Nil(t, r.name, "the payload column must not be invented")
+	})
+
+	t.Run("the repair is per field, not per row", func(t *testing.T) {
+		r := read(t, 2)
+		require.NotNil(t, r.name)
+		assert.Equal(t, "サムライ", *r.name, "the real value must survive")
+		require.NotNil(t, r.nameSrc)
+		assert.Equal(t, "bangumi", *r.nameSrc, "its correct label must survive too")
+		assert.Nil(t, r.nameCnSrc, "only the half that claimed an empty column is retracted")
+	})
+
+	t.Run("a value with no label is attributed to bangumi", func(t *testing.T) {
+		r := read(t, 3)
+		require.NotNil(t, r.nameSrc)
+		assert.Equal(t, "bangumi", *r.nameSrc,
+			"only the pre-0029 queue writers can leave a value unlabelled, and both read /subject/{id}/ep")
+		require.NotNil(t, r.name)
+		assert.Equal(t, "Orphan", *r.name)
+	})
+
+	t.Run("a correct row is left alone", func(t *testing.T) {
+		r := read(t, 4)
+		require.NotNil(t, r.nameSrc)
+		require.NotNil(t, r.nameCnSrc)
+		assert.Equal(t, "ddp", *r.nameSrc)
+		assert.Equal(t, "ddp", *r.nameCnSrc, "a 'ddp' label BACKED by a value is not the bug")
+	})
+
+	t.Run("re-running changes nothing", func(t *testing.T) {
+		before := []row{read(t, 1), read(t, 2), read(t, 3), read(t, 4)}
+		_, err := pool.Exec(ctx, string(sqlBytes))
+		require.NoError(t, err, "0030 must be safe to apply twice")
+		after := []row{read(t, 1), read(t, 2), read(t, 3), read(t, 4)}
+		assert.Equal(t, before, after,
+			"both statements' WHERE clauses describe exactly the rows their SET clauses change")
+	})
+
+	t.Run("no orphan shape survives", func(t *testing.T) {
+		var n int
+		require.NoError(t, pool.QueryRow(ctx, `
+			SELECT count(*) FROM anime_episode_titles
+			WHERE anime_id = $1 AND (
+			      (name    IS NULL     AND name_source    IS NOT NULL)
+			   OR (name_cn IS NULL     AND name_cn_source IS NOT NULL)
+			   OR (name    IS NOT NULL AND name_source    IS NULL)
+			   OR (name_cn IS NOT NULL AND name_cn_source IS NULL))`,
+			animeID).Scan(&n))
+		assert.Zero(t, n, "value and source must agree in both directions after the repair")
+	})
+}

--- a/go-api/test/integration/queue_smoke_test.go
+++ b/go-api/test/integration/queue_smoke_test.go
@@ -10,17 +10,17 @@
 // What this asserts (the contract the P2.1.2 enrichment package will
 // rely on):
 //
-//   1. queue.Boot accepts a real pool and returns a non-nil client
-//      that can Start without error against the river schema already
-//      applied by migrations 0007 + 0008.
-//   2. client.Insert publishes the job AND the worker fires AND the
-//      Subscribe(EventKindJobCompleted) channel reports completion
-//      with the right Kind.
-//   3. client.InsertTx inside a transaction defers the work until
-//      Commit and then dispatches to the worker.
-//   4. The stub workers actually return nil so jobs complete (not
-//      fail) — important because the integration suite is the first
-//      place we see a panic/error from the stubs.
+//  1. queue.Boot accepts a real pool and returns a non-nil client
+//     that can Start without error against the river schema already
+//     applied by migrations 0007 + 0008.
+//  2. client.Insert publishes the job AND the worker fires AND the
+//     Subscribe(EventKindJobCompleted) channel reports completion
+//     with the right Kind.
+//  3. client.InsertTx inside a transaction defers the work until
+//     Commit and then dispatches to the worker.
+//  4. The stub workers actually return nil so jobs complete (not
+//     fail) — important because the integration suite is the first
+//     place we see a panic/error from the stubs.
 //
 // Why subscribe rather than poll river_job table:  river's Subscribe
 // channel is buffered (1000 events default) and non-blocking — drop
@@ -132,10 +132,10 @@ func (noRowV12DB) MarkBangumiNeedsReview(_ context.Context, _ int32) error {
 	return nil
 }
 
-// UpsertEpisodeTitle satisfies queue.V2Writer.  Unreachable here because
+// UpsertEpisodeTitleSourced satisfies queue.V2Writer.  Unreachable here because
 // V2.Work() bails on the Subject ErrNotFound before it fetches episodes.
-func (noRowV12DB) UpsertEpisodeTitle(_ context.Context, _ int32, _ int32, _ *string, _ *string) error {
-	return nil
+func (noRowV12DB) UpsertEpisodeTitleSourced(_ context.Context, _ dbgen.UpsertEpisodeTitleSourcedParams) (int64, error) {
+	return 1, nil
 }
 
 func (noRowV12DB) UpdateBangumiV2(_ context.Context, _ int32, _ *float64, _ *int32, _ *string) error {


### PR DESCRIPTION
## What broke

Migration 0029 gave `anime_episode_titles` per-field provenance and stated the invariant it rests on: **a value and its source must be written by the same statement**, because a CHECK sees the row after the write and cannot tell a value replaced alongside its source from one replaced without it.

That invariant was not held. The sourced upsert shipped in #139 and `cmd/bgmbackfill` used it, but both queue writers — `BangumiV2Worker` and `EpisodesBgmWorker` — kept calling the pre-0029 statement, which sets the two value columns and **never touches the source columns at all**. So when the hourly `episodes_bgm` sweep passed over a row the dandanplay backfill had just written, the value became Bangumi's (often NULL, because Bangumi had no name for that episode) while the label stayed `'ddp'`.

Measured on production:

| shape | rows |
|---|---|
| `name_source='ddp'`, both value columns NULL | 1,966 |
| `name_cn_source` set, `name_cn` NULL | 41 |
| `name` set, `name_source` NULL | 3 |

**This is worse than untidy.** `UpsertEpisodeTitleSourced` scores precedence against the source column, so a label with nothing behind it reads as *claimed* at that rank and refuses every automatic writer ranked at or below it. Those 1,966 episodes were permanently unfillable by anything the system can do on its own. A label without a value is worse than no label, because the precedence rule believes it.

Found by the outside voice during `/plan-eng-review`, then confirmed by measuring the shape of the damage and matching it against the only writer that can produce it.

## The fix

Both queue writers now go through `UpsertEpisodeTitleSourced` under the `'bangumi'` label, and the pre-0029 query is **deleted** rather than left as a loaded gun.

The source is a package constant, not a parameter: every caller of that loop reads `/subject/{id}/ep`, and an argument would invite a future writer to push its own label through normalisation and numbering that are Bangumi-shaped. The dandanplay writer already exists and deliberately does not route through here.

**The binding pin arrives with it.** The sourced query resolves `anime_id` through `anime_cache` with `bgm_id = @bgm_id`, so a write whose binding moved mid-flight affects zero rows instead of filing one subject's episode names under another. Both callers already hold the id they fetched with; a zero-row result is counted as a failure — it is one, just a silent kind.

## Migration 0030

Repairs the existing rows in two directions, each decided by the **value**, which is the only half of the pair that is not in question:

- a source with no value behind it → retracted
- a value with no source → labelled `'bangumi'` (only the pre-0029 queue writers can produce that shape, and both read `/subject/{id}/ep`)

Nothing reads or writes the payload columns. Rows left fully empty are **not** deleted — they are indistinguishable from the ~35k rows that have held two NULLs since before 0029, and those are the only record that an episode number exists at all for entries whose catalogue episode count is unknown, where the detail grid infers its size from the highest episode number it holds.

The down migration is deliberately empty of DDL and says why: undoing this would mean restoring a state the schema's own invariant calls invalid, and nothing records which label each broken row wore.

## Test plan

- [x] `go test ./...` — 34 packages, 0 failures
- [x] `go vet -tags=integration ./test/integration/...`
- [x] `go test -tags=integration ./test/integration/...` — full suite green
- [x] `TestBangumiV2_EpisodeTitlesCarryBangumiProvenance` — the existing `TestBangumiV2_WritesEpisodeTitles` passes just as happily without a source or a binding pin, which is exactly why this survived a release, so the new test asserts both directly
- [x] `TestEpisodeTitleProvenanceRepair` — 6 subtests over a real Postgres. Seeds the two broken shapes **after** migration and then executes 0030's own file off disk rather than restating its SQL, because a copy in the test would keep passing after someone edited the migration. Covers per-field repair, the untouched correct row, idempotence, and that no orphan shape survives.

## Ordering note

0030 fixes the damage; it does not stop it recurring. That is the writer change, which ships in the same commit. Applying the migration against a server still running the old code would leave the rows to be corrupted again on the next sweep pass.
