### PR TITLE
Let the episode-title pass resume, and stop when upstream goes quiet

### DIFF
--- a/go-api/cmd/bgmbackfill/episode_titles.go
+++ b/go-api/cmd/bgmbackfill/episode_titles.go
@@ -127,7 +127,12 @@ type epTitleReport struct {
 	TitlesWritten int            `json:"titles_written"`
 	TitlesCN      int            `json:"titles_chinese"`
 	Retracted     int            `json:"retracted"`
-	Rows          []epTitleRow   `json:"rows"`
+	// Aborted is set when the empty-streak breaker stopped the pass.  A run
+	// that ended this way is INCOMPLETE, and the field exists so a reader of
+	// the artifact cannot mistake it for one that finished.
+	Aborted     bool         `json:"aborted,omitempty"`
+	AbortReason string       `json:"abort_reason,omitempty"`
+	Rows        []epTitleRow `json:"rows"`
 }
 
 // runEpisodeTitleHeal classifies every bgm-bound row and, in apply mode,
@@ -143,14 +148,19 @@ func runEpisodeTitleHeal(
 	ddp *dandanplay.Client,
 	limitDDP int,
 	apply bool,
+	resume bool,
+	maxEmptyStreak int,
 	outPath string,
 ) error {
-	rows, err := q.ListBgmBoundForBackfill(ctx)
+	rows, err := listEpisodeTitleCandidates(ctx, q, resume)
 	if err != nil {
-		return fmt.Errorf("ListBgmBoundForBackfill: %w", err)
+		return err
 	}
-	slog.Info("episode-title heal: candidates", "count", len(rows), "apply", apply)
+	slog.Info("episode-title heal: candidates",
+		"count", len(rows), "apply", apply, "resume", resume,
+		"maxEmptyStreak", maxEmptyStreak)
 
+	emptyStreak := 0
 	rep := epTitleReport{
 		Mode:   map[bool]string{true: "apply", false: "report"}[apply],
 		Total:  len(rows),
@@ -170,6 +180,32 @@ func runEpisodeTitleHeal(
 		out := healOneRow(ctx, pool, q, ddp, row, limitDDP, apply, &rep)
 		rep.Counts[out.Class]++
 		rep.Rows = append(rep.Rows, out)
+
+		// Empty-streak breaker.  The client reports a 4xx and a subject with no
+		// episodes identically, so an upstream that has stopped answering looks
+		// exactly like a long run of anime it has nothing for -- and a real
+		// catalogue does not produce hundreds of those back to back after a
+		// healthy start.  Measured on the run this exists for: the first ~40%
+		// wrote ~1,100 anime per tenth, then every remaining tenth was ~1,250
+		// NO_TITLES and 0-8 writes.  Stopping at the first few hundred turns
+		// 7,600 wasted requests into a few hundred, and leaves the unreached
+		// rows unstamped so --resume picks them up.
+		if out.Class == epClassNoTitles {
+			emptyStreak++
+		} else if out.Class != epClassSkipped {
+			emptyStreak = 0
+		}
+		if shouldAbortOnEmptyStreak(emptyStreak, maxEmptyStreak, rep.Counts[epClassWritten]) {
+			rep.Aborted = true
+			rep.AbortReason = fmt.Sprintf(
+				"%d consecutive rows returned no titles after %d successful writes; "+
+					"upstream has most likely stopped answering (the client cannot tell a 4xx "+
+					"from an empty subject). Re-run with --resume once it recovers.",
+				emptyStreak, rep.Counts[epClassWritten])
+			slog.Error("episode-title heal: aborted", "reason", rep.AbortReason,
+				"processed", i+1, "total", len(rows))
+			break
+		}
 	}
 
 	printEpisodeTitleSummary(&rep)
@@ -181,6 +217,55 @@ func runEpisodeTitleHeal(
 	return nil
 }
 
+// listEpisodeTitleCandidates picks the row set for this pass.
+//
+// resume=false is the full universe, which is what a first run wants.
+// resume=true drops rows a previous pass already wrote, using the stamp the
+// writer sets inside the same transaction as the titles -- see the query's own
+// comment for why an unstamped row is the safe direction to be wrong in.
+//
+// The two queries return different generated row types for the same columns,
+// so both are flattened here into the shape healOneRow actually reads.  A
+// conversion is cheaper than teaching the rest of the file about two types,
+// and it keeps the resume decision in one place instead of at every field.
+func listEpisodeTitleCandidates(ctx context.Context, q *dbgen.Queries, resume bool) ([]epTitleCandidate, error) {
+	if resume {
+		rows, err := q.ListBgmBoundNeedingEpisodeTitles(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("ListBgmBoundNeedingEpisodeTitles: %w", err)
+		}
+		out := make([]epTitleCandidate, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, epTitleCandidate{
+				AnilistID: r.AnilistID, BgmID: r.BgmID, Episodes: r.Episodes,
+				TitleChinese: r.TitleChinese, TitleRomaji: r.TitleRomaji,
+			})
+		}
+		return out, nil
+	}
+	rows, err := q.ListBgmBoundForBackfill(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ListBgmBoundForBackfill: %w", err)
+	}
+	out := make([]epTitleCandidate, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, epTitleCandidate{
+			AnilistID: r.AnilistID, BgmID: r.BgmID, Episodes: r.Episodes,
+			TitleChinese: r.TitleChinese, TitleRomaji: r.TitleRomaji,
+		})
+	}
+	return out, nil
+}
+
+// epTitleCandidate is the subset of a bgm-bound row this pass reads.
+type epTitleCandidate struct {
+	AnilistID    int32
+	BgmID        *int32
+	Episodes     *int32
+	TitleChinese *string
+	TitleRomaji  *string
+}
+
 // healOneRow runs the whole decision for a single anime.  It mutates only the
 // running totals on rep; the per-row result is returned.
 func healOneRow(
@@ -188,7 +273,7 @@ func healOneRow(
 	pool *pgxpool.Pool,
 	q *dbgen.Queries,
 	ddp *dandanplay.Client,
-	row dbgen.ListBgmBoundForBackfillRow,
+	row epTitleCandidate,
 	limitDDP int,
 	apply bool,
 	rep *epTitleReport,
@@ -286,6 +371,30 @@ func healOneRow(
 	return out
 }
 
+// shouldAbortOnEmptyStreak decides whether a run of empty results means the
+// upstream stopped answering rather than that the catalogue has a quiet patch.
+//
+// Two conditions, and the second is the one that keeps this from firing on a
+// legitimately barren stretch:
+//
+//   - the streak has reached the threshold, and
+//   - the pass has ALREADY written something.
+//
+// Without the second, a run that begins against a dead upstream would abort
+// before proving there was ever anything to get, and the operator would be
+// told "upstream stopped answering" about an upstream that never started.  A
+// run that has written nothing at all is a different diagnosis -- credentials,
+// network, the wrong database -- and deserves to be read as one.
+//
+// maxStreak == 0 disables the breaker, which is what a deliberate pass over a
+// known-barren slice wants.
+func shouldAbortOnEmptyStreak(streak, maxStreak, written int) bool {
+	if maxStreak <= 0 {
+		return false
+	}
+	return streak >= maxStreak && written > 0
+}
+
 // printEpisodeTitleSummary prints the table a human reads before --apply.
 //
 // The NO_TITLES share is called out separately because it is the one number
@@ -324,6 +433,9 @@ func printEpisodeTitleSummary(rep *epTitleReport) {
 			fmt.Printf("  ^ unusually high. The client reports a 4xx and an empty subject\n")
 			fmt.Printf("    identically, so check DANDANPLAY_APP_ID/SECRET before trusting this.\n")
 		}
+	}
+	if rep.Aborted {
+		fmt.Printf("\n  ABORTED — this report is INCOMPLETE\n  %s\n", rep.AbortReason)
 	}
 	fmt.Println()
 }

