### PR TITLE
Reach the rows whose Bangumi id was already known

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ EPISODE_TITLES_SWEEP_ENABLED=false
 # Gates the id-map bind sweep (river worker `bgm_bind_idmap`). Absent or
 # falsey = disabled. It binds the vendored AniList->Bangumi map onto rows that
 # have no bgm_id and dispatches their enrichment; read at work time, and the
-# `bgm_bind_idmap` queue can be paused for an immediate stop without a restart.
+# `bgm_bind` queue can be paused for an immediate stop without a restart.
 BGM_BIND_IDMAP_SWEEP_ENABLED=false
 
 # ─── v2.0.x (Express + Mongo) — still drives `main` and prod ───

--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,12 @@ DANDANPLAY_APP_SECRET=<your-dandanplay-app-secret>
 # immediate stop without a restart, pause the `episode_titles` queue.
 EPISODE_TITLES_SWEEP_ENABLED=false
 
+# Gates the id-map bind sweep (river worker `bgm_bind_idmap`). Absent or
+# falsey = disabled. It binds the vendored AniList->Bangumi map onto rows that
+# have no bgm_id and dispatches their enrichment; read at work time, and the
+# `bgm_bind_idmap` queue can be paused for an immediate stop without a restart.
+BGM_BIND_IDMAP_SWEEP_ENABLED=false
+
 # ─── v2.0.x (Express + Mongo) — still drives `main` and prod ───
 MONGODB_URI=mongodb://localhost:27017/animego
 PORT=5001

--- a/.env.production.template
+++ b/.env.production.template
@@ -131,6 +131,23 @@ DANDANPLAY_APP_SECRET=REPLACE_ME_dandanplay_app_secret
 # costs a small, bounded slice of that budget.
 EPISODE_TITLES_SWEEP_ENABLED=false
 
+# Gates the id-map bind sweep (river worker `bgm_bind_idmap`), same shape as
+# the flag above: read at work time so a restart with it off silences anything
+# river already queued, and the sweep has its own queue so a runtime pause is
+# the no-deploy stop lever.
+#
+# What it does: the V1 worker already treats bgm_id_map as authoritative, but
+# it can only act on rows at bangumi_version = 0. Rows that were already past
+# that point when the map gained their entry -- the bulk of the pre-Go
+# catalogue, parked at version 3 -- keep an answer nobody applies. This sweep
+# is that missing entry point: up to 200 rows per pass, every 6h, binding only
+# subjects no other row holds and no second unbound row also claims.
+#
+# It spends no upstream requests of its own. The cost is downstream: each
+# bound row becomes a Bangumi V2 job, which draws on the same 800ms bucket as
+# the rest of the enrichment pipeline.
+BGM_BIND_IDMAP_SWEEP_ENABLED=false
+
 # ============================================================================
 # 5. Sentry (error reporting)
 # ============================================================================

--- a/.env.production.template
+++ b/.env.production.template
@@ -143,6 +143,9 @@ EPISODE_TITLES_SWEEP_ENABLED=false
 # is that missing entry point: up to 200 rows per pass, every 6h, binding only
 # subjects no other row holds and no second unbound row also claims.
 #
+# Its queue is named `bgm_bind` rather than for this sweep: every writer of
+# anime_cache.bgm_id belongs on it, because one slot is what serialises them.
+#
 # It spends no upstream requests of its own. The cost is downstream: each
 # bound row becomes a Bangumi V2 job, which draws on the same 800ms bucket as
 # the rest of the enrichment pipeline.

--- a/TODOS.md
+++ b/TODOS.md
@@ -580,4 +580,16 @@
 
 **Context** — 2026-09-02 评审实测。这 811 部创建集中在 2026-05-31～06-08，格式以 OVA/ONA 为主。解决后分集标题、中文简介、评分三个缺口一起受益。注意 `bgm_id_map` 是从 `data/anilist_bgm_map.json` 灌进来的**输入**表不是匹配器产物，所以「改进匹配器」和「扩充 map」是两条不同的路。
 
+**2026-09-03 更新** — 这批里有一个子集已经有自动路径了。未绑定行中 826 部在 `bgm_id_map` 里**本来就有答案**，只是够不着：V1 的 tier 0 早就查这张表，但 `UpdateBangumiV1` 带 `AND bangumi_version = 0`，而这些行停在 version 3（migration 0004 记录的 Express 时代批量态），所以答案有了也没人回头用。新的 `bgm_bind_idmap` sweep 补上这个入口，可绑 **791** 部（826 减去 33 部 subject 已被别的行占用、再减去 2 部两行争一个 subject）。剩下的约 4,400 部 map 里没有条目，仍然要靠改进匹配器或扩充 map，本条其余部分不变。
+
 **Depends on / blocked by** — 无。与 `## 分割放送会 50% 概率绑错` 同属绑定质量，建议合并考虑。
+
+## `anime_cache.bgm_id` 没有唯一索引，541 个 subject 已经被多行同时持有
+
+**What** — 给 `anime_cache.bgm_id` 加唯一约束；加之前必须先裁定那 1,161 行。
+
+**Why** — 「一个 bgm subject 对应一部番」这个假设全仓到处在用，但数据库不保证它，而且**已经被破坏了 541 次**（541 个 bgm_id 被 2 行以上持有，共 1,161 行）。直接后果：`GetAnimeByBgmID` 是 `:one` 查询，对这 1,161 行返回的是任意一行——`resolveSiteAnime` 第 2 腿和 `findSiteAnime` 第 3 腿都走它，所以 `/match` 的 siteAnime 结果对这批番是不确定的。任何「按 bgm_id 拉数据写回」的作业也会把同一份中文名和简介写到多部番上。顺带一提这一列**连普通索引都没有**，每次按 bgm_id 查都是全表扫（实测 18,009 行）。
+
+**Context** — 2026-09-03 写 `bgm_bind_idmap` sweep 时量到。⚠️ **不是所有重复都是错的**：Bangumi 有时用一个 subject 覆盖 AniList 拆成两季的内容，那种重复是数据模型差异不是绑定错误。所以不能一刀切去重，得先按「同一 subject 的两行是不是同一部作品的不同季」分类。新 sweep 自己不会让这个数字变大——它拒绝任何已被占用的 subject，也拒绝两行争同一个 subject 的情况——但它也修不了存量。
+
+**Depends on / blocked by** — 无。与 `## 绑定覆盖率` 和 `## 分割放送会 50% 概率绑错` 同属绑定质量。

--- a/go-api/cmd/bgmbackfill/ddp_crosslink_probe.go
+++ b/go-api/cmd/bgmbackfill/ddp_crosslink_probe.go
@@ -1,0 +1,279 @@
+// ddp_crosslink_probe.go — read-only measurement of what dandanplay's
+// cross-links could bind, for the rows the vendored id map is silent about.
+//
+// # What it is for
+//
+// The id-map bind sweep owns every unbound row the map answers for.  What is
+// left is ~4,400 rows the map has never heard of, and for those dandanplay is
+// the only source we already have credentials to.  Two designs were on the
+// table for reaching them: capture the cross-link opportunistically when a user
+// happens to /match one of them, or sweep them all with a search.
+//
+// Both rest on exactly the same evidence -- dandanplay publishes, on one
+// curated entry, a link to an AniList id and a link to a Bangumi subject -- so
+// the choice is not about correctness.  It is about reach against cost, and
+// neither number was known: the capture reaches only the fraction of rows users
+// actually play, and the sweep's cost is a shared request budget that has been
+// hit before.  This probe measures the hit rate and the per-row request cost so
+// the choice is made on numbers.
+//
+// # Why it walks candidates rather than trusting the first hit
+//
+// The search leg is recall, not precision.  A keyword yields whatever
+// dandanplay's index returns, in an order nothing guarantees, and for a
+// franchise that means every season.  Precision comes from one exact test at
+// the end: the entry's AniList cross-link must EQUAL the row we started from.
+// That is the same loose-recall / strict-precision split findSiteAnime already
+// uses, and it is what makes a fuzzy search safe to build a binding on.
+//
+// The probe reports WHICH candidate position answered, because that number is
+// the per-row request cost of the sweep this measures.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/dandanplay"
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+// crosslinkMaxCandidates caps how deep into a search result the probe looks.
+// Every extra position is one more request per row across the whole
+// catalogue, so the cap is deliberately shallow; the position histogram in
+// the report says whether it is costing hits.
+const crosslinkMaxCandidates = 3
+
+// Probe outcome classes.  Ordered here the way the summary prints them:
+// the one that would produce a binding first, then the refusals, then the
+// failures.
+const (
+	xlinkBindable      = "BINDABLE"         // crosslink names our row, subject free
+	xlinkSubjectTaken  = "SUBJECT_TAKEN"    // crosslink names our row, subject held
+	xlinkNoBgmLink     = "NO_BGM_LINK"      // entry matches, but no bgm URL on it
+	xlinkAnilistMiss   = "ANILIST_MISMATCH" // every candidate points somewhere else
+	xlinkNoAnilistLink = "NO_ANILIST_LINK"  // no candidate published an AniList link
+	xlinkNoSearchHit   = "NO_SEARCH_HIT"    // search returned nothing
+	xlinkNoKeyword     = "NO_KEYWORD"       // the row has no title to search with
+	xlinkFetchFail     = "FETCH_FAIL"       // network / upstream error
+)
+
+// crosslinkProbeDB is the read surface the probe needs.
+type crosslinkProbeDB interface {
+	ListUnboundMapSilentForCrosslink(ctx context.Context) ([]dbgen.ListUnboundMapSilentForCrosslinkRow, error)
+	CountAnimeHoldingBgmID(ctx context.Context, bgmID *int32) (int64, error)
+}
+
+// crosslinkProbeClient is the dandanplay surface the probe needs.
+type crosslinkProbeClient interface {
+	SearchAnime(ctx context.Context, keyword string) ([]dandanplay.DandanAnime, error)
+	FetchEpisodesByDandanAnimeID(ctx context.Context, animeID int64) (*dandanplay.EpisodeData, error)
+}
+
+// crosslinkRow is one row's outcome.
+type crosslinkRow struct {
+	AnilistID int32  `json:"anilistId"`
+	Title     string `json:"title"`
+	Class     string `json:"class"`
+	BgmID     int32  `json:"bgmId,omitempty"`
+	// Position is the 1-based index of the candidate that answered, or 0 when
+	// none did.  Averaged over the bindable rows it IS the sweep's per-row
+	// request cost, which is the number the design decision turns on.
+	Position int `json:"position,omitempty"`
+}
+
+// crosslinkReport is the JSON artefact.
+type crosslinkReport struct {
+	Total       int            `json:"total"`
+	Probed      int            `json:"probed"`
+	Counts      map[string]int `json:"counts"`
+	APICalls    int            `json:"ddpApiCalls"`
+	PositionHit map[int]int    `json:"positionHit"`
+	Rows        []crosslinkRow `json:"rows"`
+}
+
+// runCrosslinkProbe walks the candidate set and reports.  Writes nothing.
+func runCrosslinkProbe(ctx context.Context, q crosslinkProbeDB, ddp crosslinkProbeClient, limit int, outPath string) error {
+	rows, err := q.ListUnboundMapSilentForCrosslink(ctx)
+	if err != nil {
+		return fmt.Errorf("list crosslink candidates: %w", err)
+	}
+	slog.Info("ddp crosslink probe: candidates", "count", len(rows), "limit", limit)
+
+	rep := crosslinkReport{
+		Total:       len(rows),
+		Counts:      map[string]int{},
+		PositionHit: map[int]int{},
+		Rows:        make([]crosslinkRow, 0, len(rows)),
+	}
+
+	for i, row := range rows {
+		if limit > 0 && rep.APICalls >= limit {
+			break
+		}
+		if i > 0 && i%50 == 0 {
+			slog.Info("ddp crosslink probe: progress",
+				"probed", rep.Probed, "bindable", rep.Counts[xlinkBindable],
+				"ddp_api_calls", rep.APICalls)
+		}
+		out := probeOneCrosslink(ctx, q, ddp, row, &rep)
+		rep.Probed++
+		rep.Counts[out.Class]++
+		if out.Position > 0 {
+			rep.PositionHit[out.Position]++
+		}
+		rep.Rows = append(rep.Rows, out)
+	}
+
+	printCrosslinkSummary(&rep)
+	if err := writeJSON(outPath, rep); err != nil {
+		return fmt.Errorf("write report %s: %w", outPath, err)
+	}
+	slog.Info("ddp crosslink report written", "path", outPath)
+	return nil
+}
+
+// probeOneCrosslink resolves a single row.
+func probeOneCrosslink(ctx context.Context, q crosslinkProbeDB, ddp crosslinkProbeClient,
+	row dbgen.ListUnboundMapSilentForCrosslinkRow, rep *crosslinkReport) crosslinkRow {
+
+	out := crosslinkRow{AnilistID: row.AnilistID, Title: crosslinkKeyword(row)}
+	if out.Title == "" {
+		out.Class = xlinkNoKeyword
+		return out
+	}
+
+	rep.APICalls++
+	hits, err := ddp.SearchAnime(ctx, out.Title)
+	if err != nil {
+		out.Class = xlinkFetchFail
+		return out
+	}
+	if len(hits) == 0 {
+		out.Class = xlinkNoSearchHit
+		return out
+	}
+
+	// sawAnilistLink separates "dandanplay publishes no AniList link for any of
+	// these entries" from "it does, and every one of them names a different
+	// show".  The first is a gap in their data and says nothing about our row;
+	// the second is a real disagreement and is worth counting on its own.
+	sawAnilistLink := false
+	n := len(hits)
+	if n > crosslinkMaxCandidates {
+		n = crosslinkMaxCandidates
+	}
+	for i := 0; i < n; i++ {
+		rep.APICalls++
+		data, err := ddp.FetchEpisodesByDandanAnimeID(ctx, hits[i].DandanAnimeID)
+		if err != nil {
+			out.Class = xlinkFetchFail
+			return out
+		}
+		if data == nil {
+			continue
+		}
+		if data.AniListID != 0 {
+			sawAnilistLink = true
+		}
+		if data.AniListID != row.AnilistID {
+			continue
+		}
+
+		// Exact identity: dandanplay's own entry names the row we started
+		// from.  Everything after this is about the subject, not the match.
+		out.Position = i + 1
+		if data.BgmID == 0 {
+			out.Class = xlinkNoBgmLink
+			return out
+		}
+		out.BgmID = data.BgmID
+		held, err := q.CountAnimeHoldingBgmID(ctx, &data.BgmID)
+		if err != nil {
+			out.Class = xlinkFetchFail
+			return out
+		}
+		if held > 0 {
+			out.Class = xlinkSubjectTaken
+			return out
+		}
+		out.Class = xlinkBindable
+		return out
+	}
+
+	if sawAnilistLink {
+		out.Class = xlinkAnilistMiss
+	} else {
+		out.Class = xlinkNoAnilistLink
+	}
+	return out
+}
+
+// crosslinkKeyword picks the search string, in the order V1 already uses:
+// native first because dandanplay's index is Japanese-titled, romaji as the
+// fallback.  Chinese is deliberately not used -- dandanplay's Chinese titles
+// are its own, and searching one against its index is not the same test.
+func crosslinkKeyword(row dbgen.ListUnboundMapSilentForCrosslinkRow) string {
+	for _, t := range []*string{row.TitleNative, row.TitleRomaji, row.TitleEnglish} {
+		if t != nil && *t != "" {
+			return *t
+		}
+	}
+	return ""
+}
+
+// printCrosslinkSummary writes the human-readable half.
+func printCrosslinkSummary(rep *crosslinkReport) {
+	fmt.Println()
+	fmt.Println("dandanplay crosslink probe (read-only)")
+	fmt.Printf("%-18s %8s %8s\n", "CLASS", "COUNT", "PCT")
+	fmt.Printf("%-18s %8s %8s\n", "────────────────", "────────", "────────")
+	for _, c := range []string{
+		xlinkBindable, xlinkSubjectTaken, xlinkNoBgmLink, xlinkAnilistMiss,
+		xlinkNoAnilistLink, xlinkNoSearchHit, xlinkNoKeyword, xlinkFetchFail,
+	} {
+		n := rep.Counts[c]
+		pct := 0.0
+		if rep.Probed > 0 {
+			pct = 100 * float64(n) / float64(rep.Probed)
+		}
+		fmt.Printf("%-18s %8d %7.1f%%\n", c, n, pct)
+	}
+
+	fmt.Printf("\n  candidates in scope: %d\n", rep.Total)
+	fmt.Printf("  rows probed:         %d\n", rep.Probed)
+	fmt.Printf("  dandanplay calls:    %d\n", rep.APICalls)
+	if rep.Probed > 0 {
+		fmt.Printf("  calls per row:       %.2f\n", float64(rep.APICalls)/float64(rep.Probed))
+	}
+
+	// The position histogram is the cost lever: if every hit is at position 1
+	// the candidate cap can come down to 1 and the sweep costs two requests a
+	// row, and if hits are spread the cap is buying real coverage.
+	if len(rep.PositionHit) > 0 {
+		keys := make([]int, 0, len(rep.PositionHit))
+		for k := range rep.PositionHit {
+			keys = append(keys, k)
+		}
+		sort.Ints(keys)
+		fmt.Println("\n  identity found at candidate position:")
+		for _, k := range keys {
+			fmt.Printf("    #%d  %d\n", k, rep.PositionHit[k])
+		}
+	}
+
+	// Extrapolation is the whole point of a probe, so it is printed rather
+	// than left for someone to do by hand -- and it is printed with the
+	// sample size beside it, because this is a head-of-catalogue sample and
+	// the id-map pass has already shown that the head is not representative.
+	if rep.Probed > 0 && rep.Total > rep.Probed {
+		rate := float64(rep.Counts[xlinkBindable]) / float64(rep.Probed)
+		fmt.Printf("\n  at this rate a full pass over %d rows would bind ~%.0f\n",
+			rep.Total, rate*float64(rep.Total))
+		fmt.Printf("  and cost ~%.0f requests (n=%d, head of the anilist_id order --\n",
+			float64(rep.APICalls)/float64(rep.Probed)*float64(rep.Total), rep.Probed)
+		fmt.Println("  the id-map pass found its head unrepresentative, so treat this as a range)")
+	}
+}

