### PR TITLE
"No entry for that id" is an answer, not a refusal

### DIFF
--- a/go-api/internal/dandanplay/client.go
+++ b/go-api/internal/dandanplay/client.go
@@ -401,7 +401,7 @@ func (c *Client) doOnce(ctx context.Context, method, path string, bodyBytes []by
 		if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
 			return false, false, 0, fmt.Errorf("dandanplay: decode %s: %w", path, err)
 		}
-		if err := checkStatus(dest); err != nil {
+		if err := checkStatus(ctx, path, dest); err != nil {
 			// Not retryable within the process.  A spent group refills on
 			// dandanplay's daily boundary, so retrying inside one job's
 			// backoff window only spends attempts and adds load; river's own
@@ -541,32 +541,68 @@ var ErrQuotaExceeded = errors.New("dandanplay: API quota exceeded")
 // an empty answer stop looking alike.
 var ErrUpstreamRejected = errors.New("dandanplay: upstream rejected the request")
 
-// ddpQuotaErrorCode is the errorCode dandanplay returns for a spent group.
-// It mirrors HTTP 429 but arrives in a 200 body, which is the entire reason
-// this constant is needed.
-const ddpQuotaErrorCode = 429
-
-// checkStatus turns a non-success envelope into an error.
+// The errorCodes we have catalogued from production, and what each one is.
 //
-// The test is `ErrorCode != 0`, not `!Success`.  Several endpoints omit
-// `success` from a healthy body, so a bare !Success check would reject every
-// good response from those -- the field defaults to false when absent, and
-// "absent" and "false" are the same value in Go.  A non-zero errorCode is
-// only ever set on a refusal, so it is the signal that actually distinguishes
-// the two.
-func checkStatus(dest any) error {
+// The distinction that matters is NOT success versus failure.  It is whether
+// the code describes THE RESOURCE -- a real answer about data, which callers
+// must keep receiving as an empty result -- or OUR ABILITY TO ASK, which is a
+// refusal and has to stop being invisible.
+const (
+	// ddpQuotaErrorCode: the function group's daily quota is spent.  Mirrors
+	// HTTP 429 but arrives in a 200 body, which is the entire reason any of
+	// this exists.  A refusal: it says nothing about the id we asked for.
+	ddpQuotaErrorCode = 429
+	// ddpNotFoundErrorCode: 无法找到指定的资源.  An ANSWER, not a refusal --
+	// dandanplay's way of saying it has no entry for this id, which for a
+	// catalogue two-thirds of which it has never heard of is the ordinary
+	// case, not an incident.
+	//
+	// This one cost a production regression.  The first version of
+	// checkStatus treated every non-zero errorCode as a rejection, which
+	// turned "this anime is not in dandanplay" into an HTTP 500 on the live
+	// danmaku route and into `episode_titles fetch failed` on the RELEASING
+	// sweep -- 26 of them within ten minutes of the deploy, every single one
+	// of them a normal answer.
+	ddpNotFoundErrorCode = 7
+)
+
+// checkStatus decides whether a decoded envelope is a refusal.
+//
+// The test is on ErrorCode, not on `success`.  Several endpoints omit
+// `success` from a healthy body, and an absent bool is false in Go, so a bare
+// !Success check would reject every good response from those -- turning a
+// silent-failure fix into an outage of the same calls.
+//
+// FAIL OPEN ON CODES WE HAVE NOT CATALOGUED, and this is the deliberate half.
+// An earlier version returned an error for every non-zero code on the
+// reasoning that a refusal must never be silent again.  That reasoning is
+// right about refusals and wrong about this API, because dandanplay also
+// reports ordinary facts through the same field: code 7 is "no entry for that
+// id", which for our catalogue is the common case.  Failing closed on it took
+// the live danmaku route to HTTP 500 for every anime dandanplay does not have.
+//
+// So: codes known to be refusals are errors, code 7 is an answer, and
+// anything else is logged with its code and message and passed through as an
+// empty result.  A code we have never seen is far more likely to be another
+// fact about the resource than a new way of being refused, and the cost of
+// guessing wrong in that direction is a log line rather than a 500 in front
+// of a reader.  The log is what the original defect actually lacked -- it
+// returned nil with no signal at all.
+func checkStatus(ctx context.Context, path string, dest any) error {
 	sc, ok := dest.(statusCarrier)
 	if !ok {
 		return nil
 	}
 	st := sc.status()
-	if st.ErrorCode == 0 {
+	switch st.ErrorCode {
+	case 0, ddpNotFoundErrorCode:
 		return nil
-	}
-	if st.ErrorCode == ddpQuotaErrorCode {
+	case ddpQuotaErrorCode:
 		return fmt.Errorf("%w (code %d: %s)", ErrQuotaExceeded, st.ErrorCode, st.ErrorMessage)
 	}
-	return fmt.Errorf("%w (code %d: %s)", ErrUpstreamRejected, st.ErrorCode, st.ErrorMessage)
+	slog.WarnContext(ctx, "dandanplay: uncatalogued errorCode, treating as no data",
+		"path", path, "errorCode", st.ErrorCode, "errorMessage", st.ErrorMessage)
+	return nil
 }
 
 type matchEnvelope struct {

--- a/go-api/internal/dandanplay/client_test.go
+++ b/go-api/internal/dandanplay/client_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -706,22 +707,132 @@ func TestQuotaRefusalIsNeverCachedAsAMiss(t *testing.T) {
 	}
 }
 
+// TestNotFoundIsAnAnswerNotARefusal is the regression this file exists for as
+// much as the quota one.
+//
+// The body below is verbatim from production. errorCode 7 -- 无法找到指定的
+// 资源 -- is dandanplay saying it has no entry for that id, which for a
+// catalogue it has never heard of most of is the ordinary case. Treating it as
+// a refusal took the live danmaku route to HTTP 500 for every such anime, and
+// filled the RELEASING sweep's log with `episode_titles fetch failed` for rows
+// that were simply not there: 26 of them inside ten minutes.
+func TestNotFoundIsAnAnswerNotARefusal(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"bangumi":null,"errorCode":7,"success":false,"errorMessage":"无法找到指定的资源"}`))
+	})
+
+	data, err := c.FetchEpisodesByDandanAnimeID(context.Background(), 24515)
+
+	if err != nil {
+		t.Fatalf("upstream having no entry is data, not failure: %v", err)
+	}
+	if data != nil {
+		t.Fatalf("want nil data, got %+v", data)
+	}
+}
+
+// captureWarnings swaps the default slog logger for one writing into a buffer,
+// and restores it. The buffer is what makes the difference between "code 7 is
+// catalogued" and "code 7 falls through the default" observable at all: both
+// return no data and no error, so behaviour alone cannot tell them apart, and
+// a test asserting only behaviour passes with the catalogue entry deleted.
+// (It did. That is why this exists.)
+func captureWarnings(t *testing.T) *strings.Builder {
+	t.Helper()
+	var buf strings.Builder
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// TestNotFoundDoesNotWarn — the catalogue entry for code 7 earns its keep in
+// the log, not in the return value.
+//
+// Production sees this code constantly: most of our catalogue is not in
+// dandanplay, and 26 arrived within ten minutes of one deploy. Routing it
+// through the uncatalogued branch would emit a WARN for each, which is how a
+// log stops being read.
+func TestNotFoundDoesNotWarn(t *testing.T) {
+	buf := captureWarnings(t)
+	c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"bangumi":null,"errorCode":7,"success":false,"errorMessage":"无法找到指定的资源"}`))
+	})
+
+	if _, err := c.FetchEpisodesByDandanAnimeID(context.Background(), 24515); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := buf.String(); strings.Contains(got, "uncatalogued") {
+		t.Fatalf("code 7 is a normal answer and must not warn; got: %s", got)
+	}
+}
+
+// TestUncataloguedCodeWarns is the other half: passing an unknown code through
+// silently would restore the exact blindness this whole change exists to end.
+// The log line IS the fix for anything not in the catalogue.
+func TestUncataloguedCodeWarns(t *testing.T) {
+	buf := captureWarnings(t)
+	c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"bangumi":null,"errorCode":9001,"success":false,"errorMessage":"something new"}`))
+	})
+
+	if _, err := c.FetchEpisodesByDandanAnimeID(context.Background(), 5415); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "uncatalogued") {
+		t.Fatalf("an unknown code must be named in the log, got: %q", got)
+	}
+	if !strings.Contains(got, "9001") || !strings.Contains(got, "something new") {
+		t.Fatalf("the log must carry the code AND upstream's message, got: %q", got)
+	}
+}
+
+// TestUncataloguedCodeFailsOpen — a code we have never seen is far more likely
+// to be another fact about the resource than a new way of being refused, and
+// the cost of guessing wrong in that direction is a log line rather than a 500
+// in front of a reader. The signal the original defect lacked was the log, not
+// the error.
+func TestUncataloguedCodeFailsOpen(t *testing.T) {
+	c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"bangumi":null,"errorCode":9001,"success":false,"errorMessage":"something new"}`))
+	})
+
+	data, err := c.FetchEpisodesByDandanAnimeID(context.Background(), 5415)
+
+	if err != nil {
+		t.Fatalf("an unknown code must not break a live route: %v", err)
+	}
+	if data != nil {
+		t.Fatalf("want nil data, got %+v", data)
+	}
+}
+
 func TestNonQuotaRejectionIsDistinguishable(t *testing.T) {
+	// 401 is not in the catalogue, so under the fail-open rule it passes
+	// through as no data rather than as ErrUpstreamRejected. That is the
+	// deliberate trade: this path is in front of readers, and a credentials
+	// failure announces itself in the WARN log and in every call returning
+	// nothing, not in a 500. The sentinel stays exported for the codes we do
+	// catalogue as refusals.
 	c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"errorCode":401,"success":false,"errorMessage":"bad credentials"}`))
 	})
 
-	_, err := c.FetchEpisodesByDandanAnimeID(context.Background(), 5415)
+	data, err := c.FetchEpisodesByDandanAnimeID(context.Background(), 5415)
 
-	if !errors.Is(err, ErrUpstreamRejected) {
-		t.Fatalf("want ErrUpstreamRejected, got %v", err)
+	if err != nil {
+		t.Fatalf("uncatalogued codes fail open: %v", err)
 	}
-	if errors.Is(err, ErrQuotaExceeded) {
-		t.Fatal("a credentials failure must not read as a quota failure -- the remedies are unrelated")
-	}
-	if !strings.Contains(err.Error(), "bad credentials") {
-		t.Fatalf("upstream's own message must survive for an operator to read, got %q", err)
+	if data != nil {
+		t.Fatalf("want nil data, got %+v", data)
 	}
 }
 


### PR DESCRIPTION
**Production regression from #151, found ten minutes after the deploy that shipped it.**

## What broke

`checkStatus` treated every non-zero `errorCode` as a rejection. dandanplay also reports **ordinary facts** through that field:

```
HTTP/1.1 200 OK
{"bangumi":null,"errorCode":7,"success":false,"errorMessage":"无法找到指定的资源"}
```

Code 7 means *"I have no entry for that id"* — which, for a catalogue most of which dandanplay has never heard of, is the common case. Failing closed on it:

- took `/api/dandanplay/episodes/{id}` to **HTTP 500** for every such anime
- filled the RELEASING sweep's log with `episode_titles fetch failed` for rows that were simply not there

**26 of them inside ten minutes**, every one a normal answer. Zero quota errors in the same window — so the thing #151 was built to catch never even fired; only the collateral did.

#151's own commit message warned that a `!Success` check *"would turn this fix into an outage of the same calls"* and avoided it. This is its sibling: **not every non-zero errorCode is a refusal either.**

## The rule now

The distinction is not success versus failure. It is whether the code describes **the resource** — a real answer callers must keep receiving as an empty result — or **our ability to ask**, which is a refusal that has to stop being invisible.

| code | is | result |
|---|---|---|
| 429 quota | refusal | `ErrQuotaExceeded` |
| 7 not found | answer | `(nil, nil)`, silently, as before |
| anything else | unknown | `(nil, nil)` + WARN naming code and message |

**Uncatalogued codes now fail open**, which reverses #151 and is deliberate. A code we have never seen is far more likely to be another fact about the resource than a new way of being refused, and this client sits in front of readers: guessing wrong toward "refusal" costs a 500 on a live route, guessing wrong toward "answer" costs a log line. The log is what the original defect actually lacked — it returned nil with **no signal at all**.

## Tests assert on the log, not the return value

Both branches return `(nil, nil)`, so behaviour alone cannot separate "code 7 is catalogued" from "code 7 falls through the default". An earlier version of this test **passed with the catalogue entry deleted** — a mutation check caught it, which is why these exist:

- `TestNotFoundDoesNotWarn` — 26 warnings in ten minutes is how a log stops being read
- `TestUncataloguedCodeWarns` — with the code *and* upstream's own message

Mutation re-run after: deleting the code-7 entry now fails, and the failure message prints the WARN that should not have been there.

- [x] `go test ./...` green
- [x] full `internal/dandanplay` package green

## Deploy

Needs deploying — production is currently serving 500s for this case.