--- a/go-api/cmd/bgmbackfill/episode_titles_test.go
+++ b/go-api/cmd/bgmbackfill/episode_titles_test.go
@@ -1,0 +1,41 @@
+package main
+
+import "testing"
+
+// TestShouldAbortOnEmptyStreak pins the breaker that turns a silent upstream
+// into a stopped run instead of a full one that wrote almost nothing.
+//
+// The case that motivated it: a production pass wrote 3,890 anime over its
+// first 40%, then received nothing for the remaining 8,215 because the shared
+// account hit a quota ceiling.  The client reports a 4xx and a subject with no
+// episodes identically, so every one of those rows was recorded as "upstream
+// had no titles" and the run reported success.
+func TestShouldAbortOnEmptyStreak(t *testing.T) {
+	tests := []struct {
+		name                     string
+		streak, maxStreak, wrote int
+		want                     bool
+	}{
+		{"below the threshold keeps going", 199, 200, 3890, false},
+		{"at the threshold stops", 200, 200, 3890, true},
+		{"past the threshold stops", 500, 200, 3890, true},
+		{
+			// A pass that has written nothing has not shown the upstream ever
+			// answered, so a long empty run is not evidence it STOPPED.  That
+			// is a different diagnosis and must not be reported as this one.
+			name:   "a long streak with no writes yet is not this failure",
+			streak: 500, maxStreak: 200, wrote: 0, want: false,
+		},
+		{"zero disables the breaker", 10000, 0, 3890, false},
+		{"negative disables the breaker", 10000, -1, 3890, false},
+		{"a fresh pass with no streak keeps going", 0, 200, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldAbortOnEmptyStreak(tt.streak, tt.maxStreak, tt.wrote); got != tt.want {
+				t.Fatalf("shouldAbortOnEmptyStreak(%d, %d, %d) = %v, want %v",
+					tt.streak, tt.maxStreak, tt.wrote, got, tt.want)
+			}
+		})
+	}
+}

