### PR TITLE
Let a human say "not this one" to the id-map bind

### DIFF
--- a/go-api/internal/db/gen/anime_cache.sql.go
+++ b/go-api/internal/db/gen/anime_cache.sql.go
@@ -109,6 +109,11 @@ WITH unbound AS (
     FROM anime_cache a
     JOIN bgm_id_map m ON m.anilist_id = a.anilist_id
     WHERE a.bgm_id IS NULL
+      -- A human's decision outranks the map.  Without this there is no way to
+      -- say "not this one": unbinding a row hands it straight back to the next
+      -- pass, because the only thing that made it a candidate was the empty
+      -- bgm_id the correction just created.
+      AND (a.admin_flag IS DISTINCT FROM 'manually-corrected')
 ),
 eligible AS (
     SELECT anilist_id, bgm_id
@@ -127,8 +132,12 @@ SET bgm_id           = e.bgm_id,
     -- bgm_match_source 'fuzzy_low') is a candidate here the moment the map
     -- gains its entry, and the map answering IS the resolution of that
     -- review.  Leaving the flag would keep a settled row in the admin queue
-    -- for good.  'manually-corrected' is deliberately not touched: that one
-    -- records a human's decision, not a pending request for one.
+    -- for good.
+    --
+    -- The ELSE arm now only ever carries NULL forward: 'manually-corrected'
+    -- is excluded from the candidate set above, which is the stronger place
+    -- for that protection -- preserving the flag while re-binding the row
+    -- would have kept the audit trail of a correction it had just undone.
     admin_flag       = CASE WHEN a.admin_flag = 'needs-review' THEN NULL
                             ELSE a.admin_flag END,
     updated_at       = now()
@@ -2531,6 +2540,9 @@ WITH unbound AS (
     FROM anime_cache a
     JOIN bgm_id_map m ON m.anilist_id = a.anilist_id
     WHERE a.bgm_id IS NULL
+      -- Same exclusion the writer applies.  A preview that listed rows the
+      -- writer will not touch would report work that never happens.
+      AND (a.admin_flag IS DISTINCT FROM 'manually-corrected')
 )
 SELECT anilist_id,
        bgm_id,

--- a/go-api/internal/db/queries/anime_cache.sql
+++ b/go-api/internal/db/queries/anime_cache.sql
@@ -587,6 +587,9 @@ WITH unbound AS (
     FROM anime_cache a
     JOIN bgm_id_map m ON m.anilist_id = a.anilist_id
     WHERE a.bgm_id IS NULL
+      -- Same exclusion the writer applies.  A preview that listed rows the
+      -- writer will not touch would report work that never happens.
+      AND (a.admin_flag IS DISTINCT FROM 'manually-corrected')
 )
 SELECT anilist_id,
        bgm_id,
@@ -660,6 +663,11 @@ WITH unbound AS (
     FROM anime_cache a
     JOIN bgm_id_map m ON m.anilist_id = a.anilist_id
     WHERE a.bgm_id IS NULL
+      -- A human's decision outranks the map.  Without this there is no way to
+      -- say "not this one": unbinding a row hands it straight back to the next
+      -- pass, because the only thing that made it a candidate was the empty
+      -- bgm_id the correction just created.
+      AND (a.admin_flag IS DISTINCT FROM 'manually-corrected')
 ),
 eligible AS (
     SELECT anilist_id, bgm_id
@@ -678,8 +686,12 @@ SET bgm_id           = e.bgm_id,
     -- bgm_match_source 'fuzzy_low') is a candidate here the moment the map
     -- gains its entry, and the map answering IS the resolution of that
     -- review.  Leaving the flag would keep a settled row in the admin queue
-    -- for good.  'manually-corrected' is deliberately not touched: that one
-    -- records a human's decision, not a pending request for one.
+    -- for good.
+    --
+    -- The ELSE arm now only ever carries NULL forward: 'manually-corrected'
+    -- is excluded from the candidate set above, which is the stronger place
+    -- for that protection -- preserving the flag while re-binding the row
+    -- would have kept the audit trail of a correction it had just undone.
     admin_flag       = CASE WHEN a.admin_flag = 'needs-review' THEN NULL
                             ELSE a.admin_flag END,
     updated_at       = now()

--- a/go-api/test/integration/id_map_bind_test.go
+++ b/go-api/test/integration/id_map_bind_test.go
@@ -273,9 +273,8 @@ func TestIdMapBind(t *testing.T) {
 			{idmapFreeMid, idmapSubjectMid, "bindable"},
 			{idmapFreeHigh, idmapSubjectHigh, "bindable"},
 			{idmapReviewed, idmapSubjectReviewed, "bindable"},
-			{idmapCorrected, idmapSubjectCorrected, "bindable"},
 		}, flat,
-			"the bound holder and the unmapped row are not candidates at all; the other eight each carry the verdict the bind will act on")
+			"the bound holder, the unmapped row and the hand-corrected row are not candidates at all; the other seven each carry the verdict the bind will act on")
 
 		// The refusals are the rows a human has to adjudicate, and the only
 		// material they get for it is what this query returns.  A refusal
