### PR TITLE
Stop reaching a pure function through a component that needs a DOM

### DIFF
--- a/next-app/src/components/anime/ContinueWatching.tsx
+++ b/next-app/src/components/anime/ContinueWatching.tsx
@@ -4,7 +4,11 @@ import { pickTitle } from "@/lib/formatters";
 import FadeImage from "@/components/ui/FadeImage";
 import type { Dict, Lang } from "@/lib/i18n";
 import type { WatchingItem } from "@/lib/types";
-import { currentSeasonHref, resolveWatchingView } from "./continueWatchingState";
+import {
+  currentSeasonHref,
+  resolveWatchingTotal,
+  resolveWatchingView,
+} from "./continueWatchingState";
 import WatchingEmptySwap from "./WatchingEmptySwap";
 import SignedOutGate from "./SignedOutGate";
 
@@ -243,16 +247,6 @@ function progressFillStyle(currentEpisode: number, episodes: number | null) {
  * keeping the fallback here rather than merging the two fields upstream is
  * what keeps that decision reversible.
  */
-export function resolveWatchingTotal(item: WatchingItem): number | null {
-  if (typeof item.episodes === "number" && item.episodes > 0) {
-    return item.episodes;
-  }
-  if (typeof item.episodesBgm === "number" && item.episodesBgm > 0) {
-    return item.episodesBgm;
-  }
-  return null;
-}
-
 function badgeText(item: WatchingItem, dict: Dict, lang: Lang): string {
   const epUnit = dict.detail.epUnit;
   const total = resolveWatchingTotal(item);

--- a/next-app/src/components/anime/continueWatchingState.ts
+++ b/next-app/src/components/anime/continueWatchingState.ts
@@ -3,6 +3,7 @@
 // same split as torrentModalLogic.ts next door).
 
 import type { SubscriptionChangeDetail } from "@/lib/subscriptionBus";
+import type { WatchingItem } from "@/lib/types";
 
 /** Which of the three ContinueWatching bodies the section renders. */
 export type WatchingView = "logged-out" | "empty" | "grid";
@@ -83,4 +84,35 @@ const SEASON_SLUGS = ["winter", "spring", "summer", "fall"] as const;
 export function currentSeasonHref(now: Date = new Date()): string {
   const slug = SEASON_SLUGS[Math.floor(now.getMonth() / 3)];
   return `/seasonal/${slug}/${now.getFullYear()}`;
+}
+
+/**
+ * The episode count a Continue Watching card should print as its total.
+ *
+ * Lives here rather than beside the component that renders it, and the reason
+ * is the test rather than the taste: importing a component to reach a pure
+ * function drags that component's whole module graph in with it. This one
+ * reaches `next/image`, whose `deployment-id` module runs
+ * `if (typeof window !== "undefined") document.documentElement.dataset...` at
+ * import time. bun:test shares one process and one module cache across every
+ * test file, several of which set `globalThis.window` while they run, so
+ * whether that import throws depends on which file happened to be running when
+ * some other file first pulled Next in -- an ordering nothing in the suite
+ * controls. The symptom was `ReferenceError: document is not defined` reported
+ * as an unhandled error between tests, on a run whose diff touched no
+ * front-end file at all.
+ *
+ * AniList's own count wins when it has one. `episodesBgm` is the inferred
+ * fallback, and zero or negative from either source means "unknown", not
+ * "zero episodes" -- a card that printed 0 would draw an empty progress bar
+ * where it should draw none.
+ */
+export function resolveWatchingTotal(item: WatchingItem): number | null {
+  if (typeof item.episodes === "number" && item.episodes > 0) {
+    return item.episodes;
+  }
+  if (typeof item.episodesBgm === "number" && item.episodesBgm > 0) {
+    return item.episodesBgm;
+  }
+  return null;
 }

--- a/next-app/src/components/anime/continueWatchingTotal.test.ts
+++ b/next-app/src/components/anime/continueWatchingTotal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolveWatchingTotal } from "./ContinueWatching";
+import { resolveWatchingTotal } from "./continueWatchingState";
 import type { WatchingItem } from "@/lib/types";
 
 const item = (over: Partial<WatchingItem>): WatchingItem =>


### PR DESCRIPTION
## The symptom

`next-app (bun test)` fails on branches whose diff touches **no front-end file at all** — twice in a row on PR #151 (go-api only), while `main` passed at the byte-identical `next-app` tree.

```
##[group] src/components/anime/continueWatchingTotal.test.ts
# Unhandled error between tests
ReferenceError: document is not defined
  at next/dist/shared/lib/deployment-id.js:33
```

## The cause

`continueWatchingTotal.test.ts` tests `resolveWatchingTotal` — nine lines of arithmetic over two numbers. It reached it by importing `ContinueWatching`, which pulls `FadeImage`, which pulls `next/image`, whose `deployment-id` module runs **at import time**:

```js
if (typeof window !== 'undefined') {
    deploymentId = document.documentElement.dataset.dplId;
}
```

`bun:test` shares one process and one module cache across every test file, and several files here set `globalThis.window` while they run (`pendingSubscribe`, `SubscriptionSetProvider`, `api.buildHeaders`). So whether that import throws depends on **which file happened to be executing when some other file first pulled Next in** — ordering nothing in the suite controls. Hence an intermittent failure that lands on unrelated diffs.

## The fix

`resolveWatchingTotal` moves to `continueWatchingState.ts`, the sibling module that already holds this component's Next-free logic. The test imports it from there; the component imports it back, so nothing about the rendered output changes.

## Verified as a before/after, not by watching CI

Under the exact hazard — `globalThis.window` set, no `document`:

| import shape | result |
|---|---|
| through `ContinueWatching` (before) | **0 pass / 1 fail**, `ReferenceError: document is not defined` |
| from `continueWatchingState` (after) | **5 pass / 0 fail** |

- [x] full suite: 1900 pass / 0 fail
- [x] `tsc --noEmit` clean
- [x] `bun run build` clean

## What this does not fix

Any other test that reaches a component module while another file has `window` set can hit the same wall. This removes the instance that was firing; the function now carries a comment saying why it lives where it does, so it does not drift back.