### PR TITLE
Put the airing schedule directly under the hot discussions

### DIFF
--- a/next-app/src/app/[lang]/(home)/page.tsx
+++ b/next-app/src/app/[lang]/(home)/page.tsx
@@ -278,9 +278,9 @@ export default async function HomePage({ params }: PageProps<"/[lang]">) {
         style={{ paddingTop: 8, paddingBottom: 60 }}
       >
         <HotDiscussions items={hotDiscussions} />
+        <WeeklySchedule schedule={schedule} dict={dict} lang={lang} />
         <TrendingSection items={trending} dict={dict} lang={lang} />
         <ContinueWatching dict={dict} lang={lang} />
-        <WeeklySchedule schedule={schedule} dict={dict} lang={lang} />
         <CompletedGems
           initialItems={gems}
           dict={dict}


### PR DESCRIPTION
## What

Moves `WeeklySchedule` (放送日历 / 本周更新) from the fourth homepage section to the second, directly below `HotDiscussions` (正在热议).

Before → after:

| | before | after |
|---|---|---|
| 1 | 正在热议 | 正在热议 |
| 2 | 大家都在追 | **本周更新** |
| 3 | 我的在追 | 大家都在追 |
| 4 | **本周更新** | 我的在追 |
| 5 | 经典好番推荐 | 经典好番推荐 |
| 6 | ActivityFeed | ActivityFeed |
| 7 | 年度榜 | 年度榜 |

The schedule is the one block on the page whose contents change every day; the two lists it now sits above are evergreen.

## Why it is only a reorder

The sections are static imports rendered in JSX order inside `<div className="container">`, and `.container` (`globals.css:238`) is `max-width` + `margin` + `padding` — no flex, no grid, no `order`. So JSX order is DOM order is visual order, and there is no lazy-loading or above-the-fold strategy keyed to position to update.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `bun test` — 1896 pass, 0 fail
- [x] `eslint` on the changed file — no output; repo-wide count is 264 problems both before and after (unchanged from `main`)
- [x] Checked `e2e/specs/home.spec.ts` — no assertions on section order or `nth-child`