--- a/go-api/cmd/bgmbackfill/main.go
+++ b/go-api/cmd/bgmbackfill/main.go
@@ -99,6 +99,8 @@ func main() {
 	outFile := flag.String("out", "report.json", "path for the JSON report")
 	healMode := flag.Bool("heal", false, "WRITES: fill title_chinese from dandanplay for map-confirmed rows missing CN")
 	epTitlesMode := flag.Bool("heal-episode-titles", false, "fill anime_episode_titles from dandanplay; read-only unless combined with --apply")
+	resumeFlag := flag.Bool("resume", false, "--heal-episode-titles: skip anime a previous pass already wrote (episode_titles_at set)")
+	maxEmptyStreak := flag.Int("max-empty-streak", 200, "--heal-episode-titles: abort after this many consecutive rows with no titles (0 disables)")
 	flag.Parse()
 
 	// Default to report mode when no explicit mode is set.
@@ -163,7 +165,7 @@ func main() {
 			slog.Error("--heal-episode-titles needs dandanplay; do not combine with --skip-ddp")
 			os.Exit(1)
 		}
-		if err := runEpisodeTitleHeal(ctx, pool, q, ddpClient, *limitFlag, *applyMode, *outFile); err != nil {
+		if err := runEpisodeTitleHeal(ctx, pool, q, ddpClient, *limitFlag, *applyMode, *resumeFlag, *maxEmptyStreak, *outFile); err != nil {
 			slog.Error("episode-title heal failed", "err", err)
 			os.Exit(1)
 		}

--- a/go-api/internal/db/gen/backfill.sql.go
+++ b/go-api/internal/db/gen/backfill.sql.go
@@ -99,3 +99,85 @@ func (q *Queries) ListBgmBoundForBackfill(ctx context.Context) ([]ListBgmBoundFo
 	}
 	return items, nil
 }
+
+const listBgmBoundNeedingEpisodeTitles = `-- name: ListBgmBoundNeedingEpisodeTitles :many
+SELECT
+    anilist_id,
+    bgm_id,
+    title_native,
+    title_romaji,
+    title_english,
+    title_chinese,
+    season_year,
+    episodes,
+    bangumi_score,
+    bgm_match_source
+FROM anime_cache
+WHERE bgm_id IS NOT NULL
+  AND episode_titles_at IS NULL
+ORDER BY anilist_id
+`
+
+type ListBgmBoundNeedingEpisodeTitlesRow struct {
+	AnilistID      int32    `json:"anilistId"`
+	BgmID          *int32   `json:"bgmId"`
+	TitleNative    *string  `json:"titleNative"`
+	TitleRomaji    *string  `json:"titleRomaji"`
+	TitleEnglish   *string  `json:"titleEnglish"`
+	TitleChinese   *string  `json:"titleChinese"`
+	SeasonYear     *int32   `json:"seasonYear"`
+	Episodes       *int32   `json:"episodes"`
+	BangumiScore   *float64 `json:"bangumiScore"`
+	BgmMatchSource *string  `json:"bgmMatchSource"`
+}
+
+// The same universe as ListBgmBoundForBackfill, minus the rows a previous
+// episode-title pass already finished.
+//
+// It exists because a full pass over that universe is hours long and the
+// upstream can stop answering partway through.  That is not hypothetical: a
+// production run wrote 3,890 anime and then received nothing for the remaining
+// 8,215, because the shared account hit a quota ceiling around 5,000 requests
+// in.  Re-running from the top would have spent that ceiling again on rows
+// already done before reaching the ones that were not.
+//
+// `episode_titles_at` is the resume marker and it is honest by construction:
+// the writer stamps it inside the same transaction that writes the titles, so
+// a stamped row is one whose titles committed.  A row that upstream had nothing
+// for is NOT stamped -- it never reaches the write -- which means it stays a
+// candidate.  That is the right direction to be wrong in: re-asking about an
+// empty subject costs one request, while skipping a row that was never
+// actually written loses it until someone notices.
+//
+// The order is unchanged (anilist_id) so a resumed run walks the same sequence
+// as the run it continues, and the report of the two can be read side by side.
+func (q *Queries) ListBgmBoundNeedingEpisodeTitles(ctx context.Context) ([]ListBgmBoundNeedingEpisodeTitlesRow, error) {
+	rows, err := q.db.Query(ctx, listBgmBoundNeedingEpisodeTitles)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListBgmBoundNeedingEpisodeTitlesRow{}
+	for rows.Next() {
+		var i ListBgmBoundNeedingEpisodeTitlesRow
+		if err := rows.Scan(
+			&i.AnilistID,
+			&i.BgmID,
+			&i.TitleNative,
+			&i.TitleRomaji,
+			&i.TitleEnglish,
+			&i.TitleChinese,
+			&i.SeasonYear,
+			&i.Episodes,
+			&i.BangumiScore,
+			&i.BgmMatchSource,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/go-api/internal/db/gen/querier.go
+++ b/go-api/internal/db/gen/querier.go
@@ -1038,6 +1038,27 @@ type Querier interface {
 	// Every row that currently has a bgm_id — the universe the backfill audits.
 	// Returns the fields the scorer + the dandanplay CN cross-check need.
 	ListBgmBoundForBackfill(ctx context.Context) ([]ListBgmBoundForBackfillRow, error)
+	// The same universe as ListBgmBoundForBackfill, minus the rows a previous
+	// episode-title pass already finished.
+	//
+	// It exists because a full pass over that universe is hours long and the
+	// upstream can stop answering partway through.  That is not hypothetical: a
+	// production run wrote 3,890 anime and then received nothing for the remaining
+	// 8,215, because the shared account hit a quota ceiling around 5,000 requests
+	// in.  Re-running from the top would have spent that ceiling again on rows
+	// already done before reaching the ones that were not.
+	//
+	// `episode_titles_at` is the resume marker and it is honest by construction:
+	// the writer stamps it inside the same transaction that writes the titles, so
+	// a stamped row is one whose titles committed.  A row that upstream had nothing
+	// for is NOT stamped -- it never reaches the write -- which means it stays a
+	// candidate.  That is the right direction to be wrong in: re-asking about an
+	// empty subject costs one request, while skipping a row that was never
+	// actually written loses it until someone notices.
+	//
+	// The order is unchanged (anilist_id) so a resumed run walks the same sequence
+	// as the run it continues, and the report of the two can be read side by side.
+	ListBgmBoundNeedingEpisodeTitles(ctx context.Context) ([]ListBgmBoundNeedingEpisodeTitlesRow, error)
 	// Queries against danmakus + episode_windows (P2.5).
 	//
 	// HTTP surface is read-only for danmaku — writes go through socket.io

--- a/go-api/internal/db/queries/backfill.sql
+++ b/go-api/internal/db/queries/backfill.sql
@@ -37,3 +37,40 @@ SET bgm_id           = NULL,
     bangumi_version  = 0,
     updated_at       = now()
 WHERE anilist_id = ANY($1::integer[]);
+
+-- name: ListBgmBoundNeedingEpisodeTitles :many
+-- The same universe as ListBgmBoundForBackfill, minus the rows a previous
+-- episode-title pass already finished.
+--
+-- It exists because a full pass over that universe is hours long and the
+-- upstream can stop answering partway through.  That is not hypothetical: a
+-- production run wrote 3,890 anime and then received nothing for the remaining
+-- 8,215, because the shared account hit a quota ceiling around 5,000 requests
+-- in.  Re-running from the top would have spent that ceiling again on rows
+-- already done before reaching the ones that were not.
+--
+-- `episode_titles_at` is the resume marker and it is honest by construction:
+-- the writer stamps it inside the same transaction that writes the titles, so
+-- a stamped row is one whose titles committed.  A row that upstream had nothing
+-- for is NOT stamped -- it never reaches the write -- which means it stays a
+-- candidate.  That is the right direction to be wrong in: re-asking about an
+-- empty subject costs one request, while skipping a row that was never
+-- actually written loses it until someone notices.
+--
+-- The order is unchanged (anilist_id) so a resumed run walks the same sequence
+-- as the run it continues, and the report of the two can be read side by side.
+SELECT
+    anilist_id,
+    bgm_id,
+    title_native,
+    title_romaji,
+    title_english,
+    title_chinese,
+    season_year,
+    episodes,
+    bangumi_score,
+    bgm_match_source
+FROM anime_cache
+WHERE bgm_id IS NOT NULL
+  AND episode_titles_at IS NULL
+ORDER BY anilist_id;


### PR DESCRIPTION
## Why

A full episode-title pass is ~12,700 rows and hours long, and the upstream can stop answering partway through. It did: a production run wrote **3,890 anime over its first 40%**, then received nothing for the remaining **8,215**, because the shared dandanplay account hit a quota ceiling around 5,000 requests in.

Two separate failures, one fix each.

### It could not tell

The client reports a 4xx and a subject with no episodes identically — both arrive as an empty result — so all 8,215 rows were recorded as *"upstream had no titles"* and the run **reported success** with a 64.6% NO_TITLES share.

The only reason it was caught is that the summary prints that share and warns above 50%. The only reason the warning could be *believed* rather than dismissed is that the failure has a shape:

```
seg  WRITTEN  NO_TITLES
  1     1181         44
  2     1057         79
  3     1012         78
  4      622        521   ← 
  5        8       1254
 ...
 10        5       1241
```

A real catalogue does not do that.

**`--max-empty-streak` (default 200)** aborts after that many consecutive empty rows — but **only once the pass has already written something**. That second condition keeps it from firing on a legitimately barren stretch, and more importantly from misdiagnosing a run that begins against a dead upstream: a pass that has written nothing has not shown the upstream ever answered, so a long empty run is not evidence it *stopped*. That is a different problem — credentials, network, wrong database — and deserves to be read as one.

The report carries `aborted` / `abort_reason` so the artifact cannot be mistaken for a complete run.

### It could not continue

`--limit` caps upstream calls but the loop always walks from the top, and cache hits count against the cap — so a second invocation re-spends the ceiling on rows already done before reaching the ones that were not.

**`--resume`** drops rows a previous pass wrote, keyed on `episode_titles_at`, which is honest by construction: the writer stamps it inside the same transaction that writes the titles. A row upstream had nothing for is **not** stamped — it never reaches the write — so it stays a candidate. That is the right direction to be wrong in: re-asking about an empty subject costs one request, while skipping a row that was never written loses it until someone notices.

## Test plan

- [x] `go test ./...` — 34 packages, 0 failures
- [x] `go test -tags=integration ./test/integration/...` — green
- [x] `TestShouldAbortOnEmptyStreak` — the breaker predicate is extracted as a pure function so the rule is testable without a database or a network; 7 cases including the threshold boundary and a long streak with no writes yet

## Next

Resuming the ~8,400 unfinished rows in production, with `--resume --max-empty-streak 200`.
