### PR TITLE
Stop writing episode-title rows that carry no name

### DIFF
--- a/go-api/internal/queue/bangumi_episodes_test.go
+++ b/go-api/internal/queue/bangumi_episodes_test.go
@@ -624,7 +624,13 @@ func TestEpisodesBgmWorker_AcceptedBindingWritesCountAndTitles(t *testing.T) {
 	assert.Equal(t, int32(400602), *counts[0].bgmID,
 		"the write must be pinned to the binding the job fetched")
 
-	assert.Len(t, titles, 3, "the SP must not become an episode title row")
+	// Two halves of the same list, deliberately different: the COUNT is 3
+	// because `{Sort: 3}` is an episode Bangumi lists but has not named, and
+	// an unnamed episode is still an episode. The WRITE is 2 because a row
+	// carrying no name in either language is two NULLs -- it renders exactly
+	// like no row at all, and it makes "how many titles do we hold" wrong.
+	assert.Len(t, titles, 2,
+		"the SP must not become a title row, and neither must the episode named in neither language")
 	assert.Empty(t, stamps, "a successful write stamps the attempt in the same statement, not separately")
 	assert.Zero(t, forbidden)
 }

--- a/go-api/internal/queue/episode_titles_write.go
+++ b/go-api/internal/queue/episode_titles_write.go
@@ -88,6 +88,18 @@ func writeEpisodeTitles(
 	titles []epTitle,
 ) (written, failures int) {
 	for _, t := range titles {
+		// Bangumi lists episodes it has no name for in either language, and
+		// the numbering function keeps them on purpose -- episodes_bgm
+		// derives a COUNT from that list, and an episode without a name is
+		// still an episode. Writing one is a different matter: the row is two
+		// NULLs, which renders exactly like no row at all while making "how
+		// many titles do we hold" unanswerable by counting rows.
+		// internal/episodetitles.Usable has dropped these on the dandanplay
+		// side since it was written; this side had not, and the gap only
+		// became visible when the RELEASING sweep began routing rows here.
+		if t.nameCN == nil && t.name == nil {
+			continue
+		}
 		n, err := db.UpsertEpisodeTitleSourced(ctx, dbgen.UpsertEpisodeTitleSourcedParams{
 			Episode: t.episode,
 			NameCn:  derefOrEmpty(t.nameCN),

--- a/go-api/internal/queue/episode_titles_write_test.go
+++ b/go-api/internal/queue/episode_titles_write_test.go
@@ -1,0 +1,70 @@
+package queue
+
+import (
+	"context"
+	"testing"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+// A row carrying no name in either language is two NULLs. It renders exactly
+// like no row at all, and it makes "how many titles do we hold for this
+// anime" unanswerable by counting rows. internal/episodetitles.Usable has
+// dropped these on the dandanplay side since it was written; this side had
+// not, and the gap stayed invisible until the RELEASING sweep began routing
+// rows here -- 21,370 such rows across 1,329 anime had accumulated, one
+// airing ONA contributing 228 by itself.
+//
+// The filter belongs here and not in normalizeEpisodeTitles: that function
+// also feeds episodes_bgm, which derives a COUNT from the list, and an
+// episode Bangumi has not named is still an episode.
+
+type recordingUpserter struct {
+	got []dbgen.UpsertEpisodeTitleSourcedParams
+}
+
+func (r *recordingUpserter) UpsertEpisodeTitleSourced(_ context.Context, arg dbgen.UpsertEpisodeTitleSourcedParams) (int64, error) {
+	r.got = append(r.got, arg)
+	return 1, nil
+}
+
+func strp(s string) *string { return &s }
+
+func TestWriteEpisodeTitles_SkipsEpisodesNamedInNeitherLanguage(t *testing.T) {
+	t.Parallel()
+
+	db := &recordingUpserter{}
+	written, failures := writeEpisodeTitles(context.Background(), db, 1234, 9999, []epTitle{
+		{episode: 1, name: strp("E1"), nameCN: strp("第一集")},
+		{episode: 2},                      // named in neither language
+		{episode: 3, nameCN: strp("第三集")}, // CN only still writes
+		{episode: 4, name: strp("E4")},    // JA only still writes
+	})
+
+	if written != 3 || failures != 0 {
+		t.Fatalf("want 3 written / 0 failures, got %d / %d", written, failures)
+	}
+	if len(db.got) != 3 {
+		t.Fatalf("the nameless episode must never reach the upsert: %d calls", len(db.got))
+	}
+	for _, g := range db.got {
+		if g.Episode == 2 {
+			t.Fatalf("episode 2 has no name in either language and must not be written")
+		}
+	}
+}
+
+func TestWriteEpisodeTitles_ANamelessEpisodeIsNotCountedAsAFailure(t *testing.T) {
+	t.Parallel()
+
+	// Skipping is a decision, not a write that went wrong. Counting it as a
+	// failure would put a WARN in the log for every airing show whose upstream
+	// lists more episodes than it has named -- which is most of them.
+	db := &recordingUpserter{}
+	_, failures := writeEpisodeTitles(context.Background(), db, 1234, 9999, []epTitle{
+		{episode: 1}, {episode: 2}, {episode: 3},
+	})
+	if failures != 0 {
+		t.Fatalf("skipped rows must not be reported as failures, got %d", failures)
+	}
+}


### PR DESCRIPTION
Found by watching the first sweep pass after #156 deployed, not by a test.

    bangumi fallback partial  anilistId=136862 written=32 failures=228

260 rows for one airing ONA, **228 of them carrying no name in either
language**. Catalogue-wide: **21,370 such rows across 1,329 anime**, and
**311 created in the 25 minutes after deploy**. The new fallback did not
invent this — it pointed a long-standing gap at a hundred more shows.

A row of two NULLs renders exactly like no row at all. It helps no reader,
and it makes "how many titles do we hold for this anime" unanswerable by
counting rows. `internal/episodetitles.Usable` has dropped these on the
dandanplay side since it was written; the Bangumi side never did.

## Where the filter goes, and why not where I first put it

In `writeEpisodeTitles`, **not** `normalizeEpisodeTitles`. The first attempt
put it in the numbering function and two existing tests failed immediately —
the right answer: `episodes_bgm` derives a **count** from that same list, and
an episode Bangumi lists but has not named is still an episode. Counting it
and writing it are different questions.

A skipped row is also not a failure. Counting it as one would log a WARN for
every airing show whose upstream lists more episodes than it has named.

## Test plan

- [x] `go build ./...`, `go vet -tags=integration ./test/integration/...`,
      `go test ./internal/queue/`
- [x] Two new tests on the write path; mutation-checked (filter removed,
      `&&` widened to `||`, skip counted as failure — all caught)
- [x] `TestEpisodesBgmWorker_AcceptedBindingWritesCountAndTitles` already had
      an unnamed episode in its fixture; it now pins both halves — count 3,
      rows written 2
- [ ] The 21,370 existing rows are not touched here. Cleanup is a separate
      call: they are invisible to readers, so this stops the growth first.