--- a/go-api/cmd/bgmbackfill/ddp_crosslink_probe_test.go
+++ b/go-api/cmd/bgmbackfill/ddp_crosslink_probe_test.go
@@ -1,0 +1,326 @@
+// ddp_crosslink_probe_test.go — the probe's classification, pinned.
+//
+// The probe exists to answer a design question with numbers, so its
+// classification IS its output.  A class that is wrong in a way nobody notices
+// does not produce a visibly broken report; it produces a plausible one that
+// argues for the wrong design.  These cases pin the distinctions that carry
+// weight in that argument:
+//
+//   - BINDABLE vs SUBJECT_TAKEN decides how many rows a sweep would actually
+//     gain, since a held subject cannot be bound twice.
+//   - ANILIST_MISMATCH vs NO_ANILIST_LINK separates "dandanplay disagrees with
+//     us" from "dandanplay has no opinion".  Collapsing them would read as
+//     upstream contradicting our catalogue when it is merely silent.
+//   - The candidate position is the sweep's per-row request cost.  If it were
+//     recorded off by one, the cost estimate would be wrong by 50%.
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/dandanplay"
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+// fakeCrosslinkClient serves canned search hits and per-entry payloads.
+type fakeCrosslinkClient struct {
+	hits      []dandanplay.DandanAnime
+	byID      map[int64]*dandanplay.EpisodeData
+	searchErr error
+	fetchErr  error
+	calls     int
+}
+
+func (f *fakeCrosslinkClient) SearchAnime(context.Context, string) ([]dandanplay.DandanAnime, error) {
+	if f.searchErr != nil {
+		return nil, f.searchErr
+	}
+	return f.hits, nil
+}
+
+func (f *fakeCrosslinkClient) FetchEpisodesByDandanAnimeID(_ context.Context, id int64) (*dandanplay.EpisodeData, error) {
+	f.calls++
+	if f.fetchErr != nil {
+		return nil, f.fetchErr
+	}
+	return f.byID[id], nil
+}
+
+// fakeCrosslinkDB answers only the held-subject question; the candidate list
+// is supplied directly to probeOneCrosslink.
+type fakeCrosslinkDB struct {
+	held map[int32]int64
+	err  error
+}
+
+func (f *fakeCrosslinkDB) ListUnboundMapSilentForCrosslink(context.Context) ([]dbgen.ListUnboundMapSilentForCrosslinkRow, error) {
+	return nil, nil
+}
+
+func (f *fakeCrosslinkDB) CountAnimeHoldingBgmID(_ context.Context, bgmID *int32) (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	if bgmID == nil {
+		return 0, nil
+	}
+	return f.held[*bgmID], nil
+}
+
+func strp(s string) *string { return &s }
+
+func xlinkHits(ids ...int64) []dandanplay.DandanAnime {
+	out := make([]dandanplay.DandanAnime, len(ids))
+	for i, id := range ids {
+		out[i] = dandanplay.DandanAnime{DandanAnimeID: id}
+	}
+	return out
+}
+
+func TestProbeOneCrosslink(t *testing.T) {
+	const ourAnilist = int32(4242)
+	row := dbgen.ListUnboundMapSilentForCrosslinkRow{
+		AnilistID:   ourAnilist,
+		TitleNative: strp("架空アニメ"),
+	}
+
+	tests := []struct {
+		name         string
+		row          dbgen.ListUnboundMapSilentForCrosslinkRow
+		client       *fakeCrosslinkClient
+		db           *fakeCrosslinkDB
+		wantClass    string
+		wantPosition int
+		wantBgm      int32
+		// wantFetches pins how many entry payloads were pulled, because that
+		// is the number the sweep's cost estimate is built from.
+		wantFetches int
+	}{
+		{
+			name: "the first candidate names our row and its subject is free",
+			row:  row,
+			client: &fakeCrosslinkClient{
+				hits: xlinkHits(11),
+				byID: map[int64]*dandanplay.EpisodeData{
+					11: {AniListID: ourAnilist, BgmID: 900001},
+				},
+			},
+			db:           &fakeCrosslinkDB{held: map[int32]int64{}},
+			wantClass:    xlinkBindable,
+			wantPosition: 1,
+			wantBgm:      900001,
+			wantFetches:  1,
+		},
+		{
+			name: "our row is named by the third candidate, not the first",
+			row:  row,
+			client: &fakeCrosslinkClient{
+				hits: xlinkHits(11, 12, 13),
+				byID: map[int64]*dandanplay.EpisodeData{
+					11: {AniListID: 1, BgmID: 900011},
+					12: {AniListID: 2, BgmID: 900012},
+					13: {AniListID: ourAnilist, BgmID: 900013},
+				},
+			},
+			db:           &fakeCrosslinkDB{held: map[int32]int64{}},
+			wantClass:    xlinkBindable,
+			wantPosition: 3,
+			wantBgm:      900013,
+			wantFetches:  3,
+		},
+		{
+			name: "the identity holds but another row already wears the subject",
+			row:  row,
+			client: &fakeCrosslinkClient{
+				hits: xlinkHits(11),
+				byID: map[int64]*dandanplay.EpisodeData{
+					11: {AniListID: ourAnilist, BgmID: 900021},
+				},
+			},
+			db:           &fakeCrosslinkDB{held: map[int32]int64{900021: 1}},
+			wantClass:    xlinkSubjectTaken,
+			wantPosition: 1,
+			wantBgm:      900021,
+			wantFetches:  1,
+		},
+		{
+			name: "the entry is ours but carries no Bangumi link",
+			row:  row,
+			client: &fakeCrosslinkClient{
+				hits: xlinkHits(11),
+				byID: map[int64]*dandanplay.EpisodeData{
+					11: {AniListID: ourAnilist, BgmID: 0},
+				},
+			},
+			db:           &fakeCrosslinkDB{held: map[int32]int64{}},
+			wantClass:    xlinkNoBgmLink,
+			wantPosition: 1,
+			wantFetches:  1,
+		},
+		{
+			name: "every candidate links to AniList, and none of them to us",
+			row:  row,
+			client: &fakeCrosslinkClient{
+				hits: xlinkHits(11, 12),
+				byID: map[int64]*dandanplay.EpisodeData{
+					11: {AniListID: 7, BgmID: 900031},
+					12: {AniListID: 8, BgmID: 900032},
+				},
+			},
+			db:          &fakeCrosslinkDB{held: map[int32]int64{}},
+			wantClass:   xlinkAnilistMiss,
+			wantFetches: 2,
+		},
+		{
+			name: "no candidate publishes an AniList link at all",
+			row:  row,
+			client: &fakeCrosslinkClient{
+				hits: xlinkHits(11, 12),
+				byID: map[int64]*dandanplay.EpisodeData{
+					11: {AniListID: 0, BgmID: 900041},
+					12: {AniListID: 0, BgmID: 900042},
+				},
+			},
+			db:          &fakeCrosslinkDB{held: map[int32]int64{}},
+			wantClass:   xlinkNoAnilistLink,
+			wantFetches: 2,
+		},
+		{
+			name:        "the search returns nothing",
+			row:         row,
+			client:      &fakeCrosslinkClient{hits: nil},
+			db:          &fakeCrosslinkDB{held: map[int32]int64{}},
+			wantClass:   xlinkNoSearchHit,
+			wantFetches: 0,
+		},
+		{
+			name:        "the row has no title to search with",
+			row:         dbgen.ListUnboundMapSilentForCrosslinkRow{AnilistID: ourAnilist},
+			client:      &fakeCrosslinkClient{},
+			db:          &fakeCrosslinkDB{held: map[int32]int64{}},
+			wantClass:   xlinkNoKeyword,
+			wantFetches: 0,
+		},
+		{
+			name:        "the search itself fails",
+			row:         row,
+			client:      &fakeCrosslinkClient{searchErr: errors.New("upstream down")},
+			db:          &fakeCrosslinkDB{held: map[int32]int64{}},
+			wantClass:   xlinkFetchFail,
+			wantFetches: 0,
+		},
+		{
+			name: "a nil payload is skipped rather than counted as a mismatch",
+			row:  row,
+			client: &fakeCrosslinkClient{
+				hits: xlinkHits(11, 12),
+				byID: map[int64]*dandanplay.EpisodeData{
+					11: nil,
+					12: {AniListID: ourAnilist, BgmID: 900051},
+				},
+			},
+			db:           &fakeCrosslinkDB{held: map[int32]int64{}},
+			wantClass:    xlinkBindable,
+			wantPosition: 2,
+			wantBgm:      900051,
+			wantFetches:  2,
+		},
+		{
+			// The cap is the cost control, so it has to actually stop the walk.
+			// Without this the probe would quietly report the cost of however
+			// many hits dandanplay happened to return.
+			name: "the candidate cap stops the walk",
+			row:  row,
+			client: &fakeCrosslinkClient{
+				hits: xlinkHits(11, 12, 13, 14, 15),
+				byID: map[int64]*dandanplay.EpisodeData{
+					11: {AniListID: 1}, 12: {AniListID: 2}, 13: {AniListID: 3},
+					14: {AniListID: ourAnilist, BgmID: 900061},
+					15: {AniListID: 5},
+				},
+			},
+			db:          &fakeCrosslinkDB{held: map[int32]int64{}},
+			wantClass:   xlinkAnilistMiss,
+			wantFetches: crosslinkMaxCandidates,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := &crosslinkReport{Counts: map[string]int{}, PositionHit: map[int]int{}}
+			got := probeOneCrosslink(context.Background(), tc.db, tc.client, tc.row, rep)
+
+			assert.Equal(t, tc.wantClass, got.Class)
+			assert.Equal(t, tc.wantPosition, got.Position,
+				"the position is the sweep's per-row request cost; an off-by-one here misprices the design")
+			assert.Equal(t, tc.wantBgm, got.BgmID)
+			assert.Equal(t, tc.wantFetches, tc.client.calls,
+				"entry fetches drive the cost estimate")
+
+			// APICalls counts the search plus every entry fetch, which is what
+			// the report divides by row count.
+			wantCalls := tc.wantFetches
+			if tc.wantClass != xlinkNoKeyword {
+				wantCalls++ // the search itself
+			}
+			assert.Equal(t, wantCalls, rep.APICalls,
+				"a request the report does not count is a request the cost estimate loses")
+		})
+	}
+}
+
+// TestCrosslinkKeyword pins the search-string order.  Chinese is absent on
+// purpose: dandanplay's Chinese titles are its own, so searching one against
+// its index tests our copy of its data rather than the identity we are after.
+func TestCrosslinkKeyword(t *testing.T) {
+	tests := []struct {
+		name string
+		row  dbgen.ListUnboundMapSilentForCrosslinkRow
+		want string
+	}{
+		{
+			name: "native wins when present",
+			row: dbgen.ListUnboundMapSilentForCrosslinkRow{
+				TitleNative: strp("ネイティブ"), TitleRomaji: strp("Romaji"),
+				TitleEnglish: strp("English"), TitleChinese: strp("中文"),
+			},
+			want: "ネイティブ",
+		},
+		{
+			name: "romaji is the fallback",
+			row: dbgen.ListUnboundMapSilentForCrosslinkRow{
+				TitleRomaji: strp("Romaji"), TitleChinese: strp("中文"),
+			},
+			want: "Romaji",
+		},
+		{
+			name: "english is the last resort",
+			row: dbgen.ListUnboundMapSilentForCrosslinkRow{
+				TitleEnglish: strp("English"), TitleChinese: strp("中文"),
+			},
+			want: "English",
+		},
+		{
+			name: "an empty string is not a title",
+			row: dbgen.ListUnboundMapSilentForCrosslinkRow{
+				TitleNative: strp(""), TitleRomaji: strp("Romaji"),
+			},
+			want: "Romaji",
+		},
+		{
+			name: "a Chinese title alone is not searched with",
+			row:  dbgen.ListUnboundMapSilentForCrosslinkRow{TitleChinese: strp("中文")},
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, crosslinkKeyword(tc.row))
+		})
+	}
+}

--- a/go-api/cmd/bgmbackfill/id_map_binds.go
+++ b/go-api/cmd/bgmbackfill/id_map_binds.go
@@ -1,0 +1,99 @@
+// id_map_binds.go — read-only preview of the id-map bind sweep.
+//
+// The sweep itself (internal/queue/bgm_bind_idmap.go) runs inside the server,
+// because the enrichment it dispatches has to draw on the process-local
+// Bangumi token bucket.  This is the half a human can run first: it prints
+// exactly what that sweep would bind and, more usefully, what it would refuse
+// and why.
+//
+// It writes nothing, and there is deliberately no --apply here.  A wrong
+// bgm_id does not fail loudly; it puts another show's Chinese title and
+// synopsis on a public page, and anime_cache.bgm_id has no unique index to
+// stop a second row claiming a subject.  Keeping the only writer behind the
+// sweep's single-slot queue is what makes that race unreachable, so this
+// command stays a reader.
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+// idMapBindLister is the read surface this report needs.
+type idMapBindLister interface {
+	ListIdMapBindCandidates(ctx context.Context) ([]dbgen.ListIdMapBindCandidatesRow, error)
+}
+
+// verdict values the query emits.  Restated here so a rename on either side
+// fails a test rather than silently emptying a section of the report.
+const (
+	verdictBindable      = "bindable"
+	verdictAlreadyBound  = "subject-already-bound"
+	verdictClaimedTwice  = "subject-claimed-twice"
+	sampleRowsPerVerdict = 10
+)
+
+// runIdMapBindReport prints the verdict breakdown and a sample of each
+// refusal.  Samples matter more than the counts: the counts say how much the
+// sweep would do, the samples are what let someone judge whether it should.
+func runIdMapBindReport(ctx context.Context, q idMapBindLister) error {
+	rows, err := q.ListIdMapBindCandidates(ctx)
+	if err != nil {
+		return fmt.Errorf("list id-map bind candidates: %w", err)
+	}
+
+	byVerdict := map[string][]dbgen.ListIdMapBindCandidatesRow{}
+	for _, r := range rows {
+		byVerdict[r.Verdict] = append(byVerdict[r.Verdict], r)
+	}
+
+	fmt.Println()
+	fmt.Println("id-map bind candidates (read-only)")
+	fmt.Printf("%-24s %8s\n", "VERDICT", "COUNT")
+	fmt.Printf("%-24s %8s\n", "──────────────────────", "────────")
+	for _, v := range []string{verdictBindable, verdictAlreadyBound, verdictClaimedTwice} {
+		fmt.Printf("%-24s %8d\n", v, len(byVerdict[v]))
+	}
+	fmt.Printf("\n  unbound rows with a map entry: %d\n", len(rows))
+
+	for _, v := range []string{verdictAlreadyBound, verdictClaimedTwice} {
+		printVerdictSample(v, byVerdict[v])
+	}
+	return nil
+}
+
+// printVerdictSample shows the first few rows of one refusal class, ordered by
+// anilist_id so repeated runs print the same sample.
+func printVerdictSample(verdict string, rows []dbgen.ListIdMapBindCandidatesRow) {
+	if len(rows) == 0 {
+		return
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].AnilistID < rows[j].AnilistID })
+	n := len(rows)
+	if n > sampleRowsPerVerdict {
+		n = sampleRowsPerVerdict
+	}
+	fmt.Printf("\n  %s (%d rows, showing %d)\n", verdict, len(rows), n)
+	for _, r := range rows[:n] {
+		fmt.Printf("    anilist=%-8d bgm=%-8d %s\n", r.AnilistID, r.BgmID, bindRowTitle(r))
+	}
+}
+
+// bindRowTitle picks the most legible label available.  Romaji first because
+// it is the one a reader can scan quickly; native is the fallback for rows
+// AniList only carries a Japanese title for.
+func bindRowTitle(r dbgen.ListIdMapBindCandidatesRow) string {
+	title := "(untitled)"
+	if r.TitleRomaji != nil && *r.TitleRomaji != "" {
+		title = *r.TitleRomaji
+	} else if r.TitleNative != nil && *r.TitleNative != "" {
+		title = *r.TitleNative
+	}
+	if r.SeasonYear != nil {
+		return fmt.Sprintf("%s (%d)", title, *r.SeasonYear)
+	}
+	return title
+}

