### PR TITLE
Re-run phase 2 over an explicit list of anilist_ids

### DIFF
--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -1033,6 +1033,7 @@ func main() {
 
 		// Enrichment writes — static paths first to keep chi happy.
 		r.Post("/enrichment/re-enrich", adminEnrichmentHandlers.ReEnrich)
+		r.Post("/enrichment/re-enrich-ids", adminEnrichmentHandlers.ReEnrichIDs)
 		r.Post("/enrichment/heal-cn", adminEnrichmentHandlers.HealCn)
 		r.Post("/enrichment/heal-cn/pause", adminEnrichmentHandlers.PauseHeal)
 		r.Post("/enrichment/heal-cn/resume", adminEnrichmentHandlers.ResumeHeal)

--- a/go-api/internal/admin/enrichment.go
+++ b/go-api/internal/admin/enrichment.go
@@ -3,6 +3,7 @@
 //
 //	PATCH /api/admin/enrichment/:anilistId          updateEnrichment
 //	POST  /api/admin/enrichment/re-enrich            reEnrich (?version=0|1|2)
+//	POST  /api/admin/enrichment/re-enrich-ids        reEnrichIDs (JSON body)
 //	POST  /api/admin/enrichment/heal-cn              healCnTitles
 //	POST  /api/admin/enrichment/heal-cn/pause        pauseHeal
 //	POST  /api/admin/enrichment/heal-cn/resume       resumeHeal
@@ -71,8 +72,8 @@ const (
 // Stored as a set keyed on the string form (treating "" as the null
 // case the JSON request body uses).
 var allowedFlagValues = map[string]struct{}{
-	"needs-review":        {},
-	"manually-corrected":  {},
+	"needs-review":       {},
+	"manually-corrected": {},
 }
 
 // EnrichmentDB is the sqlc subset the enrichment handlers consume.
@@ -93,6 +94,7 @@ type EnrichmentDB interface {
 	ListEnrichedV2WithoutBgm(ctx context.Context) ([]int32, error)
 	PromoteAnimeToV3(ctx context.Context, dollar_1 []int32) error
 	ListHealCnCandidates(ctx context.Context) ([]dbgen.ListHealCnCandidatesRow, error)
+	ListBgmBindingsForReEnrich(ctx context.Context, anilistIds []int32) ([]dbgen.ListBgmBindingsForReEnrichRow, error)
 }
 
 // txQuerier is the subset of the sqlc-generated Querier that supports
@@ -111,13 +113,17 @@ type txQuerier interface {
 // router behind the RequireAuth + RequireAdmin chain.
 //
 // Pool — required by Reset (transaction over the three reset queries)
-//        and by transactional re-enrich (v=2 promote-to-v3 + enqueue
-//        atomicity is desirable but Express did not have it; we match
-//        Express here).
+//
+//	and by transactional re-enrich (v=2 promote-to-v3 + enqueue
+//	atomicity is desirable but Express did not have it; we match
+//	Express here).
+//
 // DB — the sqlc surface for the non-transactional reads + writes.
 // NewTxQuerier — pluggable factory that lets tests substitute a fake
-//        transactional querier without standing up Postgres.  Production
-//        wires this as `func(tx pgx.Tx) txQuerier { return dbgen.New(tx) }`.
+//
+//	transactional querier without standing up Postgres.  Production
+//	wires this as `func(tx pgx.Tx) txQuerier { return dbgen.New(tx) }`.
+//
 // Enq — queue dispatcher for V1 / V2 / V3 batches.
 // QueueCtrl — admin pause/resume surface from internal/queue.
 type EnrichmentHandlers struct {
@@ -368,6 +374,123 @@ func (h *EnrichmentHandlers) runResetTransaction(ctx context.Context, anilistID 
 		return fmt.Errorf("admin reset: commit: %w", err)
 	}
 	return nil
+}
+
+// ============================================================================
+// POST /api/admin/enrichment/re-enrich-ids — reEnrichIDs
+// ============================================================================
+
+// maxReEnrichIDs caps one request.
+//
+// The version-keyed endpoint is uncapped because its input is a query the
+// database answers; this one's input is typed by a person, and a paste
+// accident should not become a queue flood.  A thousand is well past any
+// list an operator assembles by hand and still one bounded enqueue.
+const maxReEnrichIDs = 1000
+
+// reEnrichIDsRequest is the body: an explicit list of anilist_ids.
+type reEnrichIDsRequest struct {
+	AnilistIDs []int32 `json:"anilistIds"`
+}
+
+// reEnrichIDsResponse separates the two reasons an id produced no job.
+//
+// One `skipped` number would answer neither question the operator has after
+// pasting a list: whether they mistyped an id, or whether the row is real but
+// unbound.  Those lead to different next actions, so they are counted apart.
+type reEnrichIDsResponse struct {
+	Requested int `json:"requested"`
+	Enqueued  int `json:"enqueued"`
+	NotFound  int `json:"notFound"`
+	NoBinding int `json:"noBinding"`
+}
+
+// ReEnrichIDs handles POST /api/admin/enrichment/re-enrich-ids.
+//
+// It re-runs PHASE 2 over an explicit list, which is the one thing the
+// version-keyed endpoint cannot do.  `re-enrich?version=1` selects rows at
+// bangumi_version = 1 -- rows V1 bound and V2 has not finished -- so a row
+// that already completed V2 sits at version 2 or 3 and is outside every
+// branch.  A change to what V2 writes therefore has no way to reach the rows
+// V2 has already written, which is exactly the shape of ceiling PR #105 and
+// #108 each hit from the other side.
+//
+// Rows without a bgm_id are counted, never enqueued: V2 fetches a Bangumi
+// subject and there is nothing to fetch.  The version is deliberately left
+// alone -- this endpoint re-runs a phase, it does not rewind one.
+func (h *EnrichmentHandlers) ReEnrichIDs(w http.ResponseWriter, r *http.Request) {
+	var req reEnrichIDsRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		httpx.Fail(w, httpx.NewError(http.StatusBadRequest, httpx.CodeBadRequest, "无效的请求体"))
+		return
+	}
+	if len(req.AnilistIDs) == 0 {
+		httpx.Fail(w, httpx.NewError(http.StatusBadRequest, httpx.CodeBadRequest, "anilistIds 不能为空"))
+		return
+	}
+	if len(req.AnilistIDs) > maxReEnrichIDs {
+		httpx.Fail(w, httpx.NewError(http.StatusBadRequest, httpx.CodeBadRequest,
+			fmt.Sprintf("一次最多 %d 个 id", maxReEnrichIDs)))
+		return
+	}
+
+	// De-duplicate before the query.  A repeated id would otherwise enqueue
+	// the same job twice, and river has no arg-hash dedupe -- the second one
+	// spends an upstream request to write what the first already wrote.
+	seen := make(map[int32]struct{}, len(req.AnilistIDs))
+	ids := make([]int32, 0, len(req.AnilistIDs))
+	for _, id := range req.AnilistIDs {
+		if id <= 0 {
+			httpx.Fail(w, httpx.NewError(http.StatusBadRequest, httpx.CodeBadRequest, "anilistIds 必须为正整数"))
+			return
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), enrichmentQueryTimeout)
+	defer cancel()
+
+	rows, err := h.DB.ListBgmBindingsForReEnrich(ctx, ids)
+	if err != nil {
+		slog.WarnContext(ctx, "admin: ListBgmBindingsForReEnrich", "n", len(ids), "err", err)
+		httpx.Fail(w, httpx.WrapError(err, http.StatusInternalServerError, httpx.CodeServerError, "internal error"))
+		return
+	}
+
+	jobs := make([]queue.BangumiV2Args, 0, len(rows))
+	noBinding := 0
+	for _, row := range rows {
+		if row.BgmID == nil {
+			noBinding++
+			continue
+		}
+		jobs = append(jobs, queue.BangumiV2Args{
+			AnilistID: int(row.AnilistID),
+			BgmID:     int(*row.BgmID),
+		})
+	}
+	if len(jobs) > 0 {
+		if err := h.Enq.EnqueueV2Many(ctx, jobs); err != nil {
+			slog.WarnContext(ctx, "admin: reEnrichIDs V2 enqueue", "n", len(jobs), "err", err)
+			httpx.Fail(w, httpx.WrapError(err, http.StatusInternalServerError, httpx.CodeServerError, "internal error"))
+			return
+		}
+	}
+
+	resp := reEnrichIDsResponse{
+		Requested: len(ids),
+		Enqueued:  len(jobs),
+		NotFound:  len(ids) - len(rows),
+		NoBinding: noBinding,
+	}
+	slog.InfoContext(ctx, "admin: re-enrich by id",
+		"requested", resp.Requested, "enqueued", resp.Enqueued,
+		"notFound", resp.NotFound, "noBinding", resp.NoBinding)
+	httpx.Data(w, http.StatusOK, resp)
 }
 
 // ============================================================================

--- a/go-api/internal/admin/enrichment_test.go
+++ b/go-api/internal/admin/enrichment_test.go
@@ -43,6 +43,7 @@ type fakeEnrichmentDB struct {
 	listV2NoBgm     func(ctx context.Context) ([]int32, error)
 	promoteV3       func(ctx context.Context, ids []int32) error
 	listHealCn      func(ctx context.Context) ([]dbgen.ListHealCnCandidatesRow, error)
+	listBindings    func(ctx context.Context, ids []int32) ([]dbgen.ListBgmBindingsForReEnrichRow, error)
 
 	// recorded calls
 	promoteCalls [][]int32
@@ -86,6 +87,13 @@ func (f *fakeEnrichmentDB) PromoteAnimeToV3(ctx context.Context, ids []int32) er
 		return f.promoteV3(ctx, ids)
 	}
 	return nil
+}
+
+func (f *fakeEnrichmentDB) ListBgmBindingsForReEnrich(ctx context.Context, ids []int32) ([]dbgen.ListBgmBindingsForReEnrichRow, error) {
+	if f.listBindings == nil {
+		return nil, nil
+	}
+	return f.listBindings(ctx, ids)
 }
 
 func (f *fakeEnrichmentDB) ListHealCnCandidates(ctx context.Context) ([]dbgen.ListHealCnCandidatesRow, error) {
@@ -156,10 +164,10 @@ func (s *spyEnqueuer) EnqueueDescriptionLlmBackfillMany(_ context.Context, _ []q
 type fakeQueueController struct {
 	mu sync.Mutex
 
-	paused  bool
-	pauseErr error
+	paused    bool
+	pauseErr  error
 	resumeErr error
-	getErr error
+	getErr    error
 }
 
 func (f *fakeQueueController) QueuePause(ctx context.Context, name string, opts *river.QueuePauseOpts) error {
@@ -668,5 +676,123 @@ func TestDecodeJSONBody_RejectsUnknownFields(t *testing.T) {
 	}
 	if err := decodeJSONBody(req, &v); err == nil {
 		t.Error("expected error for unknown field")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/enrichment/re-enrich-ids
+//
+// This endpoint exists because the version-keyed one cannot reach the rows
+// this kind of fix needs. `re-enrich?version=1` selects bangumi_version = 1 —
+// bound by V1, not finished by V2 — so every row that HAS completed V2 sits at
+// 2 or 3, outside all three branches. A change to what V2 writes therefore has
+// no trigger that reaches what V2 already wrote. Measured 2026-09-05: of the
+// 663 anime still holding out-of-range title rows, 617 were at version 3 and
+// 46 at version 2. None at version 1.
+//
+// The alternative — re-stamping those rows' version to squeeze them into the
+// version=1 branch — was rejected: bangumi_version is the whole pipeline's
+// scheduling state, and rewriting it to trigger a one-off is a lasting change
+// made for a temporary reason.
+// ---------------------------------------------------------------------------
+
+func postReEnrichIDs(t *testing.T, h *EnrichmentHandlers, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/enrichment/re-enrich-ids",
+		strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ReEnrichIDs(rec, req)
+	return rec
+}
+
+func TestReEnrichIDs_EnqueuesV2ForBoundRows(t *testing.T) {
+	bgm := int32(555)
+	db := &fakeEnrichmentDB{
+		listBindings: func(_ context.Context, ids []int32) ([]dbgen.ListBgmBindingsForReEnrichRow, error) {
+			if len(ids) != 2 {
+				t.Errorf("ids=%v, want 2 after de-duplication", ids)
+			}
+			return []dbgen.ListBgmBindingsForReEnrichRow{
+				{AnilistID: 1, BgmID: &bgm},
+				{AnilistID: 2, BgmID: nil}, // in the catalogue, no binding
+			}, nil
+		},
+	}
+	enq := &spyEnqueuer{}
+	h := newEnrichmentHandlersWithFakes(db, enq, nil)
+
+	// 1 appears twice: river has no arg-hash dedupe, so a repeated id would
+	// spend a second upstream request writing what the first already wrote.
+	rec := postReEnrichIDs(t, h, `{"anilistIds":[1,2,1]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if len(enq.v2Calls) != 1 || len(enq.v2Calls[0]) != 1 {
+		t.Fatalf("want one V2 batch of one job, got %+v", enq.v2Calls)
+	}
+	if got := enq.v2Calls[0][0]; got.AnilistID != 1 || got.BgmID != 555 {
+		t.Fatalf("wrong job: %+v", got)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{`"requested":2`, `"enqueued":1`, `"noBinding":1`, `"notFound":0`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body %s missing %s", body, want)
+		}
+	}
+}
+
+func TestReEnrichIDs_CountsMissingAndUnboundApart(t *testing.T) {
+	// An operator who pasted a list needs to know whether they mistyped an id
+	// or whether the row is real but unbound. Those lead to different next
+	// actions, so one `skipped` number would answer neither.
+	db := &fakeEnrichmentDB{
+		listBindings: func(_ context.Context, _ []int32) ([]dbgen.ListBgmBindingsForReEnrichRow, error) {
+			return []dbgen.ListBgmBindingsForReEnrichRow{{AnilistID: 7, BgmID: nil}}, nil
+		},
+	}
+	h := newEnrichmentHandlersWithFakes(db, &spyEnqueuer{}, nil)
+	rec := postReEnrichIDs(t, h, `{"anilistIds":[7,8,9]}`)
+	body := rec.Body.String()
+	for _, want := range []string{`"requested":3`, `"enqueued":0`, `"notFound":2`, `"noBinding":1`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body %s missing %s", body, want)
+		}
+	}
+}
+
+func TestReEnrichIDs_RejectsBadInput(t *testing.T) {
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, nil)
+	big := make([]string, maxReEnrichIDs+1)
+	for i := range big {
+		big[i] = "1"
+	}
+	for name, body := range map[string]string{
+		"not json":     `{`,
+		"empty list":   `{"anilistIds":[]}`,
+		"zero id":      `{"anilistIds":[0]}`,
+		"negative id":  `{"anilistIds":[-3]}`,
+		"over the cap": `{"anilistIds":[` + strings.Join(big, ",") + `]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if rec := postReEnrichIDs(t, h, body); rec.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d, want 400 (body=%s)", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestReEnrichIDs_DoesNotEnqueueWhenTheReadFails(t *testing.T) {
+	db := &fakeEnrichmentDB{
+		listBindings: func(_ context.Context, _ []int32) ([]dbgen.ListBgmBindingsForReEnrichRow, error) {
+			return nil, errors.New("connection reset")
+		},
+	}
+	enq := &spyEnqueuer{}
+	h := newEnrichmentHandlersWithFakes(db, enq, nil)
+	if rec := postReEnrichIDs(t, h, `{"anilistIds":[1]}`); rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d, want 500", rec.Code)
+	}
+	if len(enq.v2Calls) != 0 {
+		t.Fatalf("a failed read must not enqueue anything, got %+v", enq.v2Calls)
 	}
 }

--- a/go-api/internal/db/gen/anime_cache.sql.go
+++ b/go-api/internal/db/gen/anime_cache.sql.go
@@ -2315,6 +2315,54 @@ func (q *Queries) ListAnimeForHantBackfill(ctx context.Context) ([]ListAnimeForH
 	return items, nil
 }
 
+const listBgmBindingsForReEnrich = `-- name: ListBgmBindingsForReEnrich :many
+SELECT anilist_id, bgm_id
+FROM anime_cache
+WHERE anilist_id = ANY($1::int[])
+`
+
+type ListBgmBindingsForReEnrichRow struct {
+	AnilistID int32  `json:"anilistId"`
+	BgmID     *int32 `json:"bgmId"`
+}
+
+// The bindings behind an explicit list of anilist_ids, for the admin
+// re-enrich-by-id path.
+//
+// It exists because ListAnimeForReEnrichByVersion cannot serve that path: it
+// selects by `bangumi_version`, and a row that has already completed V2 sits
+// at version 2 or 3 -- outside every branch of the version-keyed endpoint.  So
+// a fix that changes what V2 WRITES has no way to reach the rows V2 already
+// wrote.  That gap is the reason this query is here, and re-stamping 600 rows'
+// version to squeeze them back into the version=1 branch is the alternative it
+// exists to avoid: `bangumi_version` is the whole pipeline's scheduling state,
+// and rewriting it to trigger a one-off is a lasting change made for a
+// temporary reason.
+//
+// bgm_id comes back NULLABLE on purpose.  "not in the catalogue" and "in the
+// catalogue with no binding" are different answers for the operator who typed
+// the list, and collapsing them into a single `skipped` count hides which of
+// the two happened.  The caller reports them separately.
+func (q *Queries) ListBgmBindingsForReEnrich(ctx context.Context, anilistIds []int32) ([]ListBgmBindingsForReEnrichRow, error) {
+	rows, err := q.db.Query(ctx, listBgmBindingsForReEnrich, anilistIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListBgmBindingsForReEnrichRow{}
+	for rows.Next() {
+		var i ListBgmBindingsForReEnrichRow
+		if err := rows.Scan(&i.AnilistID, &i.BgmID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDescriptionCnCandidates = `-- name: ListDescriptionCnCandidates :many
 SELECT ac.anilist_id, ac.bgm_id
 FROM description_cn_eligible ac

--- a/go-api/internal/db/gen/querier.go
+++ b/go-api/internal/db/gen/querier.go
@@ -1099,6 +1099,24 @@ type Querier interface {
 	// In PG the column is `NOT NULL DEFAULT 0` (see 0001_init.up.sql:53) so
 	// "missing" is impossible — a single = 0 covers it.
 	ListAnimeForReEnrichByVersion(ctx context.Context, bangumiVersion int32) ([]ListAnimeForReEnrichByVersionRow, error)
+	// The bindings behind an explicit list of anilist_ids, for the admin
+	// re-enrich-by-id path.
+	//
+	// It exists because ListAnimeForReEnrichByVersion cannot serve that path: it
+	// selects by `bangumi_version`, and a row that has already completed V2 sits
+	// at version 2 or 3 -- outside every branch of the version-keyed endpoint.  So
+	// a fix that changes what V2 WRITES has no way to reach the rows V2 already
+	// wrote.  That gap is the reason this query is here, and re-stamping 600 rows'
+	// version to squeeze them back into the version=1 branch is the alternative it
+	// exists to avoid: `bangumi_version` is the whole pipeline's scheduling state,
+	// and rewriting it to trigger a one-off is a lasting change made for a
+	// temporary reason.
+	//
+	// bgm_id comes back NULLABLE on purpose.  "not in the catalogue" and "in the
+	// catalogue with no binding" are different answers for the operator who typed
+	// the list, and collapsing them into a single `skipped` count hides which of
+	// the two happened.  The caller reports them separately.
+	ListBgmBindingsForReEnrich(ctx context.Context, anilistIds []int32) ([]ListBgmBindingsForReEnrichRow, error)
 	// backfill.sql — one-time re-validation of existing bgm bindings
 	// (cmd/bgmbackfill).  The new matcher + dandanplay cross-check flag rows
 	// whose bgm_id is likely wrong; the apply step RESETS them so the fixed V1

--- a/go-api/internal/db/queries/anime_cache.sql
+++ b/go-api/internal/db/queries/anime_cache.sql
@@ -553,6 +553,28 @@ WHERE a.anilist_id = $1 AND a.bangumi_version = 0
                        WHERE b.bgm_id = $2::integer
                          AND b.anilist_id <> $1));
 
+-- name: ListBgmBindingsForReEnrich :many
+-- The bindings behind an explicit list of anilist_ids, for the admin
+-- re-enrich-by-id path.
+--
+-- It exists because ListAnimeForReEnrichByVersion cannot serve that path: it
+-- selects by `bangumi_version`, and a row that has already completed V2 sits
+-- at version 2 or 3 -- outside every branch of the version-keyed endpoint.  So
+-- a fix that changes what V2 WRITES has no way to reach the rows V2 already
+-- wrote.  That gap is the reason this query is here, and re-stamping 600 rows'
+-- version to squeeze them back into the version=1 branch is the alternative it
+-- exists to avoid: `bangumi_version` is the whole pipeline's scheduling state,
+-- and rewriting it to trigger a one-off is a lasting change made for a
+-- temporary reason.
+--
+-- bgm_id comes back NULLABLE on purpose.  "not in the catalogue" and "in the
+-- catalogue with no binding" are different answers for the operator who typed
+-- the list, and collapsing them into a single `skipped` count hides which of
+-- the two happened.  The caller reports them separately.
+SELECT anilist_id, bgm_id
+FROM anime_cache
+WHERE anilist_id = ANY(sqlc.arg(anilist_ids)::int[]);
+
 -- name: CountAnimeBoundToBgmID :one
 -- How many OTHER anime already hold this Bangumi subject.
 --


### PR DESCRIPTION
`re-enrich?version=N` cannot reach a row that has already completed V2. Its
three branches select by `bangumi_version` — 0, 1, 2 — so a finished row sits
at 2 or 3, outside all of them. **A change to what V2 writes has no trigger
that reaches what V2 already wrote.**

Measured 2026-09-05, of the 663 anime still holding out-of-range episode-title
rows: **617 at version 3, 46 at version 2, none at version 1.**

This is the same ceiling PR #105 and #108 each hit from the other side, and it
has now cost three rounds — the fix lands, and nothing triggers it over the
data that needed it.

```
POST /api/admin/enrichment/re-enrich-ids
{"anilistIds": [136862, 210031, ...]}

→ {"requested": 2, "enqueued": 1, "notFound": 0, "noBinding": 1}
```

## The alternative I rejected

Re-stamping those rows' `bangumi_version` to squeeze them into the `version=1`
branch. `bangumi_version` is the whole pipeline's scheduling state; rewriting
it to trigger a one-off is a lasting change made for a temporary reason, and
it would have needed a second pass afterwards to put the 617 rows back to v3.

## Three deliberate choices

- **Capped at 1,000.** The version-keyed endpoint is uncapped because its input
  is a query the database answers; this one's is typed by a person.
- **Ids are de-duplicated before the query.** river has no arg-hash dedupe, so
  a repeated id spends a second upstream request writing what the first wrote.
- **`notFound` and `noBinding` are counted apart.** One `skipped` number would
  answer neither question an operator has after pasting a list.

## Test plan

- [x] `go build ./...`, `go vet ./internal/admin/`,
      `go vet -tags=integration ./test/integration/...`
- [x] Four fake-based tests: enqueue + dedupe, the two skip reasons counted
      apart, four bad-input shapes, and "a failed read enqueues nothing"
- [ ] **Not run locally.** `internal/admin`'s TestMain starts a postgres
      testcontainer and Docker is unavailable in this environment, so CI is the
      first execution of these tests.