@@ -348,7 +347,6 @@ func TestIdMapBind(t *testing.T) {
 		assert.ElementsMatch(t, []dbgen.BindBgmIdsFromIdMapRow{
 			{AnilistID: idmapFreeHigh, BgmID: idmapSubjectHigh},
 			{AnilistID: idmapReviewed, BgmID: idmapSubjectReviewed},
-			{AnilistID: idmapCorrected, BgmID: idmapSubjectCorrected},
 		}, bound,
 			"the refusals are a property of the catalogue, not of how many rows were asked for")
 	})
@@ -364,14 +362,31 @@ func TestIdMapBind(t *testing.T) {
 			"the label must describe the binding the row now carries, not the fuzzy guess that was abandoned")
 	})
 
-	t.Run("a human's correction is not cleared", func(t *testing.T) {
+	// The audit of the first production batch found one wrong binding, and
+	// undoing it exposed this: clearing the bgm_id is the only thing that made
+	// the row a candidate, so the correction handed it straight back to the
+	// next pass.  There was no way to say "not this one".
+	//
+	// 'needs-review' and 'manually-corrected' therefore pull in opposite
+	// directions here, which is the whole point of them being two values: one
+	// is a question the map can answer, the other is an answer already given.
+	t.Run("a hand-corrected row is never offered again", func(t *testing.T) {
 		got := read(t, idmapCorrected)
-		require.NotNil(t, got.bgmID, "this row binds too; only the flag's treatment differs")
-		assert.Equal(t, idmapSubjectCorrected, *got.bgmID)
-		require.NotNil(t, got.adminFlag,
-			"the CASE has exactly one branch that clears, and this value is not it")
+		assert.Nil(t, got.bgmID,
+			"a human unbound this row on purpose; re-binding it from the map undoes the correction and there is no second chance to notice")
+		assert.Nil(t, got.matchSource)
+		require.NotNil(t, got.adminFlag)
 		assert.Equal(t, "manually-corrected", *got.adminFlag,
-			"that flag records a decision somebody already made rather than a pending request for one; clearing it would silently drop the audit trail for every hand-fixed row the map later touches")
+			"the flag is the record of that decision and nothing here may touch it")
+	})
+
+	t.Run("a corrected row is not even listed as a candidate", func(t *testing.T) {
+		rows, err := q.ListIdMapBindCandidates(ctx)
+		require.NoError(t, err)
+		for _, r := range rows {
+			assert.NotEqual(t, idmapCorrected, r.AnilistID,
+				"a preview that offered a row the writer will not touch would report work that never happens")
+		}
 	})
 
 	t.Run("neither claimant of a twice-claimed subject is bound", func(t *testing.T) {


### PR DESCRIPTION
## What the audit found

Checking all 791 sweep bindings against the Bangumi subject each points at — Japanese original name, air year, episode count, all three from AniList's separate ingest — turned up **one wrong binding out of 791 (99.87% correct)**:

| | ours (AniList 111137) | bound subject (bgm 320824) |
|---|---|---|
| title | `WAVE!!～サーフィンやっぺ!!～` | `WAVE!!～サーフィンやっぺ!!～` |
| format | **MOVIE** | TV |
| year | **2020** | **2021** |
| episodes | **3** | **12** |

The titles are byte-identical (similarity 1.00), so the title signal was useless here. Only the corroborating year and episode-count checks caught it. It is the 2020 movie trilogy bound to the 2021 TV series, and it was showing the TV series' score, Chinese name and synopsis on the movie's public page.

## The defect that undoing it exposed

Clearing the `bgm_id` is the only thing that made the row a candidate in the first place — so **the correction handed it straight back to the next pass**. There was no way to say "not this one":

- the admin `PATCH` endpoint cannot write a null `bgm_id` (a `null` decodes to nil and trips "No fields to update")
- deleting the `bgm_id_map` row would not survive a restart — that table is `TRUNCATE`d and reseeded from the vendored file on every boot

## The fix

The candidate set now excludes `admin_flag = 'manually-corrected'`.

The two flag values pull in opposite directions here, which is exactly why there are two of them: **`needs-review` is a question the map is allowed to answer** (and binding still clears it), **`manually-corrected` is an answer already given**.

Both CTEs get the exclusion — a preview that offered rows the writer will not touch would report work that never happens.

The SET clause's `manually-corrected` arm is now unreachable, and its comment claimed the protection lived there. It does not, and the new place is stronger: preserving the flag while re-binding the row would have kept the audit trail of a correction it had just undone.

## Testing

Three existing assertions asserted the old behaviour and are **rewritten rather than deleted** — the change is deliberate, so the tests say so. Two new cases cover what this is actually about: a hand-corrected row is never bound again, and never even listed.

Mutation-verified: removing the exclusion turns `a hand-corrected row is never offered again` and `a generous limit does not soften the refusals` red.

## Production state

- `111137` is unbound, its wrong Chinese title / score / synopsis cleared, flagged `manually-corrected`
- the `bgm_bind` queue is **paused** until this ships
- the other 790 bindings stand; 626 candidates were drained in one go and the 35 left are exactly the 33 + 2 the guards are meant to refuse
- `dup_subjects` held at 541 through the whole drain — the no-double-binding guard held under load

## Test plan

- [x] `go test ./...`
- [x] `go test -tags=integration ./test/integration/` — 12 subtests
- [x] Mutation: exclusion removed → 2 red; restored → green
- [ ] After deploy: unpause `bgm_bind`, confirm 111137 is not re-bound