--- a/go-api/cmd/bgmbackfill/main.go
+++ b/go-api/cmd/bgmbackfill/main.go
@@ -101,10 +101,11 @@ func main() {
 	epTitlesMode := flag.Bool("heal-episode-titles", false, "fill anime_episode_titles from dandanplay; read-only unless combined with --apply")
 	resumeFlag := flag.Bool("resume", false, "--heal-episode-titles: skip anime a previous pass already wrote (episode_titles_at set)")
 	maxEmptyStreak := flag.Int("max-empty-streak", 200, "--heal-episode-titles: abort after this many consecutive rows with no titles (0 disables)")
+	idMapBinds := flag.Bool("report-id-map-binds", false, "read-only: what the id-map bind sweep would bind, and what it would refuse")
 	flag.Parse()
 
 	// Default to report mode when no explicit mode is set.
-	if !*applyMode && !*reportMode && !*healMode && !*epTitlesMode {
+	if !*applyMode && !*reportMode && !*healMode && !*epTitlesMode && !*idMapBinds {
 		*reportMode = true
 	}
 
@@ -137,6 +138,17 @@ func main() {
 	defer pool.Close()
 
 	q := dbgen.New(pool)
+
+	// ── id-map bind preview ───────────────────────────────────────────────
+	// Reads two tables and prints; needs neither dandanplay nor the
+	// classifier, so it returns before either is built.
+	if *idMapBinds {
+		if err := runIdMapBindReport(ctx, q); err != nil {
+			slog.Error("id-map bind report failed", "err", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	// ── dandanplay client ─────────────────────────────────────────────────
 	var ddpClient *dandanplay.Client

--- a/go-api/cmd/bgmbackfill/main.go
+++ b/go-api/cmd/bgmbackfill/main.go
@@ -102,10 +102,11 @@ func main() {
 	resumeFlag := flag.Bool("resume", false, "--heal-episode-titles: skip anime a previous pass already wrote (episode_titles_at set)")
 	maxEmptyStreak := flag.Int("max-empty-streak", 200, "--heal-episode-titles: abort after this many consecutive rows with no titles (0 disables)")
 	idMapBinds := flag.Bool("report-id-map-binds", false, "read-only: what the id-map bind sweep would bind, and what it would refuse")
+	xlinkProbe := flag.Bool("probe-ddp-crosslink", false, "read-only: measure what dandanplay cross-links could bind for map-silent unbound rows")
 	flag.Parse()
 
 	// Default to report mode when no explicit mode is set.
-	if !*applyMode && !*reportMode && !*healMode && !*epTitlesMode && !*idMapBinds {
+	if !*applyMode && !*reportMode && !*healMode && !*epTitlesMode && !*idMapBinds && !*xlinkProbe {
 		*reportMode = true
 	}
 
@@ -164,6 +165,21 @@ func main() {
 			os.Exit(1)
 		}
 		defer ddpClient.Close()
+	}
+
+	// ── dandanplay crosslink probe ────────────────────────────────────────
+	// Read-only, and placed before the write modes for that reason.  Needs
+	// the client above, so it cannot sit with the id-map preview.
+	if *xlinkProbe {
+		if *skipDDP || ddpClient == nil {
+			slog.Error("--probe-ddp-crosslink needs dandanplay; do not combine with --skip-ddp")
+			os.Exit(1)
+		}
+		if err := runCrosslinkProbe(ctx, q, ddpClient, *limitFlag, *outFile); err != nil {
+			slog.Error("ddp crosslink probe failed", "err", err)
+			os.Exit(1)
+		}
+		return
 	}
 
 	// ── episode-title heal: fill anime_episode_titles from dandanplay ─────

--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -211,6 +211,15 @@ func main() {
 	// it.
 	queue.AddEpisodeTitlesWorker(workers, pool, q, dandanClient)
 
+	// The id-map bind sweep.  Takes the pool because its unit of work is a
+	// transaction spanning a binding write and that binding's V2 dispatch --
+	// a bound row with no enrichment queued behind it would drop out of the
+	// sweep's own candidate set and never be looked at again.  Takes the
+	// enqueuer for the same reason; `enqueuer` is late-bound above and is
+	// wired to river before any job can run.  Gated at work time by
+	// BGM_BIND_IDMAP_SWEEP_ENABLED.
+	queue.AddBindIdMapWorker(workers, pool, q, enqueuer)
+
 	riverClient, err := queue.Boot(pool, queue.Config{
 		Workers: workers,
 		// Queues: default for V1+V2+warm_season+orphan_scan, bangumi_v3
@@ -265,6 +274,13 @@ func main() {
 			// would only take twice as many tokens away from the request
 			// path.
 			queue.EpisodeTitlesQueueName: {MaxWorkers: 1},
+			// MaxWorkers 1 is load-bearing rather than polite here.
+			// BindBgmIdsFromIdMap refuses a subject some bound row already
+			// holds, but that check and its UPDATE are one statement: two
+			// concurrent passes could each pass it for the same subject and
+			// both bind, and anime_cache.bgm_id has no unique index to catch
+			// it.  A single slot is what makes the race unreachable.
+			queue.BindIdMapQueueName: {MaxWorkers: 1},
 		},
 		PeriodicJobs: []*river.PeriodicJob{
 			queue.PeriodicWarmSeasonJob(),
@@ -276,6 +292,7 @@ func main() {
 			// otherwise push the sweep a full hour out every time.
 			queue.PeriodicEpisodesBgmScanJob(),
 			queue.PeriodicEpisodeTitlesJob(),
+			queue.PeriodicBindIdMapJob(),
 			// 90 days, and deliberately NOT RunOnStart — see the note on
 			// PeriodicHantBackfillJob for why this one reads the opposite
 			// way round from the two sweeps above it, and for what that

--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -279,8 +279,9 @@ func main() {
 			// holds, but that check and its UPDATE are one statement: two
 			// concurrent passes could each pass it for the same subject and
 			// both bind, and anime_cache.bgm_id has no unique index to catch
-			// it.  A single slot is what makes the race unreachable.
-			queue.BindIdMapQueueName: {MaxWorkers: 1},
+			// it.  A single slot is what makes the race unreachable, and it
+			// is why every writer of anime_cache.bgm_id shares this queue.
+			queue.BgmBindQueueName: {MaxWorkers: 1},
 		},
 		PeriodicJobs: []*river.PeriodicJob{
 			queue.PeriodicWarmSeasonJob(),

--- a/go-api/internal/db/gen/anime_cache.sql.go
+++ b/go-api/internal/db/gen/anime_cache.sql.go
@@ -101,6 +101,117 @@ func (q *Queries) ApplyHantTitleBatch(ctx context.Context, anilistIds []int32, t
 	return result.RowsAffected(), nil
 }
 
+const bindBgmIdsFromIdMap = `-- name: BindBgmIdsFromIdMap :many
+WITH unbound AS (
+    SELECT a.anilist_id,
+           m.bgm_id,
+           count(*) OVER (PARTITION BY m.bgm_id) AS claims
+    FROM anime_cache a
+    JOIN bgm_id_map m ON m.anilist_id = a.anilist_id
+    WHERE a.bgm_id IS NULL
+),
+eligible AS (
+    SELECT anilist_id, bgm_id
+    FROM unbound
+    WHERE claims = 1
+      AND NOT EXISTS (
+          SELECT 1 FROM anime_cache b WHERE b.bgm_id = unbound.bgm_id
+      )
+    ORDER BY anilist_id
+    LIMIT $1::int
+)
+UPDATE anime_cache a
+SET bgm_id           = e.bgm_id,
+    bgm_match_source = 'id_map',
+    -- A row parked by V1's needs-review path (no bgm_id, admin_flag set,
+    -- bgm_match_source 'fuzzy_low') is a candidate here the moment the map
+    -- gains its entry, and the map answering IS the resolution of that
+    -- review.  Leaving the flag would keep a settled row in the admin queue
+    -- for good.  'manually-corrected' is deliberately not touched: that one
+    -- records a human's decision, not a pending request for one.
+    admin_flag       = CASE WHEN a.admin_flag = 'needs-review' THEN NULL
+                            ELSE a.admin_flag END,
+    updated_at       = now()
+FROM eligible e
+WHERE a.anilist_id = e.anilist_id
+  AND a.bgm_id IS NULL
+RETURNING a.anilist_id, e.bgm_id
+`
+
+type BindBgmIdsFromIdMapRow struct {
+	AnilistID int32 `json:"anilistId"`
+	BgmID     int32 `json:"bgmId"`
+}
+
+// Bind the vendored id map's answer onto rows that carry no bgm_id.
+//
+// # Why these rows need a second entry point at all
+//
+// The V1 worker already consults this same map first, and trusts it without
+// a search (bangumi_v1.go step 0).  But UpdateBangumiV1 is guarded on
+// `bangumi_version = 0`, and the rows this query is for sit at version 3 --
+// the bulk state migration 0004 records for everything enriched under the
+// pre-Go pipeline.  So V1's tier-0 answer is right and simply unreachable
+// for them: the map gained an entry after their one pass had already run,
+// and no producer looks at a version-3 row again.
+//
+// # What licenses trusting the map without a second signal
+//
+// Measured on production before this query was written: of the rows that
+// ARE bound and have a map entry, 3,769 were bound by the pre-Go pipeline
+// with no bgm_match_source recorded -- an entirely separate process from
+// this map -- and the map agrees with every single one of them.  Zero
+// disagreements out of 3,769 independent bindings is the evidence; V1
+// trusting the same map unconditionally is the precedent.
+//
+// # The two guards, and why both are load-bearing
+//
+// anime_cache.bgm_id has no unique index (541 subjects are already held by
+// more than one row, so one cannot be added without a cleanup first), which
+// means nothing below this query would catch a double binding.  Both guards
+// are therefore the only defence:
+//
+//	claims = 1   no OTHER unbound row maps to the same subject.  Needed
+//	             because a data-modifying statement cannot see its own
+//	             writes: without it, two rows mapping to one subject would
+//	             both pass the NOT EXISTS check in the same statement and
+//	             both be bound.
+//	NOT EXISTS   no BOUND row already holds the subject.
+//
+// `AND a.bgm_id IS NULL` on the UPDATE itself is the CAS: it re-checks, at
+// write time, the condition the CTE selected on.
+//
+// The write also retires a 'needs-review' flag, for the reason given inline
+// on that clause.
+//
+// Concurrency: two of these running at once could each pass NOT EXISTS for
+// the same subject.  The sweep that calls it runs on its own queue at
+// MaxWorkers 1, which is what makes that unreachable; a second caller would
+// need the same discipline.
+//
+// LIMIT keeps a batch bounded so the sweep's runtime is predictable.  The
+// ORDER BY makes successive batches walk the catalogue in a stable order
+// rather than re-drawing from the same end of it.
+func (q *Queries) BindBgmIdsFromIdMap(ctx context.Context, lim int32) ([]BindBgmIdsFromIdMapRow, error) {
+	rows, err := q.db.Query(ctx, bindBgmIdsFromIdMap, lim)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []BindBgmIdsFromIdMapRow{}
+	for rows.Next() {
+		var i BindBgmIdsFromIdMapRow
+		if err := rows.Scan(&i.AnilistID, &i.BgmID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const clearEpisodeTitlesBySourceOutside = `-- name: ClearEpisodeTitlesBySourceOutside :many
 UPDATE anime_episode_titles t
    SET name_cn        = CASE WHEN t.name_cn_source = $1::text
@@ -2399,6 +2510,93 @@ func (q *Queries) ListEpisodesBgmCandidates(ctx context.Context, arg ListEpisode
 	for rows.Next() {
 		var i ListEpisodesBgmCandidatesRow
 		if err := rows.Scan(&i.AnilistID, &i.BgmID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listIdMapBindCandidates = `-- name: ListIdMapBindCandidates :many
+WITH unbound AS (
+    SELECT a.anilist_id,
+           m.bgm_id,
+           a.title_romaji,
+           a.title_native,
+           a.season_year,
+           count(*) OVER (PARTITION BY m.bgm_id) AS claims
+    FROM anime_cache a
+    JOIN bgm_id_map m ON m.anilist_id = a.anilist_id
+    WHERE a.bgm_id IS NULL
+)
+SELECT anilist_id,
+       bgm_id,
+       title_romaji,
+       title_native,
+       season_year,
+       CASE
+           WHEN EXISTS (
+               SELECT 1 FROM anime_cache b WHERE b.bgm_id = unbound.bgm_id
+           ) THEN 'subject-already-bound'
+           WHEN claims > 1 THEN 'subject-claimed-twice'
+           ELSE 'bindable'
+       END::text AS verdict
+FROM unbound
+ORDER BY anilist_id
+`
+
+type ListIdMapBindCandidatesRow struct {
+	AnilistID   int32   `json:"anilistId"`
+	BgmID       int32   `json:"bgmId"`
+	TitleRomaji *string `json:"titleRomaji"`
+	TitleNative *string `json:"titleNative"`
+	SeasonYear  *int32  `json:"seasonYear"`
+	Verdict     string  `json:"verdict"`
+}
+
+// Read-only preview of what BindBgmIdsFromIdMap would do, and of what it
+// would refuse.  It exists so a human can read the refusals before any
+// binding is written: a wrong bgm_id does not fail loudly, it quietly puts
+// another show's Chinese title and synopsis on a public page.
+//
+// The three verdicts, and why the two refusals are refusals:
+//
+//	bindable               the map names a subject nothing else holds.
+//	subject-already-bound  another anime_cache row already carries this
+//	                       bgm_id.  Binding a second row to it would make
+//	                       GetAnimeByBgmID -- a :one query -- return an
+//	                       arbitrary one of them, so the subject is left
+//	                       to the row that already has it.
+//	subject-claimed-twice  two unbound AniList entries both map to this
+//	                       subject.  At least one of the two is wrong and
+//	                       nothing here can say which, so neither is bound.
+//	                       (Live example: Gekidol and its prequel special
+//	                       Alice in Deadly School both map to bgm 195723.)
+//
+// `claims` counts over the unbound set only, which is what makes the two
+// refusals distinct rather than one collapsed "taken" case: a subject held
+// by a bound row is somebody else's, while a subject two unbound rows both
+// want is nobody's yet.
+func (q *Queries) ListIdMapBindCandidates(ctx context.Context) ([]ListIdMapBindCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listIdMapBindCandidates)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListIdMapBindCandidatesRow{}
+	for rows.Next() {
+		var i ListIdMapBindCandidatesRow
+		if err := rows.Scan(
+			&i.AnilistID,
+			&i.BgmID,
+			&i.TitleRomaji,
+			&i.TitleNative,
+			&i.SeasonYear,
+			&i.Verdict,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/go-api/internal/db/gen/backfill.sql.go
+++ b/go-api/internal/db/gen/backfill.sql.go
@@ -31,6 +31,25 @@ func (q *Queries) BackfillResetRows(ctx context.Context, dollar_1 []int32) error
 	return err
 }
 
+const countAnimeHoldingBgmID = `-- name: CountAnimeHoldingBgmID :one
+SELECT count(*)::bigint FROM anime_cache WHERE bgm_id = $1
+`
+
+// Whether any anime_cache row already holds this subject.
+//
+// The crosslink path has to ask this per row rather than as a set predicate,
+// because the subject it is testing does not exist until dandanplay answers.
+// Same refusal the id-map bind makes with its NOT EXISTS, asked one row at a
+// time: anime_cache.bgm_id has no unique index, so a second row claiming a
+// held subject would be accepted silently and make GetAnimeByBgmID -- a :one
+// query -- return an arbitrary one of them.
+func (q *Queries) CountAnimeHoldingBgmID(ctx context.Context, bgmID *int32) (int64, error) {
+	row := q.db.QueryRow(ctx, countAnimeHoldingBgmID, bgmID)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const listBgmBoundForBackfill = `-- name: ListBgmBoundForBackfill :many
 
 SELECT
@@ -171,6 +190,79 @@ func (q *Queries) ListBgmBoundNeedingEpisodeTitles(ctx context.Context) ([]ListB
 			&i.Episodes,
 			&i.BangumiScore,
 			&i.BgmMatchSource,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUnboundMapSilentForCrosslink = `-- name: ListUnboundMapSilentForCrosslink :many
+SELECT
+    anilist_id,
+    title_native,
+    title_romaji,
+    title_english,
+    title_chinese,
+    season_year,
+    episodes,
+    format,
+    status
+FROM anime_cache a
+WHERE a.bgm_id IS NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM bgm_id_map m WHERE m.anilist_id = a.anilist_id
+  )
+ORDER BY a.anilist_id
+`
+
+type ListUnboundMapSilentForCrosslinkRow struct {
+	AnilistID    int32   `json:"anilistId"`
+	TitleNative  *string `json:"titleNative"`
+	TitleRomaji  *string `json:"titleRomaji"`
+	TitleEnglish *string `json:"titleEnglish"`
+	TitleChinese *string `json:"titleChinese"`
+	SeasonYear   *int32  `json:"seasonYear"`
+	Episodes     *int32  `json:"episodes"`
+	Format       *string `json:"format"`
+	Status       *string `json:"status"`
+}
+
+// Rows with no bgm_id that the vendored id map has nothing to say about.
+//
+// This is the population left after the id-map bind sweep has run: the sweep
+// owns every unbound row the map DOES answer for, and deliberately writes
+// nothing where it is silent.  Excluding those rows here is what keeps the two
+// paths from ever disagreeing about the same row -- the map wins where it
+// speaks, without either side having to check what the other decided.
+//
+// The order is anilist_id, so a run that stops partway and a run that resumes
+// walk the same sequence and their reports can be read side by side.  Ordering
+// by popularity would read better in a report and be wrong here: it would make
+// successive probes re-draw the same head of the catalogue.
+func (q *Queries) ListUnboundMapSilentForCrosslink(ctx context.Context) ([]ListUnboundMapSilentForCrosslinkRow, error) {
+	rows, err := q.db.Query(ctx, listUnboundMapSilentForCrosslink)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListUnboundMapSilentForCrosslinkRow{}
+	for rows.Next() {
+		var i ListUnboundMapSilentForCrosslinkRow
+		if err := rows.Scan(
+			&i.AnilistID,
+			&i.TitleNative,
+			&i.TitleRomaji,
+			&i.TitleEnglish,
+			&i.TitleChinese,
+			&i.SeasonYear,
+			&i.Episodes,
+			&i.Format,
+			&i.Status,
 		); err != nil {
 			return nil, err
 		}

--- a/go-api/internal/db/gen/querier.go
+++ b/go-api/internal/db/gen/querier.go
@@ -210,6 +210,15 @@ type Querier interface {
 	// comes back short. SearchLocalKeywordConsistency in search_test.go pins them
 	// to the same shape.
 	CountAnimeCacheLocal(ctx context.Context, contains string, containsFolded string) (int64, error)
+	// Whether any anime_cache row already holds this subject.
+	//
+	// The crosslink path has to ask this per row rather than as a set predicate,
+	// because the subject it is testing does not exist until dandanplay answers.
+	// Same refusal the id-map bind makes with its NOT EXISTS, asked one row at a
+	// time: anime_cache.bgm_id has no unique index, so a second row claiming a
+	// held subject would be accepted silently and make GetAnimeByBgmID -- a :one
+	// query -- return an arbitrary one of them.
+	CountAnimeHoldingBgmID(ctx context.Context, bgmID *int32) (int64, error)
 	// Boot log + admin dashboard: how many AniList->Bangumi rows are loaded.
 	CountBgmIdMap(ctx context.Context) (int64, error)
 	CountCommentReactions(ctx context.Context, commentID uuid.UUID) (int64, error)
@@ -1360,6 +1369,19 @@ type Querier interface {
 	// ordering jump at a hard date boundary.  Authenticated viewers do not see
 	// threads authored only by someone they blocked or were blocked by.
 	ListTrendingDiscussions(ctx context.Context, pageLimit int32, windowHours int32, viewerUserID *uuid.UUID) ([]ListTrendingDiscussionsRow, error)
+	// Rows with no bgm_id that the vendored id map has nothing to say about.
+	//
+	// This is the population left after the id-map bind sweep has run: the sweep
+	// owns every unbound row the map DOES answer for, and deliberately writes
+	// nothing where it is silent.  Excluding those rows here is what keeps the two
+	// paths from ever disagreeing about the same row -- the map wins where it
+	// speaks, without either side having to check what the other decided.
+	//
+	// The order is anilist_id, so a run that stops partway and a run that resumes
+	// walk the same sequence and their reports can be read side by side.  Ordering
+	// by popularity would read better in a report and be wrong here: it would make
+	// successive probes re-draw the same head of the catalogue.
+	ListUnboundMapSilentForCrosslink(ctx context.Context) ([]ListUnboundMapSilentForCrosslinkRow, error)
 	// Boot-time orphan scan: returns anilist_ids of rows where
 	// bangumi_version=0 (never enriched).  Paginated via limit/offset so
 	// the caller can batch-enqueue without loading the whole table into

--- a/go-api/internal/db/gen/querier.go
+++ b/go-api/internal/db/gen/querier.go
@@ -85,6 +85,56 @@ type Querier interface {
 	// score/votes so the bad data disappears immediately; bangumi_version=0
 	// re-queues them via the orphan scan / a follow-up V1 enqueue.
 	BackfillResetRows(ctx context.Context, dollar_1 []int32) error
+	// Bind the vendored id map's answer onto rows that carry no bgm_id.
+	//
+	// # Why these rows need a second entry point at all
+	//
+	// The V1 worker already consults this same map first, and trusts it without
+	// a search (bangumi_v1.go step 0).  But UpdateBangumiV1 is guarded on
+	// `bangumi_version = 0`, and the rows this query is for sit at version 3 --
+	// the bulk state migration 0004 records for everything enriched under the
+	// pre-Go pipeline.  So V1's tier-0 answer is right and simply unreachable
+	// for them: the map gained an entry after their one pass had already run,
+	// and no producer looks at a version-3 row again.
+	//
+	// # What licenses trusting the map without a second signal
+	//
+	// Measured on production before this query was written: of the rows that
+	// ARE bound and have a map entry, 3,769 were bound by the pre-Go pipeline
+	// with no bgm_match_source recorded -- an entirely separate process from
+	// this map -- and the map agrees with every single one of them.  Zero
+	// disagreements out of 3,769 independent bindings is the evidence; V1
+	// trusting the same map unconditionally is the precedent.
+	//
+	// # The two guards, and why both are load-bearing
+	//
+	// anime_cache.bgm_id has no unique index (541 subjects are already held by
+	// more than one row, so one cannot be added without a cleanup first), which
+	// means nothing below this query would catch a double binding.  Both guards
+	// are therefore the only defence:
+	//
+	//	claims = 1   no OTHER unbound row maps to the same subject.  Needed
+	//	             because a data-modifying statement cannot see its own
+	//	             writes: without it, two rows mapping to one subject would
+	//	             both pass the NOT EXISTS check in the same statement and
+	//	             both be bound.
+	//	NOT EXISTS   no BOUND row already holds the subject.
+	//
+	// `AND a.bgm_id IS NULL` on the UPDATE itself is the CAS: it re-checks, at
+	// write time, the condition the CTE selected on.
+	//
+	// The write also retires a 'needs-review' flag, for the reason given inline
+	// on that clause.
+	//
+	// Concurrency: two of these running at once could each pass NOT EXISTS for
+	// the same subject.  The sweep that calls it runs on its own queue at
+	// MaxWorkers 1, which is what makes that unreachable; a second caller would
+	// need the same discipline.
+	//
+	// LIMIT keeps a batch bounded so the sweep's runtime is predictable.  The
+	// ORDER BY makes successive batches walk the catalogue in a stable order
+	// rather than re-drawing from the same end of it.
+	BindBgmIdsFromIdMap(ctx context.Context, lim int32) ([]BindBgmIdsFromIdMapRow, error)
 	// Community safety data access introduced by migration 0019.
 	// Blocking is one atomic boundary: create the directional block and sever all
 	// social/notification edges between the two users. Repeating the request is
@@ -1215,6 +1265,30 @@ type Querier interface {
 	// Returns the queue payload shape (anilistId / bgmId / titleChinese /
 	// bangumiVersion) so the handler can build V3 jobs directly.
 	ListHealCnCandidates(ctx context.Context) ([]ListHealCnCandidatesRow, error)
+	// Read-only preview of what BindBgmIdsFromIdMap would do, and of what it
+	// would refuse.  It exists so a human can read the refusals before any
+	// binding is written: a wrong bgm_id does not fail loudly, it quietly puts
+	// another show's Chinese title and synopsis on a public page.
+	//
+	// The three verdicts, and why the two refusals are refusals:
+	//
+	//	bindable               the map names a subject nothing else holds.
+	//	subject-already-bound  another anime_cache row already carries this
+	//	                       bgm_id.  Binding a second row to it would make
+	//	                       GetAnimeByBgmID -- a :one query -- return an
+	//	                       arbitrary one of them, so the subject is left
+	//	                       to the row that already has it.
+	//	subject-claimed-twice  two unbound AniList entries both map to this
+	//	                       subject.  At least one of the two is wrong and
+	//	                       nothing here can say which, so neither is bound.
+	//	                       (Live example: Gekidol and its prequel special
+	//	                       Alice in Deadly School both map to bgm 195723.)
+	//
+	// `claims` counts over the unbound set only, which is what makes the two
+	// refusals distinct rather than one collapsed "taken" case: a subject held
+	// by a bound row is somebody else's, while a subject two unbound rows both
+	// want is nobody's yet.
+	ListIdMapBindCandidates(ctx context.Context) ([]ListIdMapBindCandidatesRow, error)
 	// Heal targets for the dandanplay CN backfill: rows whose CURRENT bgm_id IS
 	// the authoritative id-map binding (so the subject is trusted) but that still
 	// have no Chinese title.  Healing these from dandanplay's animeTitle is safe

--- a/go-api/internal/db/queries/anime_cache.sql
+++ b/go-api/internal/db/queries/anime_cache.sql
@@ -553,6 +553,141 @@ SET bgm_id           = NULL,
     updated_at       = now()
 WHERE anilist_id = $1 AND bangumi_version = 0;
 
+-- name: ListIdMapBindCandidates :many
+-- Read-only preview of what BindBgmIdsFromIdMap would do, and of what it
+-- would refuse.  It exists so a human can read the refusals before any
+-- binding is written: a wrong bgm_id does not fail loudly, it quietly puts
+-- another show's Chinese title and synopsis on a public page.
+--
+-- The three verdicts, and why the two refusals are refusals:
+--
+--	bindable               the map names a subject nothing else holds.
+--	subject-already-bound  another anime_cache row already carries this
+--	                       bgm_id.  Binding a second row to it would make
+--	                       GetAnimeByBgmID -- a :one query -- return an
+--	                       arbitrary one of them, so the subject is left
+--	                       to the row that already has it.
+--	subject-claimed-twice  two unbound AniList entries both map to this
+--	                       subject.  At least one of the two is wrong and
+--	                       nothing here can say which, so neither is bound.
+--	                       (Live example: Gekidol and its prequel special
+--	                       Alice in Deadly School both map to bgm 195723.)
+--
+-- `claims` counts over the unbound set only, which is what makes the two
+-- refusals distinct rather than one collapsed "taken" case: a subject held
+-- by a bound row is somebody else's, while a subject two unbound rows both
+-- want is nobody's yet.
+WITH unbound AS (
+    SELECT a.anilist_id,
+           m.bgm_id,
+           a.title_romaji,
+           a.title_native,
+           a.season_year,
+           count(*) OVER (PARTITION BY m.bgm_id) AS claims
+    FROM anime_cache a
+    JOIN bgm_id_map m ON m.anilist_id = a.anilist_id
+    WHERE a.bgm_id IS NULL
+)
+SELECT anilist_id,
+       bgm_id,
+       title_romaji,
+       title_native,
+       season_year,
+       CASE
+           WHEN EXISTS (
+               SELECT 1 FROM anime_cache b WHERE b.bgm_id = unbound.bgm_id
+           ) THEN 'subject-already-bound'
+           WHEN claims > 1 THEN 'subject-claimed-twice'
+           ELSE 'bindable'
+       END::text AS verdict
+FROM unbound
+ORDER BY anilist_id;
+
+-- name: BindBgmIdsFromIdMap :many
+-- Bind the vendored id map's answer onto rows that carry no bgm_id.
+--
+-- # Why these rows need a second entry point at all
+--
+-- The V1 worker already consults this same map first, and trusts it without
+-- a search (bangumi_v1.go step 0).  But UpdateBangumiV1 is guarded on
+-- `bangumi_version = 0`, and the rows this query is for sit at version 3 --
+-- the bulk state migration 0004 records for everything enriched under the
+-- pre-Go pipeline.  So V1's tier-0 answer is right and simply unreachable
+-- for them: the map gained an entry after their one pass had already run,
+-- and no producer looks at a version-3 row again.
+--
+-- # What licenses trusting the map without a second signal
+--
+-- Measured on production before this query was written: of the rows that
+-- ARE bound and have a map entry, 3,769 were bound by the pre-Go pipeline
+-- with no bgm_match_source recorded -- an entirely separate process from
+-- this map -- and the map agrees with every single one of them.  Zero
+-- disagreements out of 3,769 independent bindings is the evidence; V1
+-- trusting the same map unconditionally is the precedent.
+--
+-- # The two guards, and why both are load-bearing
+--
+-- anime_cache.bgm_id has no unique index (541 subjects are already held by
+-- more than one row, so one cannot be added without a cleanup first), which
+-- means nothing below this query would catch a double binding.  Both guards
+-- are therefore the only defence:
+--
+--	claims = 1   no OTHER unbound row maps to the same subject.  Needed
+--	             because a data-modifying statement cannot see its own
+--	             writes: without it, two rows mapping to one subject would
+--	             both pass the NOT EXISTS check in the same statement and
+--	             both be bound.
+--	NOT EXISTS   no BOUND row already holds the subject.
+--
+-- `AND a.bgm_id IS NULL` on the UPDATE itself is the CAS: it re-checks, at
+-- write time, the condition the CTE selected on.
+--
+-- The write also retires a 'needs-review' flag, for the reason given inline
+-- on that clause.
+--
+-- Concurrency: two of these running at once could each pass NOT EXISTS for
+-- the same subject.  The sweep that calls it runs on its own queue at
+-- MaxWorkers 1, which is what makes that unreachable; a second caller would
+-- need the same discipline.
+--
+-- LIMIT keeps a batch bounded so the sweep's runtime is predictable.  The
+-- ORDER BY makes successive batches walk the catalogue in a stable order
+-- rather than re-drawing from the same end of it.
+WITH unbound AS (
+    SELECT a.anilist_id,
+           m.bgm_id,
+           count(*) OVER (PARTITION BY m.bgm_id) AS claims
+    FROM anime_cache a
+    JOIN bgm_id_map m ON m.anilist_id = a.anilist_id
+    WHERE a.bgm_id IS NULL
+),
+eligible AS (
+    SELECT anilist_id, bgm_id
+    FROM unbound
+    WHERE claims = 1
+      AND NOT EXISTS (
+          SELECT 1 FROM anime_cache b WHERE b.bgm_id = unbound.bgm_id
+      )
+    ORDER BY anilist_id
+    LIMIT sqlc.arg(lim)::int
+)
+UPDATE anime_cache a
+SET bgm_id           = e.bgm_id,
+    bgm_match_source = 'id_map',
+    -- A row parked by V1's needs-review path (no bgm_id, admin_flag set,
+    -- bgm_match_source 'fuzzy_low') is a candidate here the moment the map
+    -- gains its entry, and the map answering IS the resolution of that
+    -- review.  Leaving the flag would keep a settled row in the admin queue
+    -- for good.  'manually-corrected' is deliberately not touched: that one
+    -- records a human's decision, not a pending request for one.
+    admin_flag       = CASE WHEN a.admin_flag = 'needs-review' THEN NULL
+                            ELSE a.admin_flag END,
+    updated_at       = now()
+FROM eligible e
+WHERE a.anilist_id = e.anilist_id
+  AND a.bgm_id IS NULL
+RETURNING a.anilist_id, e.bgm_id;
+
 -- name: UpdateBangumiV2 :exec
 -- Phase 2 result: write bangumi_score + bangumi_votes from Bangumi
 -- Subject API.  Also conditionally fills title_chinese if it's still

--- a/go-api/internal/db/queries/backfill.sql
+++ b/go-api/internal/db/queries/backfill.sql
@@ -74,3 +74,44 @@ FROM anime_cache
 WHERE bgm_id IS NOT NULL
   AND episode_titles_at IS NULL
 ORDER BY anilist_id;
+
+-- name: ListUnboundMapSilentForCrosslink :many
+-- Rows with no bgm_id that the vendored id map has nothing to say about.
+--
+-- This is the population left after the id-map bind sweep has run: the sweep
+-- owns every unbound row the map DOES answer for, and deliberately writes
+-- nothing where it is silent.  Excluding those rows here is what keeps the two
+-- paths from ever disagreeing about the same row -- the map wins where it
+-- speaks, without either side having to check what the other decided.
+--
+-- The order is anilist_id, so a run that stops partway and a run that resumes
+-- walk the same sequence and their reports can be read side by side.  Ordering
+-- by popularity would read better in a report and be wrong here: it would make
+-- successive probes re-draw the same head of the catalogue.
+SELECT
+    anilist_id,
+    title_native,
+    title_romaji,
+    title_english,
+    title_chinese,
+    season_year,
+    episodes,
+    format,
+    status
+FROM anime_cache a
+WHERE a.bgm_id IS NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM bgm_id_map m WHERE m.anilist_id = a.anilist_id
+  )
+ORDER BY a.anilist_id;
+
+-- name: CountAnimeHoldingBgmID :one
+-- Whether any anime_cache row already holds this subject.
+--
+-- The crosslink path has to ask this per row rather than as a set predicate,
+-- because the subject it is testing does not exist until dandanplay answers.
+-- Same refusal the id-map bind makes with its NOT EXISTS, asked one row at a
+-- time: anime_cache.bgm_id has no unique index, so a second row claiming a
+-- held subject would be accepted silently and make GetAnimeByBgmID -- a :one
+-- query -- return an arbitrary one of them.
+SELECT count(*)::bigint FROM anime_cache WHERE bgm_id = @bgm_id;

--- a/go-api/internal/queue/bgm_bind_idmap.go
+++ b/go-api/internal/queue/bgm_bind_idmap.go
@@ -1,0 +1,238 @@
+// bgm_bind_idmap.go — periodic sweep that binds the vendored AniList→Bangumi
+// id map onto rows that carry no bgm_id.
+//
+// # The gap this fills
+//
+// The V1 worker already consults this map first and trusts it without a search
+// (bangumi_v1.go step 0), so for a row entering the pipeline the map's answer
+// is applied automatically.  What has no entry point is a row that was ALREADY
+// past V1 when the map gained its entry: UpdateBangumiV1 is guarded on
+// `bangumi_version = 0`, and the rows this sweep is for sit at version 3, the
+// bulk state migration 0004 records for everything enriched under the pre-Go
+// pipeline.  Nothing looks at a version-3 row again, so a correct answer sat
+// unreachable in a table we already trust.
+//
+// That shape — an enrichment producer that runs at most once per anime, and a
+// source of truth that improves afterwards — is the same one that stranded
+// episode titles (see episode_titles_releasing.go) and Chinese descriptions
+// (description_backfill.go).  It is tracked in TODOS.md as the version
+// ratchet; this file is the third patch over it rather than a fix for it.
+//
+// # Why the map is trusted with no second signal
+//
+// Measured on production before this sweep was written: of the bound rows that
+// also have a map entry, 3,769 were bound by the pre-Go pipeline with no
+// bgm_match_source recorded — an entirely separate process — and the map
+// agrees with all 3,769.  Zero disagreements against an independent producer
+// is the evidence.  V1 trusting the same table unconditionally is the
+// precedent.  The refusals that DO matter are structural rather than
+// evidential, and live in the query: a subject another row already holds, and
+// a subject two unbound rows both claim.
+//
+// # Why the bind and the enqueue share a transaction
+//
+// A binding with no enrichment behind it is worse than no binding: the row
+// gains a bgm_id, which removes it from this sweep's candidate set forever,
+// and nothing else will ever fetch its Chinese title or score.  So the V2
+// dispatch goes through EnqueueV2ManyTx on the same transaction as the bind.
+// Either the row is bound and queued, or it is neither and stays a candidate.
+//
+// # Why there is no attempt bookkeeping
+//
+// Migrations 0015 and 0023 both had to add attempt/outcome columns because
+// their sweeps decided candidacy on "the value is still missing", so a row
+// that could never produce a value held the front of every batch forever.
+// Neither ingredient is present here.  A bound row stops matching
+// `bgm_id IS NULL`, and a row the query refuses is excluded before the LIMIT
+// applies — so refusals never consume a batch slot, and once the bindable set
+// is drained every subsequent run is one cheap query that returns nothing.
+package queue
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+const (
+	// BindIdMapQueueName is the sweep's own river queue.  A dedicated queue
+	// is what lets river's runtime pause apply to this alone — the same
+	// mechanism the admin surface uses to freeze heal-CN — and a pause needs
+	// no deploy, unlike the env flag below.
+	//
+	// It also carries a correctness role: BindBgmIdsFromIdMap's "no bound row
+	// holds this subject" check and its UPDATE are one statement, but two
+	// concurrent statements could still each pass it for the same subject.
+	// Registering this queue at MaxWorkers 1 makes that unreachable.
+	BindIdMapQueueName = "bgm_bind_idmap"
+
+	// bindIdMapEnabledEnv gates the sweep at WORK time, not at registration.
+	// Gating registration would leave already-enqueued jobs to run anyway, so
+	// the flag would not describe the running system.
+	bindIdMapEnabledEnv = "BGM_BIND_IDMAP_SWEEP_ENABLED"
+
+	// bindIdMapInterval is how often the sweep fires.  The work is one SQL
+	// statement plus an insert; the cost that matters is downstream, where
+	// each bound row becomes a V2 job against Bangumi's 800ms bucket.
+	bindIdMapInterval = 6 * time.Hour
+
+	// bindIdMapBatch caps one pass.  At 800ms per Bangumi call a full batch
+	// is ~3 minutes of V2 work, which shares the bucket with user-facing
+	// traffic, so the batch is sized to be absorbed rather than noticed.
+	bindIdMapBatch = 200
+
+	// bindIdMapTimeout bounds the transaction.  Generous for two statements;
+	// it exists so a stuck pass cannot hold the queue's single slot open.
+	bindIdMapTimeout = 2 * time.Minute
+)
+
+// BindIdMapArgs is the river job payload.  The sweep takes no parameters:
+// the candidate set is entirely a function of the two tables.
+type BindIdMapArgs struct{}
+
+// Kind implements river.JobArgs.
+func (BindIdMapArgs) Kind() string { return "bgm_bind_idmap" }
+
+// InsertOpts pins the job to the sweep's own queue.
+func (BindIdMapArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{Queue: BindIdMapQueueName}
+}
+
+// bindIdMapV2Enqueuer is the single method the sweep needs from the enqueuer,
+// declared at the use site so a test can supply a stub without standing up a
+// river client.  *LateBoundEnqueuer (production) and *RealEnqueuer satisfy it.
+//
+// It is deliberately NOT part of the shared Enqueuer interface: no other
+// caller wants a transactional enqueue, and widening that interface would
+// force a method onto every existing implementation and test double for the
+// benefit of one worker.
+type bindIdMapV2Enqueuer interface {
+	EnqueueV2ManyTx(ctx context.Context, tx pgx.Tx, jobs []BangumiV2Args) error
+}
+
+// BindIdMapWorker binds map answers onto unbound rows and dispatches their
+// enrichment.
+type BindIdMapWorker struct {
+	river.WorkerDefaults[BindIdMapArgs]
+	pool *pgxpool.Pool
+	q    *dbgen.Queries
+	enq  bindIdMapV2Enqueuer
+}
+
+// NewBindIdMapWorker constructs the sweep worker.
+func NewBindIdMapWorker(pool *pgxpool.Pool, q *dbgen.Queries, enq bindIdMapV2Enqueuer) *BindIdMapWorker {
+	return &BindIdMapWorker{pool: pool, q: q, enq: enq}
+}
+
+// Work runs one pass.
+//
+// Returning an error hands the job to river's retry policy, whose default is
+// 25 attempts with attempt⁴ backoff — roughly 20 days for the last one.  That
+// is the wrong shape for a periodic sweep, which gets a fresh job every
+// interval anyway, so a failed pass logs and returns nil: the next fire is a
+// better retry than river's.
+func (w *BindIdMapWorker) Work(ctx context.Context, job *river.Job[BindIdMapArgs]) error {
+	if !bindIdMapSweepEnabled() {
+		slog.DebugContext(ctx, "bgm_bind_idmap sweep disabled", "env", bindIdMapEnabledEnv)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, bindIdMapTimeout)
+	defer cancel()
+
+	bound, err := w.bindBatch(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "bgm_bind_idmap sweep failed", "err", err)
+		return nil
+	}
+	if len(bound) == 0 {
+		slog.DebugContext(ctx, "bgm_bind_idmap sweep: nothing bindable")
+		return nil
+	}
+	slog.InfoContext(ctx, "bgm_bind_idmap sweep done",
+		"bound", len(bound), "batch", bindIdMapBatch)
+	return nil
+}
+
+// bindBatch is the transactional unit: bind up to one batch, and enqueue the
+// V2 follow-up for exactly the rows that were bound.  A failure at either step
+// rolls back both, leaving every row a candidate for the next pass.
+func (w *BindIdMapWorker) bindBatch(ctx context.Context) ([]dbgen.BindBgmIdsFromIdMapRow, error) {
+	tx, err := w.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	bound, err := w.q.WithTx(tx).BindBgmIdsFromIdMap(ctx, bindIdMapBatch)
+	if err != nil {
+		return nil, fmt.Errorf("bind: %w", err)
+	}
+	if len(bound) == 0 {
+		return nil, nil
+	}
+
+	jobs := make([]BangumiV2Args, len(bound))
+	for i, b := range bound {
+		jobs[i] = BangumiV2Args{AnilistID: int(b.AnilistID), BgmID: int(b.BgmID)}
+	}
+	if err := w.enq.EnqueueV2ManyTx(ctx, tx, jobs); err != nil {
+		return nil, fmt.Errorf("enqueue v2 (n=%d): %w", len(jobs), err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit: %w", err)
+	}
+	return bound, nil
+}
+
+// bindIdMapSweepEnabled reads the kill switch.  Anything unparseable is OFF:
+// a typo in a variable that gates writes against production should fail closed.
+func bindIdMapSweepEnabled() bool {
+	v := os.Getenv(bindIdMapEnabledEnv)
+	if v == "" {
+		return false
+	}
+	on, err := strconv.ParseBool(v)
+	return err == nil && on
+}
+
+// PeriodicBindIdMapJob returns the river PeriodicJob for the sweep.
+//
+// RunOnStart is true because river's open-source pilot does not persist
+// periodic schedules — nextRunAt is recomputed at every Start — so a service
+// that deploys more often than the interval would otherwise never sweep.
+// Firing on boot is safe here for the same reason the sweep needs no attempt
+// bookkeeping: a pass that has nothing left to bind is one query returning
+// zero rows.
+func PeriodicBindIdMapJob() *river.PeriodicJob {
+	return river.NewPeriodicJob(
+		river.PeriodicInterval(bindIdMapInterval),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return BindIdMapArgs{}, nil
+		},
+		&river.PeriodicJobOpts{RunOnStart: true},
+	)
+}
+
+// AddBindIdMapWorker registers the sweep on an existing bundle.
+func AddBindIdMapWorker(w *river.Workers, pool *pgxpool.Pool, q *dbgen.Queries, enq bindIdMapV2Enqueuer) {
+	river.AddWorker(w, NewBindIdMapWorker(pool, q, enq))
+}
+
+// Compile-time guards: the worker must satisfy river.Worker for its args, and
+// the production enqueuers must satisfy the narrow use-site interface.
+var (
+	_ river.Worker[BindIdMapArgs] = (*BindIdMapWorker)(nil)
+	_ bindIdMapV2Enqueuer         = (*LateBoundEnqueuer)(nil)
+	_ bindIdMapV2Enqueuer         = (*RealEnqueuer)(nil)
+)

--- a/go-api/internal/queue/bgm_bind_idmap.go
+++ b/go-api/internal/queue/bgm_bind_idmap.go
@@ -64,16 +64,19 @@ import (
 )
 
 const (
-	// BindIdMapQueueName is the sweep's own river queue.  A dedicated queue
-	// is what lets river's runtime pause apply to this alone — the same
-	// mechanism the admin surface uses to freeze heal-CN — and a pause needs
-	// no deploy, unlike the env flag below.
+	// BgmBindQueueName is the river queue for every worker that writes
+	// anime_cache.bgm_id.  A dedicated queue lets river's runtime pause apply
+	// to binding alone — the same mechanism the admin surface uses to freeze
+	// heal-CN — and a pause needs no deploy, unlike the env flag below.
 	//
-	// It also carries a correctness role: BindBgmIdsFromIdMap's "no bound row
-	// holds this subject" check and its UPDATE are one statement, but two
-	// concurrent statements could still each pass it for the same subject.
-	// Registering this queue at MaxWorkers 1 makes that unreachable.
-	BindIdMapQueueName = "bgm_bind_idmap"
+	// It also carries a correctness role, which is why it is named for the
+	// operation rather than for this one sweep.  BindBgmIdsFromIdMap's "no
+	// bound row holds this subject" check and its UPDATE are one statement,
+	// but two concurrent statements could each pass it for the same subject,
+	// and anime_cache.bgm_id has no unique index to catch the result.  One
+	// queue at MaxWorkers 1 is what serialises every binding writer against
+	// every other, so any future one belongs on this queue too.
+	BgmBindQueueName = "bgm_bind"
 
 	// bindIdMapEnabledEnv gates the sweep at WORK time, not at registration.
 	// Gating registration would leave already-enqueued jobs to run anyway, so
@@ -104,7 +107,7 @@ func (BindIdMapArgs) Kind() string { return "bgm_bind_idmap" }
 
 // InsertOpts pins the job to the sweep's own queue.
 func (BindIdMapArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{Queue: BindIdMapQueueName}
+	return river.InsertOpts{Queue: BgmBindQueueName}
 }
 
 // bindIdMapV2Enqueuer is the single method the sweep needs from the enqueuer,

--- a/go-api/internal/queue/enqueue.go
+++ b/go-api/internal/queue/enqueue.go
@@ -149,6 +149,34 @@ func (e *RealEnqueuer) EnqueueV2Many(ctx context.Context, jobs []BangumiV2Args) 
 	return nil
 }
 
+// EnqueueV2ManyTx is EnqueueV2Many inside a caller-supplied transaction.
+//
+// It exists for one caller: the id-map bind sweep, which writes a binding and
+// dispatches that binding's enrichment as a single unit.  Doing those in two
+// transactions has a failure mode with no recovery path -- the bind commits,
+// the insert fails, and the row now has a bgm_id, so the sweep's own candidate
+// query (bgm_id IS NULL) never returns it again.  The enrichment for that row
+// is then lost permanently and silently.  Sharing the transaction makes the
+// two outcomes the only two possible: bound and queued, or neither.
+//
+// Every other enqueue path is deliberately NOT transactional.  The V1→V2 and
+// V2→V3 chains enqueue AFTER their own write has committed, where a failed
+// insert costs a re-run rather than a lost row, so they take the simpler
+// non-transactional call and swallow the error.
+func (e *RealEnqueuer) EnqueueV2ManyTx(ctx context.Context, tx pgx.Tx, jobs []BangumiV2Args) error {
+	if len(jobs) == 0 {
+		return nil
+	}
+	params := make([]river.InsertManyParams, len(jobs))
+	for i, j := range jobs {
+		params[i] = river.InsertManyParams{Args: j}
+	}
+	if _, err := e.client.InsertManyTx(ctx, tx, params); err != nil {
+		return fmt.Errorf("queue.EnqueueV2ManyTx (n=%d): %w", len(jobs), err)
+	}
+	return nil
+}
+
 // EnqueueV3Many inserts V3 heal-CN jobs for each {anilistId, bgmId}
 // pair.  Empty slice → noop.  Uses river.Client.InsertMany so the
 // round-trip is one statement per batch.  Errors are wrapped with
@@ -390,6 +418,24 @@ func (l *LateBoundEnqueuer) EnqueueV1Many(ctx context.Context, anilistIDs []int3
 		return nil
 	}
 	return e.EnqueueV1Many(ctx, anilistIDs)
+}
+
+// EnqueueV2ManyTx delegates to the bound RealEnqueuer inside the caller's
+// transaction, or no-ops when unbound.
+//
+// Unbound is unreachable for its one caller.  The sweep that uses this runs as
+// a river job, and river only dispatches jobs after Start, which main.go calls
+// after Bind -- the same ordering the V1 worker's V2 chain already depends on.
+// The nil branch is here because the type promises it, not because a bind
+// sweep can observe it.
+func (l *LateBoundEnqueuer) EnqueueV2ManyTx(ctx context.Context, tx pgx.Tx, jobs []BangumiV2Args) error {
+	l.mu.RLock()
+	e := l.inner
+	l.mu.RUnlock()
+	if e == nil {
+		return nil
+	}
+	return e.EnqueueV2ManyTx(ctx, tx, jobs)
 }
 
 // EnqueueV2Many delegates to the bound RealEnqueuer, or no-ops when unbound.

--- a/go-api/test/integration/id_map_bind_test.go
+++ b/go-api/test/integration/id_map_bind_test.go
@@ -1,0 +1,588 @@
+//go:build integration
+
+// id_map_bind_test.go — ListIdMapBindCandidates and BindBgmIdsFromIdMap
+// against a real Postgres, on a fixture shaped like the three cases they
+// exist to tell apart.
+//
+// Both queries are pure SQL: the Go around them chooses nothing, so this is
+// the only place their guards can be shown to still hold.  And a guard that
+// quietly stopped holding does not surface as an error.  It surfaces as
+// another show's Chinese title and synopsis on a public anime page, for as
+// long as nobody happens to look.
+//
+// Three properties need a real database rather than a unit test, because
+// each of them is a property of the executor rather than of our code:
+//
+//  1. `claims = 1` defends against a rule of statement execution — a
+//     data-modifying statement cannot see its own writes.  Two unbound rows
+//     mapping to the same subject would BOTH pass the NOT EXISTS check
+//     inside one statement and both be bound.  Nothing about the SQL text
+//     looks wrong when this happens; only running it shows it.
+//
+//  2. Nothing downstream would catch that double binding.  anime_cache.bgm_id
+//     carries no unique index (it cannot yet — the catalogue already holds
+//     subjects bound to more than one row), so the guard is not a
+//     belt-and-braces on top of a constraint.  It is the constraint.
+//
+//  3. The LIMIT sits inside the `eligible` CTE, i.e. AFTER both guards, and
+//     that placement is load-bearing rather than cosmetic.  Refusals are
+//     permanent: a twice-claimed subject stays twice-claimed until a human
+//     adjudicates it.  So if the LIMIT ever moved above the guards, every
+//     batch would re-draw the same refused prefix of the catalogue (the
+//     ORDER BY is stable), bind fewer rows than it was asked for — possibly
+//     none — and the sweep would keep running without making progress.
+//
+// A fourth property is not about the executor but about a queue outside the
+// database: this statement is the exit from the admin review queue for every
+// row V1 parked as 'needs-review' before the map had an answer.  Clearing the
+// wrong flag there is unrecoverable by hand at catalogue scale in one
+// direction, and in the other it leaves settled rows queued for a review that
+// will never have anything left to decide.
+//
+// Hermeticity.  BindBgmIdsFromIdMap is catalogue-wide: it takes no id, and a
+// generous LIMIT would happily bind whatever else the database holds, which
+// would make the batch-size assertions below meaningless.  Two things scope
+// it to this fixture:
+//
+//   - The whole test runs inside one transaction that is rolled back in
+//     t.Cleanup, so nothing it writes — including the neutralisation below —
+//     outlives it.
+//   - Inside that transaction bgm_id_map is emptied before the fixture is
+//     seeded.  The JOIN to that table is the only funnel into either query,
+//     so a catalogue-wide statement then operates on exactly these eight
+//     rows and the assertions can name the full result set.
+//
+// The one path that still reaches outside the fixture is the NOT EXISTS
+// sub-select, which scans all of anime_cache for a row already holding the
+// subject.  A precondition check asserts the fixture's bgm_id range is unheld
+// before seeding, so a collision fails with a sentence rather than as an
+// inexplicable refusal.
+//
+// Run with:
+//
+//	go test -race -tags=integration -timeout=300s ./test/integration/...
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+	"github.com/lawrenceli0228/animego/go-api/internal/testutil"
+)
+
+// Fixture ids, in both id spaces, held far above anything either the
+// catalogue or the vendored map contains.  The AniList ids are ordered so
+// that every REFUSED row sorts BEFORE every bindable one: that ordering is
+// what makes the batch-size subtest able to tell "the LIMIT counts bound
+// rows" apart from "the LIMIT counts candidates", since the two answers
+// differ only when refusals come first.
+const (
+	idmapClaimantA = int32(9910011) // maps to the same subject as B
+	idmapClaimantB = int32(9910012) // maps to the same subject as A
+	idmapLoser     = int32(9910021) // wants a subject the holder already has
+	idmapHolder    = int32(9910022) // bound already; the incumbent
+	idmapUnmapped  = int32(9910031) // no bgm_id_map row at all
+	idmapFreeLow   = int32(9910041)
+	idmapFreeMid   = int32(9910042)
+	idmapFreeHigh  = int32(9910043)
+	idmapReviewed  = int32(9910051) // parked by V1 as 'needs-review'
+	idmapCorrected = int32(9910052) // carries a human's 'manually-corrected'
+
+	idmapSubjectShared    = int32(9920011) // claimed by A and B
+	idmapSubjectHeld      = int32(9920021) // held by idmapHolder
+	idmapSubjectHolder    = int32(9920099) // what the map says about the holder
+	idmapSubjectLow       = int32(9920041)
+	idmapSubjectMid       = int32(9920042)
+	idmapSubjectHigh      = int32(9920043)
+	idmapSubjectReviewed  = int32(9920051)
+	idmapSubjectCorrected = int32(9920052)
+)
+
+// idmapSeededAt is a timestamp no writer would ever produce, so it doubles as
+// a touch detector: `updated_at = now()` in the UPDATE moves a row off it, and
+// a row still wearing it was not written to.  A sentinel rather than a
+// before/after clock reading because now() inside a transaction is the
+// transaction's own start time — it would be identical to the seed's.
+var idmapSeededAt = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func TestIdMapBind(t *testing.T) {
+	ctx := context.Background()
+	pool := newPGPool(t, ctx)
+
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err, "begin fixture transaction")
+	// The rollback IS the cleanup: every row seeded below and every row the
+	// bind writes disappears with it, as does the emptied bgm_id_map.
+	t.Cleanup(func() { _ = tx.Rollback(context.Background()) })
+
+	_, err = tx.Exec(ctx, `DELETE FROM bgm_id_map`)
+	require.NoError(t, err, "neutralise the vendored map for the duration of the transaction")
+
+	var held int
+	require.NoError(t, tx.QueryRow(ctx, `
+		SELECT count(*) FROM anime_cache WHERE bgm_id BETWEEN 9920000 AND 9929999`).Scan(&held))
+	require.Zero(t, held,
+		"a pre-existing row holding a fixture subject would turn every bindable row into a refusal, which reads as a query bug rather than as a dirty database")
+
+	bgm := func(id int32) *int32 { return &id }
+	src := func(s string) *string { return &s }
+
+	// admin_flag is constrained to 'needs-review' / 'manually-corrected' /
+	// NULL by anime_cache_admin_flag_chk, so those are the only three states
+	// this fixture can express — and all three appear below.
+	seed := func(anilistID int32, romaji, native string, year int32, bgmID *int32, matchSource, adminFlag *string) {
+		t.Helper()
+		_, err := tx.Exec(ctx, `
+			INSERT INTO anime_cache
+			    (anilist_id, title_romaji, title_native, season_year,
+			     bgm_id, bgm_match_source, admin_flag, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+			anilistID, romaji, native, year, bgmID, matchSource, adminFlag, idmapSeededAt)
+		require.NoError(t, err, "seed anime_cache %d", anilistID)
+	}
+
+	mapEntry := func(anilistID, bgmID int32) {
+		t.Helper()
+		_, err := tx.Exec(ctx, `
+			INSERT INTO bgm_id_map (anilist_id, bgm_id, source)
+			VALUES ($1, $2, 'mal')`, anilistID, bgmID)
+		require.NoError(t, err, "seed bgm_id_map %d -> %d", anilistID, bgmID)
+	}
+
+	// Two unbound rows the map sends to one subject.  This is the shape that
+	// actually occurs — a show and its own prequel special can share a
+	// Bangumi subject — and the reason neither may be bound is that nothing
+	// in the data says which of the two the subject belongs to.
+	seed(idmapClaimantA, "Idmap Claimant A", "アイドマップ・クレイマントA", 2021, nil, nil, nil)
+	seed(idmapClaimantB, "Idmap Claimant B", "アイドマップ・クレイマントB", 2021, nil, nil, nil)
+	mapEntry(idmapClaimantA, idmapSubjectShared)
+	mapEntry(idmapClaimantB, idmapSubjectShared)
+
+	// An unbound row whose map answer is already worn by somebody else.  The
+	// holder is bound and therefore not a candidate at all; its own map entry
+	// deliberately names a DIFFERENT subject, so the fixture also says what
+	// happens to a bound row the map disagrees with: nothing.
+	seed(idmapLoser, "Idmap Loser", "アイドマップ・ルーザー", 2022, nil, nil, nil)
+	seed(idmapHolder, "Idmap Holder", "アイドマップ・ホルダー", 2022, bgm(idmapSubjectHeld), src("manual"), nil)
+	mapEntry(idmapLoser, idmapSubjectHeld)
+	mapEntry(idmapHolder, idmapSubjectHolder)
+
+	// A row the map has never heard of.  It is the majority shape in the
+	// catalogue, and the query must reach it neither as a candidate nor as a
+	// write.
+	seed(idmapUnmapped, "Idmap Unmapped", "アイドマップ・アンマップド", 2023, nil, nil, nil)
+
+	// Three rows nobody contests.  Three rather than one so a LIMIT smaller
+	// than the bindable set can be shown to cap the batch.
+	seed(idmapFreeLow, "Idmap Free Low", "アイドマップ・フリー1", 2024, nil, nil, nil)
+	seed(idmapFreeMid, "Idmap Free Mid", "アイドマップ・フリー2", 2024, nil, nil, nil)
+	seed(idmapFreeHigh, "Idmap Free High", "アイドマップ・フリー3", 2024, nil, nil, nil)
+	mapEntry(idmapFreeLow, idmapSubjectLow)
+	mapEntry(idmapFreeMid, idmapSubjectMid)
+	mapEntry(idmapFreeHigh, idmapSubjectHigh)
+
+	// Two bindable rows carrying the two admin_flag states, seeded with ids
+	// above the plain bindable three so they fall outside the first batch and
+	// the batch-size subtest keeps its exact expectations.
+	//
+	// The 'needs-review' one wears V1's park shape exactly — no bgm_id, a
+	// 'fuzzy_low' label, the flag — because that is the row this clause was
+	// written for: V1 could not decide, so it asked a human, and the map
+	// arriving afterwards answers the question the human was queued to
+	// answer.
+	seed(idmapReviewed, "Idmap Reviewed", "アイドマップ・レビュード", 2025, nil, src("fuzzy_low"), src("needs-review"))
+	seed(idmapCorrected, "Idmap Corrected", "アイドマップ・コレクテッド", 2025, nil, nil, src("manually-corrected"))
+	mapEntry(idmapReviewed, idmapSubjectReviewed)
+	mapEntry(idmapCorrected, idmapSubjectCorrected)
+
+	q := dbgen.New(tx)
+
+	// updatedMicro rather than a time.Time so snapshots compare by value:
+	// reflect.DeepEqual on time.Time compares the representation (wall clock,
+	// monotonic reading, location pointer) rather than the instant.  The
+	// column's own resolution is microseconds, so nothing is lost.
+	type animeRow struct {
+		bgmID        *int32
+		matchSource  *string
+		adminFlag    *string
+		updatedMicro int64
+	}
+	read := func(t *testing.T, anilistID int32) animeRow {
+		t.Helper()
+		var r animeRow
+		var updated time.Time
+		require.NoError(t, tx.QueryRow(ctx, `
+			SELECT bgm_id, bgm_match_source, admin_flag, updated_at
+			FROM anime_cache WHERE anilist_id = $1`, anilistID).
+			Scan(&r.bgmID, &r.matchSource, &r.adminFlag, &updated), "read anime_cache %d", anilistID)
+		r.updatedMicro = updated.UnixMicro()
+		return r
+	}
+	untouched := func(t *testing.T, anilistID int32, why string) {
+		t.Helper()
+		got := read(t, anilistID)
+		assert.Equal(t, idmapSeededAt.UnixMicro(), got.updatedMicro, why)
+	}
+
+	fixture := []int32{
+		idmapClaimantA, idmapClaimantB, idmapLoser, idmapHolder,
+		idmapUnmapped, idmapFreeLow, idmapFreeMid, idmapFreeHigh,
+		idmapReviewed, idmapCorrected,
+	}
+	snapshot := func(t *testing.T) []animeRow {
+		t.Helper()
+		rows := make([]animeRow, 0, len(fixture))
+		for _, id := range fixture {
+			rows = append(rows, read(t, id))
+		}
+		return rows
+	}
+
+	// The subtests run in order against one shared fixture: the first reads
+	// the verdicts before anything is written, the rest walk the same rows
+	// through two batches and a third no-op call.
+	t.Run("the preview classifies all three cases", func(t *testing.T) {
+		got, err := q.ListIdMapBindCandidates(ctx)
+		require.NoError(t, err, "ListIdMapBindCandidates")
+
+		// Asserting the WHOLE result set rather than a filtered view is
+		// deliberate: the query takes no id, so this doubles as the proof
+		// that the emptied bgm_id_map really did scope it to the fixture.
+		// A stray row here means the hermeticity argument above has a hole.
+		type candidate struct {
+			anilistID int32
+			bgmID     int32
+			verdict   string
+		}
+		flat := make([]candidate, 0, len(got))
+		for _, r := range got {
+			flat = append(flat, candidate{r.AnilistID, r.BgmID, r.Verdict})
+		}
+		assert.Equal(t, []candidate{
+			// Ordered by anilist_id, which is the query's own ORDER BY.
+			{idmapClaimantA, idmapSubjectShared, "subject-claimed-twice"},
+			{idmapClaimantB, idmapSubjectShared, "subject-claimed-twice"},
+			{idmapLoser, idmapSubjectHeld, "subject-already-bound"},
+			{idmapFreeLow, idmapSubjectLow, "bindable"},
+			{idmapFreeMid, idmapSubjectMid, "bindable"},
+			{idmapFreeHigh, idmapSubjectHigh, "bindable"},
+			{idmapReviewed, idmapSubjectReviewed, "bindable"},
+			{idmapCorrected, idmapSubjectCorrected, "bindable"},
+		}, flat,
+			"the bound holder and the unmapped row are not candidates at all; the other eight each carry the verdict the bind will act on")
+
+		// The refusals are the rows a human has to adjudicate, and the only
+		// material they get for it is what this query returns.  A refusal
+		// that arrived without its titles or its year would be unreadable —
+		// two AniList ids and a subject number say nothing about which show
+		// the subject belongs to.
+		for _, r := range got {
+			if r.AnilistID != idmapClaimantA {
+				continue
+			}
+			require.NotNil(t, r.TitleRomaji)
+			require.NotNil(t, r.TitleNative)
+			require.NotNil(t, r.SeasonYear)
+			assert.Equal(t, "Idmap Claimant A", *r.TitleRomaji)
+			assert.Equal(t, "アイドマップ・クレイマントA", *r.TitleNative)
+			assert.Equal(t, int32(2021), *r.SeasonYear,
+				"the year is how a reviewer separates a show from its own prequel special")
+		}
+	})
+
+	t.Run("refusals do not consume the batch's limit", func(t *testing.T) {
+		bound, err := q.BindBgmIdsFromIdMap(ctx, 2)
+		require.NoError(t, err, "BindBgmIdsFromIdMap")
+
+		// Three refusals sort ahead of every bindable row, so a LIMIT applied
+		// before the guards would have returned nothing here, and one applied
+		// to candidates-then-filtered would have returned fewer than two.
+		// ElementsMatch rather than Equal: RETURNING has no ORDER BY, so the
+		// row order is the executor's business and asserting it would buy a
+		// flake instead of a property.
+		assert.ElementsMatch(t, []dbgen.BindBgmIdsFromIdMapRow{
+			{AnilistID: idmapFreeLow, BgmID: idmapSubjectLow},
+			{AnilistID: idmapFreeMid, BgmID: idmapSubjectMid},
+		}, bound,
+			"a batch of 2 must be 2 BOUND rows; refusals are permanent, so a limit that counted them would re-draw the same refused prefix forever and the sweep would never finish")
+
+		// ...and the limit is still a cap.  Without this the subtest above
+		// would also pass an implementation that ignored `lim` entirely.
+		assert.Nil(t, read(t, idmapFreeHigh).bgmID,
+			"the third bindable row is beyond a batch of 2 and must wait for the next one")
+	})
+
+	t.Run("a bound row records how it was bound", func(t *testing.T) {
+		for _, c := range []struct {
+			anilistID int32
+			subject   int32
+		}{
+			{idmapFreeLow, idmapSubjectLow},
+			{idmapFreeMid, idmapSubjectMid},
+		} {
+			got := read(t, c.anilistID)
+			require.NotNil(t, got.bgmID, "row %d must be bound", c.anilistID)
+			assert.Equal(t, c.subject, *got.bgmID, "the map's answer, unaltered")
+			require.NotNil(t, got.matchSource, "row %d must be labelled", c.anilistID)
+			assert.Equal(t, "id_map", *got.matchSource,
+				"the label is what lets a later audit find every binding this sweep made and undo exactly those")
+			assert.Greater(t, got.updatedMicro, idmapSeededAt.UnixMicro(),
+				"the row was written, so it must not still wear the seed timestamp")
+		}
+	})
+
+	t.Run("a generous limit does not soften the refusals", func(t *testing.T) {
+		bound, err := q.BindBgmIdsFromIdMap(ctx, 10)
+		require.NoError(t, err, "BindBgmIdsFromIdMap")
+
+		// A limit larger than the whole candidate set: what is left is the row
+		// the previous batch could not fit, plus the two flagged ones.  If
+		// either guard were a function of batch size rather than of the data,
+		// the three refused rows would come through here too.
+		assert.ElementsMatch(t, []dbgen.BindBgmIdsFromIdMapRow{
+			{AnilistID: idmapFreeHigh, BgmID: idmapSubjectHigh},
+			{AnilistID: idmapReviewed, BgmID: idmapSubjectReviewed},
+			{AnilistID: idmapCorrected, BgmID: idmapSubjectCorrected},
+		}, bound,
+			"the refusals are a property of the catalogue, not of how many rows were asked for")
+	})
+
+	t.Run("binding a reviewed row closes its review", func(t *testing.T) {
+		got := read(t, idmapReviewed)
+		require.NotNil(t, got.bgmID, "the flag is not a refusal — the row binds like any other")
+		assert.Equal(t, idmapSubjectReviewed, *got.bgmID)
+		assert.Nil(t, got.adminFlag,
+			"'needs-review' is a question, and the map answering it IS the answer; leaving the flag parks a settled row in the admin queue for good")
+		require.NotNil(t, got.matchSource)
+		assert.Equal(t, "id_map", *got.matchSource,
+			"the label must describe the binding the row now carries, not the fuzzy guess that was abandoned")
+	})
+
+	t.Run("a human's correction is not cleared", func(t *testing.T) {
+		got := read(t, idmapCorrected)
+		require.NotNil(t, got.bgmID, "this row binds too; only the flag's treatment differs")
+		assert.Equal(t, idmapSubjectCorrected, *got.bgmID)
+		require.NotNil(t, got.adminFlag,
+			"the CASE has exactly one branch that clears, and this value is not it")
+		assert.Equal(t, "manually-corrected", *got.adminFlag,
+			"that flag records a decision somebody already made rather than a pending request for one; clearing it would silently drop the audit trail for every hand-fixed row the map later touches")
+	})
+
+	t.Run("neither claimant of a twice-claimed subject is bound", func(t *testing.T) {
+		// The one the guards exist for.  A statement cannot see its own
+		// writes, so without `claims = 1` both of these would pass NOT EXISTS
+		// in the same pass and both end up holding 9920011 — and with no
+		// unique index on bgm_id, nothing beneath would object.  The symptom
+		// would surface much later and somewhere else: GetAnimeByBgmID is a
+		// :one query, so every subsequent Bangumi write for that subject
+		// would land on an arbitrary one of the two.
+		assert.Nil(t, read(t, idmapClaimantA).bgmID, "A is one of two claimants and nothing says it is the right one")
+		assert.Nil(t, read(t, idmapClaimantB).bgmID, "B is the other; refusing only one of them would be a coin toss, not a decision")
+		untouched(t, idmapClaimantA, "a refused row must not be written to at all")
+		untouched(t, idmapClaimantB, "a refused row must not be written to at all")
+	})
+
+	t.Run("a subject stays with the row that already holds it", func(t *testing.T) {
+		assert.Nil(t, read(t, idmapLoser).bgmID,
+			"the map's answer is already worn by another row, and the incumbent binding is the older evidence")
+		untouched(t, idmapLoser, "a refused row must not be written to at all")
+
+		holder := read(t, idmapHolder)
+		require.NotNil(t, holder.bgmID)
+		assert.Equal(t, idmapSubjectHeld, *holder.bgmID,
+			"the map says this row belongs to a different subject; a bound row is never re-bound, so the disagreement is left alone")
+		require.NotNil(t, holder.matchSource)
+		assert.Equal(t, "manual", *holder.matchSource,
+			"overwriting an existing label with 'id_map' would erase the provenance of a decision a human made")
+		untouched(t, idmapHolder, "`bgm_id IS NULL` excludes bound rows from the candidate set entirely")
+	})
+
+	t.Run("a row the map has never heard of is never touched", func(t *testing.T) {
+		got := read(t, idmapUnmapped)
+		assert.Nil(t, got.bgmID, "there is no answer to write")
+		assert.Nil(t, got.matchSource, "and therefore nothing to label")
+		untouched(t, idmapUnmapped, "the inner JOIN is what keeps the sweep off the rest of the catalogue")
+	})
+
+	t.Run("running the bind again binds nothing", func(t *testing.T) {
+		before := snapshot(t)
+		bound, err := q.BindBgmIdsFromIdMap(ctx, 10)
+		require.NoError(t, err, "BindBgmIdsFromIdMap")
+		assert.Empty(t, bound,
+			"every bindable row now has a bgm_id, and `bgm_id IS NULL` is the whole candidate set — a sweep that re-ran on a schedule must cost nothing")
+		assert.Equal(t, before, snapshot(t),
+			"no timestamps moved either: an idempotent statement that still rewrote updated_at would churn the rows it claims not to touch")
+	})
+
+	t.Run("no subject ends up held twice", func(t *testing.T) {
+		// The invariant all of the above serves, asserted directly rather
+		// than inferred from the per-row assertions — this is the shape that
+		// no index and no downstream query would reject.
+		var dupes int
+		require.NoError(t, tx.QueryRow(ctx, `
+			SELECT count(*) FROM (
+			    SELECT bgm_id FROM anime_cache
+			    WHERE bgm_id BETWEEN 9920000 AND 9929999
+			    GROUP BY bgm_id HAVING count(*) > 1
+			) d`).Scan(&dupes))
+		assert.Zero(t, dupes, "one bgm.tv subject, at most one anime_cache row")
+
+		var claimed int
+		require.NoError(t, tx.QueryRow(ctx, `
+			SELECT count(*) FROM anime_cache WHERE bgm_id = $1`, idmapSubjectShared).Scan(&claimed))
+		assert.Zero(t, claimed,
+			"the contested subject belongs to nobody until a human says whose it is")
+	})
+}
+
+// TestIdMapBindConcurrentClaim pins the one guard the single-statement tests
+// above structurally cannot reach: the `AND a.bgm_id IS NULL` re-check on the
+// UPDATE itself.
+//
+// Inside one statement that clause is dead weight.  The `eligible` CTE already
+// selected on `bgm_id IS NULL`, and a statement evaluates its CTEs and its
+// UPDATE against one snapshot, so the re-check can only ever agree with the
+// CTE.  Deleting it leaves every subtest in TestIdMapBind green — verified by
+// mutation, which is the reason this test exists rather than a note saying the
+// clause looks important.
+//
+// It stops being dead weight the moment another writer touches the same row.
+// Postgres does not simply skip a row a concurrent transaction has locked: the
+// UPDATE blocks, and when that transaction commits the executor re-evaluates
+// the WHERE clause against the row's NEW version (EvalPlanQual).  That
+// re-evaluation is the only thing standing between this sweep and silently
+// overwriting a binding somebody else just wrote — a manual admin correction,
+// say — with the map's answer.
+//
+// The sweep's own queue runs at MaxWorkers 1, so two copies of THIS statement
+// cannot race.  That is not the same as the row being safe: anime_cache.bgm_id
+// is written by the V1 worker, the admin surface, and the heal CLI, none of
+// which coordinate with the sweep.
+//
+// Why the wait-for-lock step is not optional: without it the bind can finish
+// before the rival's UPDATE takes its lock, and then the assertions hold for
+// the wrong reason — the row was never contended and the CAS was never
+// consulted.  The test would pass with the clause deleted.
+func TestIdMapBindConcurrentClaim(t *testing.T) {
+	ctx := context.Background()
+	pool := newPGPool(t, ctx)
+
+	// A committed fixture, not a rolled-back one: two transactions have to see
+	// it, which is exactly what the isolation trick in TestIdMapBind rules out.
+	// TruncateAll gives the clean slate that keeps a catalogue-wide statement
+	// scoped to this one row.
+	testutil.TruncateAll(t, ctx, pool)
+
+	const (
+		casAnilist      = int32(9930001)
+		casMapSubject   = int32(9930099) // what the map would bind
+		casRivalSubject = int32(9930088) // what the other writer binds first
+	)
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO anime_cache (anilist_id, title_romaji, bgm_id, updated_at)
+		VALUES ($1, 'Idmap CAS Fixture', NULL, $2)`, casAnilist, idmapSeededAt)
+	require.NoError(t, err, "seed anime_cache")
+	_, err = pool.Exec(ctx, `
+		INSERT INTO bgm_id_map (anilist_id, bgm_id, source) VALUES ($1, $2, 'mal')`,
+		casAnilist, casMapSubject)
+	require.NoError(t, err, "seed bgm_id_map")
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM bgm_id_map WHERE anilist_id = $1`, casAnilist)
+		_, _ = pool.Exec(bg, `DELETE FROM anime_cache WHERE anilist_id = $1`, casAnilist)
+	})
+
+	// The rival writer: binds a different subject and holds the row lock.  Any
+	// of V1, the admin surface, or the heal CLI can be on this side in
+	// production; 'manual' is the label that makes losing the race worst.
+	rival, err := pool.Begin(ctx)
+	require.NoError(t, err, "begin rival transaction")
+	defer func() { _ = rival.Rollback(context.Background()) }()
+	_, err = rival.Exec(ctx, `
+		UPDATE anime_cache SET bgm_id = $1, bgm_match_source = 'manual'
+		WHERE anilist_id = $2`, casRivalSubject, casAnilist)
+	require.NoError(t, err, "rival binds the row")
+
+	type outcome struct {
+		rows []dbgen.BindBgmIdsFromIdMapRow
+		err  error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		// A deadline rather than the parent context: if the CAS were removed
+		// AND the rival never committed, this would block forever and the test
+		// would time out with no explanation.
+		bindCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		tx, err := pool.Begin(bindCtx)
+		if err != nil {
+			done <- outcome{err: err}
+			return
+		}
+		defer func() { _ = tx.Rollback(context.Background()) }()
+		rows, err := dbgen.New(pool).WithTx(tx).BindBgmIdsFromIdMap(bindCtx, 200)
+		if err == nil {
+			err = tx.Commit(bindCtx)
+		}
+		done <- outcome{rows: rows, err: err}
+	}()
+
+	requireBlockedOnLock(t, ctx, pool)
+
+	// The rival wins the row.  The bind unblocks into EvalPlanQual.
+	require.NoError(t, rival.Commit(ctx), "rival commit")
+
+	var out outcome
+	select {
+	case out = <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("the bind never returned after the rival committed")
+	}
+	require.NoError(t, out.err, "the bind must lose the row quietly, not error")
+	assert.Empty(t, out.rows,
+		"the row was no longer unbound when the UPDATE reached it, so it must not appear as bound")
+
+	var bgmID *int32
+	var source *string
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT bgm_id, bgm_match_source FROM anime_cache WHERE anilist_id = $1`,
+		casAnilist).Scan(&bgmID, &source))
+	require.NotNil(t, bgmID)
+	assert.Equal(t, casRivalSubject, *bgmID,
+		"the sweep must not overwrite a binding another writer committed first")
+	require.NotNil(t, source)
+	assert.Equal(t, "manual", *source,
+		"losing the row means writing none of its columns, not just none of its bgm_id")
+}
+
+// requireBlockedOnLock waits until some backend is stalled on a row lock while
+// running the bind, and fails if that never happens.
+//
+// Matching on the statement text is what makes this specific: pg_stat_activity
+// carries the query, and sqlc prefixes every statement with its own
+// `-- name: <Query>` comment, so the wait being observed is provably the
+// bind's and not some unrelated backend's.
+func requireBlockedOnLock(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		var n int
+		require.NoError(t, pool.QueryRow(ctx, `
+			SELECT count(*) FROM pg_stat_activity
+			WHERE wait_event_type = 'Lock'
+			  AND query LIKE '%BindBgmIdsFromIdMap%'`).Scan(&n))
+		if n > 0 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("the bind never blocked on the rival's row lock; the race this test " +
+		"is about did not happen, so a pass here would prove nothing")
+}

--- a/go-api/test/integration/id_map_bind_test.go
+++ b/go-api/test/integration/id_map_bind_test.go
@@ -516,22 +516,30 @@ func TestIdMapBindConcurrentClaim(t *testing.T) {
 	}
 	done := make(chan outcome, 1)
 	go func() {
-		// A deadline rather than the parent context: if the CAS were removed
-		// AND the rival never committed, this would block forever and the test
-		// would time out with no explanation.
-		bindCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		tx, err := pool.Begin(bindCtx)
-		if err != nil {
-			done <- outcome{err: err}
-			return
-		}
-		defer func() { _ = tx.Rollback(context.Background()) }()
-		rows, err := dbgen.New(pool).WithTx(tx).BindBgmIdsFromIdMap(bindCtx, 200)
-		if err == nil {
-			err = tx.Commit(bindCtx)
-		}
-		done <- outcome{rows: rows, err: err}
+		var out outcome
+		func() {
+			// A deadline rather than the parent context: if the CAS were
+			// removed AND the rival never committed, this would block forever
+			// and the test would time out with no explanation.
+			bindCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			tx, err := pool.Begin(bindCtx)
+			if err != nil {
+				out.err = err
+				return
+			}
+			defer func() { _ = tx.Rollback(context.Background()) }()
+			out.rows, out.err = dbgen.New(pool).WithTx(tx).BindBgmIdsFromIdMap(bindCtx, 200)
+			if out.err == nil {
+				out.err = tx.Commit(bindCtx)
+			}
+		}()
+		// Signal only after that closure has returned, so the transaction is
+		// closed and its connection is back in the pool.  The test returns on
+		// this signal and the next test in the package opens with TRUNCATE,
+		// which takes ACCESS EXCLUSIVE and would queue behind a transaction
+		// this goroutine had not finished unwinding.
+		done <- out
 	}()
 
 	requireBlockedOnLock(t, ctx, pool)

--- a/go-api/test/integration/id_map_bind_worker_test.go
+++ b/go-api/test/integration/id_map_bind_worker_test.go
@@ -1,0 +1,324 @@
+//go:build integration
+
+// id_map_bind_worker_test.go — the bgm_bind_idmap sweep WORKER
+// (internal/queue/bgm_bind_idmap.go) driven against a real Postgres.
+//
+// The query it calls is one statement and can be reasoned about by reading
+// it.  The worker around it cannot: it decides whether to write at all (an
+// env kill switch), it decides what a failure means (return nil, not an
+// error), and it makes the bind and the V2 dispatch one transaction.  Those
+// three decisions are invisible in SQL and each of them fails silently when
+// it regresses, so they are what this file pins.
+//
+// # What breaks if each property regresses
+//
+//	kill switch      A flag that gates writes against production but is only
+//	                 consulted by a boolean helper nobody wired to the write
+//	                 is worse than no flag: it reads as OFF on the dashboard
+//	                 while the sweep binds the whole catalogue.  So the two
+//	                 disabled cases assert on the ROWS, not on the helper.
+//
+//	rollback         The reason EnqueueV2ManyTx exists at all.  A row that is
+//	                 bound but not queued stops matching `bgm_id IS NULL`, so
+//	                 it leaves this sweep's candidate set forever and no other
+//	                 producer looks at a version-3 row again — its Chinese
+//	                 title and score are then lost permanently and silently.
+//	                 "Work returned without panicking" does not prove this;
+//	                 only reading the rows back afterwards does.
+//
+//	Work returns nil A periodic sweep that returns an error hands the job to
+//	                 river's retry policy — 25 attempts, attempt⁴ backoff,
+//	                 roughly 20 days for the last one — while the next
+//	                 scheduled fire is 6 hours away and is the better retry.
+//
+//	drained set      A second pass over already-bound rows must enqueue
+//	                 nothing.  If it did, every 6-hour fire would re-dispatch
+//	                 the same subjects at Bangumi's 800ms bucket forever.
+//
+// # Hermeticity, and why it needs the whole slate
+//
+// BindBgmIdsFromIdMap takes no anime id: its candidate set is every
+// anime_cache row with `bgm_id IS NULL` that has a bgm_id_map entry, capped
+// at a batch of 200.  Distinctive fixture ids therefore scope the ASSERTIONS
+// but not the WORK — one stray unbound row with a map entry anywhere in the
+// database would be bound by the Work call below and would arrive at the stub
+// enqueuer as an extra pair, turning "exactly these pairs" and "no enqueue
+// call at all" into claims about the neighbours instead of the worker.
+//
+// So this test starts from the package's own clean-slate primitive
+// (testutil.TruncateAll, the same one resetState uses) rather than trusting
+// that the container happens to be empty.  That is safe here for the reason
+// it is safe in the other tests that call it: the container is per-package
+// and the DB-touching tests in it are sequential, each seeding what it needs.
+// With bgm_id_map holding nothing but this file's fixtures, the sweep cannot
+// reach a row this file did not create — which is what makes the negative
+// assertions ("nothing was bound", "the enqueuer was never called") mean
+// something.
+package integration
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+	"github.com/lawrenceli0228/animego/go-api/internal/queue"
+	"github.com/lawrenceli0228/animego/go-api/internal/testutil"
+)
+
+const (
+	// bindWorkerEnv restates the kill switch's name because the constant that
+	// holds it in package queue is unexported.  A rename there fails loudly
+	// here rather than quietly: the enabled subtests would set a variable
+	// nothing reads, the sweep would stay OFF, and their "these rows are now
+	// bound" assertions would fail.
+	bindWorkerEnv = "BGM_BIND_IDMAP_SWEEP_ENABLED"
+
+	// bindWorkerIDFloor is the low end of the fixture id space.  Every row and
+	// map entry this file writes sits above it, so a single predicate
+	// separates "what this test made" from anything else, and the fixtures
+	// cannot collide with a real AniList id.
+	bindWorkerIDFloor = 9900000
+)
+
+// bindWorkerStubEnqueuer stands in for the river enqueuer.
+//
+// It satisfies queue's bindIdMapV2Enqueuer structurally.  That interface is
+// unexported, so its NAME is unreachable from this package — but its single
+// method is exported, and Go's interface satisfaction is structural, so a
+// type declared here can still be handed to the exported constructor.  That
+// is exactly why the worker declares the interface at its use site: a test
+// double costs no river client and no river schema.
+type bindWorkerStubEnqueuer struct {
+	// err is what EnqueueV2ManyTx returns — the injected failure.
+	err error
+
+	// calls counts invocations.  Zero is the assertion for both "the sweep
+	// was disabled" and "there was nothing left to bind"; those two cases are
+	// only distinguishable from the rows.
+	calls int
+
+	// jobs accumulates every job handed over, so the happy path can assert on
+	// the PAIRS rather than on a count.  A count would still pass if the
+	// worker paired every row with the first row's bgm_id.
+	jobs []queue.BangumiV2Args
+
+	// boundInTx is how many fixture rows carried a bgm_id when read back
+	// through the caller's own transaction, and txErr is that read's error.
+	boundInTx int
+	txErr     error
+}
+
+// EnqueueV2ManyTx records the call and reads the fixtures back through the
+// transaction it was handed.
+//
+// That read is the load-bearing part.  Nothing outside the transaction can
+// see the bind yet, so a non-zero boundInTx proves two things at once: the
+// UPDATE really ran, and the tx passed to the enqueuer is the same one that
+// ran it.  Without it the rollback subtest would pass just as happily against
+// fixtures that were never bindable in the first place — the classic shape of
+// a test that is green for a reason it does not name.
+func (s *bindWorkerStubEnqueuer) EnqueueV2ManyTx(ctx context.Context, tx pgx.Tx, jobs []queue.BangumiV2Args) error {
+	s.calls++
+	s.jobs = append(s.jobs, jobs...)
+	s.txErr = tx.QueryRow(ctx, `
+		SELECT count(*) FROM anime_cache
+		WHERE anilist_id >= $1 AND bgm_id IS NOT NULL`,
+		bindWorkerIDFloor).Scan(&s.boundInTx)
+	return s.err
+}
+
+// bindWorkerSeed creates unbound anime_cache rows plus the id-map entries that
+// make them bindable, and registers their removal.
+//
+// bangumi_version is 3 deliberately: that is the state migration 0004 records
+// for everything enriched under the pre-Go pipeline, and it is the whole
+// reason this sweep exists — UpdateBangumiV1 is guarded on version 0, so no
+// other producer will ever look at these rows again.
+//
+// The pairs are expressed as BangumiV2Args because the fixture list is also
+// the expected dispatch: what goes into the database is what must come out of
+// the enqueuer.
+func bindWorkerSeed(t *testing.T, ctx context.Context, pool *pgxpool.Pool, pairs []queue.BangumiV2Args) {
+	t.Helper()
+	t.Cleanup(func() {
+		bg := context.Background()
+		_, _ = pool.Exec(bg, `DELETE FROM bgm_id_map WHERE anilist_id >= $1`, bindWorkerIDFloor)
+		_, _ = pool.Exec(bg, `DELETE FROM anime_cache WHERE anilist_id >= $1`, bindWorkerIDFloor)
+	})
+	for _, p := range pairs {
+		require.GreaterOrEqual(t, p.AnilistID, bindWorkerIDFloor,
+			"fixtures must live above the floor or cleanup and the read-back predicate miss them")
+		_, err := pool.Exec(ctx, `
+			INSERT INTO anime_cache (anilist_id, title_romaji, bgm_id, bangumi_version)
+			VALUES ($1, 'Bind Sweep Fixture', NULL, 3)`, p.AnilistID)
+		require.NoError(t, err, "seed anime_cache %d", p.AnilistID)
+		_, err = pool.Exec(ctx, `
+			INSERT INTO bgm_id_map (anilist_id, bgm_id, source)
+			VALUES ($1, $2, 'test')`, p.AnilistID, p.BgmID)
+		require.NoError(t, err, "seed bgm_id_map %d", p.AnilistID)
+	}
+}
+
+// bindWorkerBoundPairs reads back which fixture rows now carry a bgm_id.
+// Returning pairs rather than a count is what lets the happy path assert that
+// each row got ITS OWN subject.
+func bindWorkerBoundPairs(t *testing.T, ctx context.Context, pool *pgxpool.Pool) []queue.BangumiV2Args {
+	t.Helper()
+	rows, err := pool.Query(ctx, `
+		SELECT anilist_id, bgm_id FROM anime_cache
+		WHERE anilist_id >= $1 AND bgm_id IS NOT NULL
+		ORDER BY anilist_id`, bindWorkerIDFloor)
+	require.NoError(t, err, "read back bound fixtures")
+	defer rows.Close()
+
+	out := []queue.BangumiV2Args{}
+	for rows.Next() {
+		var p queue.BangumiV2Args
+		require.NoError(t, rows.Scan(&p.AnilistID, &p.BgmID))
+		out = append(out, p)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// bindWorkerRun builds the worker and runs exactly one pass.  The job value is
+// empty because BindIdMapArgs carries no payload and Work never reads the job:
+// the candidate set is entirely a function of the two tables.
+func bindWorkerRun(t *testing.T, ctx context.Context, pool *pgxpool.Pool, stub *bindWorkerStubEnqueuer) error {
+	t.Helper()
+	w := queue.NewBindIdMapWorker(pool, dbgen.New(pool), stub)
+	return w.Work(ctx, &river.Job[queue.BindIdMapArgs]{})
+}
+
+func TestBindIdMapWorker(t *testing.T) {
+	ctx := context.Background()
+	pool := newPGPool(t, ctx)
+
+	// See the file header: the sweep is catalogue-wide, so scoping it means
+	// owning the whole slate, not just picking unusual ids.
+	testutil.TruncateAll(t, ctx, pool)
+
+	// The kill switch gates the WRITE, not just a helper.
+	//
+	// Both disabled values are asserted against the rows for the same reason:
+	// the failure this guards against is a flag that is read somewhere and
+	// wired nowhere.  "yes-please" is the fail-closed half — a typo in a
+	// variable that gates production writes must not be read as ON, and
+	// ParseBool rejects everything outside its small vocabulary.
+	//
+	// The empty string stands in for "unset": bindIdMapSweepEnabled reads it
+	// with os.Getenv, which cannot tell the two apart, and t.Setenv restores
+	// whatever the developer's shell had — including an inherited "1", which
+	// would otherwise make this subtest silently untestable.
+	for _, value := range []struct{ name, env string }{
+		{"unset", ""},
+		{"unparseable", "yes-please"},
+	} {
+		t.Run("kill switch "+value.name+" binds nothing", func(t *testing.T) {
+			pairs := []queue.BangumiV2Args{
+				{AnilistID: 9900101, BgmID: 9900901},
+				{AnilistID: 9900102, BgmID: 9900902},
+			}
+			bindWorkerSeed(t, ctx, pool, pairs)
+			t.Setenv(bindWorkerEnv, value.env)
+
+			stub := &bindWorkerStubEnqueuer{}
+			require.NoError(t, bindWorkerRun(t, ctx, pool, stub))
+
+			assert.Empty(t, bindWorkerBoundPairs(t, ctx, pool),
+				"bindable candidates existed and the switch was off; a bind here means the flag gates nothing")
+			assert.Zero(t, stub.calls,
+				"a disabled sweep must not reach the enqueuer either — the V2 jobs would run against Bangumi regardless of the flag")
+		})
+	}
+
+	// THE one this file is for: the bind and the dispatch are one unit.
+	t.Run("an enqueue failure rolls the bind back", func(t *testing.T) {
+		pairs := []queue.BangumiV2Args{
+			{AnilistID: 9900201, BgmID: 9900801},
+			{AnilistID: 9900202, BgmID: 9900802},
+		}
+		bindWorkerSeed(t, ctx, pool, pairs)
+		t.Setenv(bindWorkerEnv, "1")
+
+		stub := &bindWorkerStubEnqueuer{err: errors.New("river InsertManyTx failed")}
+		err := bindWorkerRun(t, ctx, pool, stub)
+
+		// Property 4 lives on this path: a failed pass is logged and swallowed
+		// so the next 6-hour fire retries it, instead of river's 25 attempts
+		// with attempt⁴ backoff stretching the last one out to ~20 days.
+		require.NoError(t, err,
+			"a failed pass must not return an error — river's retry policy is the wrong shape for a periodic sweep")
+
+		// Without these two, "the rows are still NULL" would also be true of a
+		// test whose fixtures were never bindable, or whose worker never got
+		// as far as the enqueuer.  They make the rollback assertion mean what
+		// it says.
+		require.Equal(t, 1, stub.calls, "the enqueuer must actually have been reached")
+		require.NoError(t, stub.txErr,
+			"the enqueuer must be handed a LIVE transaction — the one that did the bind, not a committed handle")
+		require.Equal(t, len(pairs), stub.boundInTx,
+			"the bind must already be written inside the transaction the enqueuer was handed")
+
+		assert.Empty(t, bindWorkerBoundPairs(t, ctx, pool),
+			"a bound-but-not-enqueued row leaves the candidate set (bgm_id IS NULL) forever and is never enriched")
+	})
+
+	t.Run("a pass binds candidates and dispatches exactly them", func(t *testing.T) {
+		pairs := []queue.BangumiV2Args{
+			{AnilistID: 9900301, BgmID: 9900701},
+			{AnilistID: 9900302, BgmID: 9900702},
+			{AnilistID: 9900303, BgmID: 9900703},
+		}
+		bindWorkerSeed(t, ctx, pool, pairs)
+		t.Setenv(bindWorkerEnv, "1")
+
+		stub := &bindWorkerStubEnqueuer{}
+		require.NoError(t, bindWorkerRun(t, ctx, pool, stub))
+
+		assert.ElementsMatch(t, pairs, bindWorkerBoundPairs(t, ctx, pool),
+			"every candidate must carry the subject the map named for IT")
+
+		// One statement, so one enqueue call — and the pairs, not the count,
+		// because a worker that dispatched three jobs all carrying the first
+		// row's bgm_id would satisfy a count and would enrich two rows with
+		// another show's Chinese title and score.
+		assert.Equal(t, 1, stub.calls, "one batch is one dispatch")
+		assert.ElementsMatch(t, pairs, stub.jobs,
+			"exactly one V2 job per bound row, carrying that row's own {anilistId, bgmId}")
+	})
+
+	t.Run("a second pass over a drained set is a no-op", func(t *testing.T) {
+		pairs := []queue.BangumiV2Args{
+			{AnilistID: 9900401, BgmID: 9900601},
+			{AnilistID: 9900402, BgmID: 9900602},
+		}
+		bindWorkerSeed(t, ctx, pool, pairs)
+		t.Setenv(bindWorkerEnv, "1")
+
+		// Draining the set through a real pass rather than asserting against
+		// an empty database is the point: it pins the claim that lets this
+		// sweep skip attempt bookkeeping — a bound row stops matching
+		// `bgm_id IS NULL`, so it never returns to the front of a batch.  A
+		// regression here would re-dispatch the same subjects at every fire,
+		// forever, against Bangumi's 800ms bucket.
+		stub := &bindWorkerStubEnqueuer{}
+		require.NoError(t, bindWorkerRun(t, ctx, pool, stub))
+		require.Equal(t, 1, stub.calls, "the first pass must have had something to bind")
+		require.Len(t, bindWorkerBoundPairs(t, ctx, pool), len(pairs))
+
+		require.NoError(t, bindWorkerRun(t, ctx, pool, stub),
+			"an empty pass is a success, not a failure")
+		assert.Equal(t, 1, stub.calls,
+			"nothing was bindable, so nothing may be enqueued — bindBatch returns before it reaches the enqueuer")
+		assert.ElementsMatch(t, pairs, bindWorkerBoundPairs(t, ctx, pool),
+			"the second pass must not have disturbed what the first one bound")
+	})
+}


### PR DESCRIPTION
## What

A periodic sweep that binds the vendored AniList→Bangumi id map onto rows carrying no `bgm_id`, and dispatches their enrichment in the same transaction.

## Why these rows had no path

The V1 worker already consults `bgm_id_map` first and trusts it without a search (`bangumi_v1.go` step 0). But `UpdateBangumiV1` is guarded on `bangumi_version = 0`, so it only ever acts on a row's single pass through the pipeline — and **826 unbound rows sit at version 3**, the bulk state migration 0004 records for everything enriched under the pre-Go pipeline. Their answer has been sitting in a table we already trust, unreachable, ever since the map gained their entry.

Same shape as the version ratchet that stranded episode titles and Chinese descriptions. This is the third patch over it, not a fix for it.

## Why the map is trusted with no second signal

Measured on production before the query was written, and deliberately excluding rows the map itself bound so the evidence is not circular:

| bound by | rows with a map entry | map agrees |
|---|---|---|
| `id_map` | 5,633 | 100% |
| **(legacy null — pre-Go pipeline)** | **3,769** | **100%** |
| `fuzzy_high` | 5 | 100% |

Zero disagreements against 3,769 independently-produced bindings.

## The refusals

Structural, not evidential — and they are the query's whole job:

| guard | what it stops |
|---|---|
| `claims = 1` | Two unbound rows mapping to one subject. A data-modifying statement cannot see its own writes, so without this both would pass `NOT EXISTS` in the same statement and **both** be bound. |
| `NOT EXISTS` | A subject some already-bound row holds. |
| `AND a.bgm_id IS NULL` on the UPDATE | The CAS. Makes the sweep lose the row rather than overwrite a binding another writer just committed. |

Verdicts on production right now: **791 bindable, 33 subject-already-bound, 2 subject-claimed-twice** (`Gekidol` and its prequel special `Alice in Deadly School`, which the map sends to one subject).

## Two design points

**The bind and the V2 dispatch share a transaction** (new `EnqueueV2ManyTx`). A bound row with nothing queued behind it is worse than an unbound one — it stops matching the sweep's own `bgm_id IS NULL` predicate and is never enriched. Every other enqueue path stays non-transactional, where a failed insert costs a re-run rather than a row.

**`MaxWorkers: 1` is load-bearing, not polite.** `anime_cache.bgm_id` has no unique index, so two concurrent passes could each clear `NOT EXISTS` for the same subject and both bind, with nothing downstream to catch it.

Binding also retires an `admin_flag` of `needs-review` — the map answering *is* the resolution of the review V1 asked for. `manually-corrected` is left alone: that one records a human's decision, not a pending request for one.

## Testing

Six mutations against a real Postgres, six killed:

| mutation | killed by |
|---|---|
| drop `claims = 1` | 5 subtests |
| drop `NOT EXISTS` | 5 subtests |
| `admin_flag` cleared unconditionally | `a human's correction is not cleared` |
| `bgm_match_source` mislabelled | 2 subtests |
| verdicts swapped | `the preview classifies all three cases` |
| **drop the CAS** | `TestIdMapBindConcurrentClaim` |

The CAS one is the interesting one: it **survived every single-statement test**, because inside one statement the re-check can only agree with the CTE that selected the row. `TestIdMapBindConcurrentClaim` forces the EvalPlanQual path with two transactions, and asserts the bind genuinely blocked on the rival's row lock first — without that step it would pass from a race that never happened.

The worker's own tests were mutation-verified separately (7 mutations, 7 killed), including that an enqueue failure rolls the bind back and that the kill switch gates the write rather than just the boolean.

`EXPLAIN ANALYZE` on the production table: 59ms, hash anti-join, no per-row scan.

## What this does not fix

`TODOS.md` gains an entry: **541 subjects are already held by more than one row** (1,161 rows), which makes `GetAnimeByBgmID` — a `:one` query — return an arbitrary one of them. `resolveSiteAnime` leg 2 and `findSiteAnime` leg 3 both go through it. The sweep refuses to make that number larger and cannot make it smaller; not all of those duplicates are errors, since Bangumi sometimes covers one subject where AniList splits two seasons.

`anime_cache.bgm_id` also has **no index at all** — every lookup by it is a seq scan.

## Rollout

Ships disabled. `BGM_BIND_IDMAP_SWEEP_ENABLED` is read at work time and fails closed; the `bgm_bind_idmap` queue can be paused for an immediate stop without a deploy. Run `bgmbackfill --report-id-map-binds` first — it writes nothing and prints every refusal with a sample.

## Test plan

- [x] `go test ./...`
- [x] `go test -tags=integration ./test/integration/`
- [x] Mutation: 6/6 on the SQL, 7/7 on the worker
- [x] `EXPLAIN ANALYZE` + verdict counts against the production table
- [ ] Enable the flag on production and confirm the first pass binds 200 and enqueues 200