### PR TITLE
A concurrent push must not rewind a reader's progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 ---
 
+## [3.30.0] - 2026-09-06
+
+### ★★ 修完 500 之后，同一条 e2e 又红了——这次是「看到第 3 集」被并发写回 0
+
+#159 修掉 `POST /api/subscriptions` 的 500 之后，`library-watch-sync.spec.ts:274` 仍然失败，但形态变了：订阅建出来了、状态是 `watching`，**`currentEpisode` 是 0，不是 3**。那次运行的服务日志里**一个 500 都没有**（修生效了），有的是两次几乎同时的 `PUT /api/subscriptions/900201/episodes`，双双 200。
+
+### 快照问题的第二种形态：坏掉的不是行数，是那个数
+
+`MarkEpisodesWatched` 对自己的快照是很小心的——`watched` 特意 UNION 了 `inserted`，注释写明「plain SELECT 看不见本语句刚写的行」。但它只补得上**自己**那一半：
+
+```
+target      SELECT ... FOR UPDATE                    ← 两个 PUT 在这里串行
+inserted    INSERT ... ON CONFLICT DO NOTHING
+watched     SELECT FROM episode_watches ∪ inserted   ← 仍然走自己的快照
+recomputed  UPDATE ... SET current_episode = MAX(watched)
+```
+
+后到的那次在 `FOR UPDATE` 上等，等完之后**继续用开始等之前取的那个快照**——赢家写进 `episode_watches` 的三行在它眼里不存在。它自己要插的第 1 集撞键、`inserted` 为空、`watched` 为空，于是 `MAX(空集) = 0` 被写进 `current_episode`。
+
+★★ **集合确实只增不减，倒退的是从集合派生出来的那个数。** 这条查询的注释用大写字母写着 IT UNIONS. IT NEVER REPLACES —— 说的是集合，破的是数字。开两个标签页就够了。
+
+### 改法：拿一个不受快照约束的值兜底
+
+`s.current_episode` 是这条语句里唯一不受快照约束的值——READ COMMITTED 下 UPDATE 会**对并发写方提交后的最新行版本重新求值**。所以两个 mark 查询改成
+
+```sql
+SET current_episode = GREATEST(s.current_episode, (SELECT COALESCE(MAX(...)) FROM watched))
+```
+
+这正是它自己那条契约（只增不减）套用到派生值上。降低仍然只发生在 `UnmarkEpisodeWatched`，那条**故意不加**下界——加了就变成删不掉。
+
+先确认过没有语义冲突：migration 0024 把 `1..current_episode` 回填进了集合，`current_episode = MAX(集合)` 从那一刻起处处成立，`GREATEST` 只在读不全时才与原式不同——也就是只在竞态里。
+
+### 测试同样是把竞态摁住
+
+一个事务写 1/2/3 挂起不提交；另一个 goroutine 推第 1 集，撞在行锁上；主 goroutine 轮询 `pg_stat_activity` 确认真堵住了才提交。修前 **3 → 0**，与线上完全一致；修后 3。单集入口是另一条查询，单独一条测试——**只回滚其中一条，另一条的测试照样绿**，两个变异各自被自己那条杀掉。
+
+### ★ 未修，写进注释而不是糊过去
+
+`UnmarkEpisodeWatched` 有镜像的暴露面：取消标记若与「标记更高集」并发，会算出一个低于真实集合的值。**不加下界是故意的**（那会让取消标记无法生效），理由三条写在查询注释里：需要同一个人同时在两处一标一取消；集合本身没丢；下一次任何写入都会重算回来。
+
+---
+
 ## [3.29.0] - 2026-09-06
 
 ### ★★ 那个「大概是 flake」的 500，是一条真的并发缺陷

--- a/go-api/internal/db/gen/subscriptions.sql.go
+++ b/go-api/internal/db/gen/subscriptions.sql.go
@@ -373,7 +373,27 @@ WITH target AS (
     SELECT i.episode FROM inserted i
 ), recomputed AS (
     UPDATE subscriptions s
-    SET current_episode = (SELECT COALESCE(MAX(w.episode), 0) FROM watched w),
+    -- GREATEST, not the bare recompute, and ` + "`" + `target` + "`" + ` is what makes it safe.
+    --
+    -- ` + "`" + `watched` + "`" + ` above closes this statement's OWN snapshot gap. It cannot
+    -- close a concurrent transaction's: two overlapping pushes serialise on
+    -- the FOR UPDATE in ` + "`" + `target` + "`" + `, and the loser then resumes on the snapshot
+    -- it took BEFORE it began waiting, where the winner's episode_watches
+    -- rows do not exist. Its own inserts all conflict, ` + "`" + `inserted` + "`" + ` comes back
+    -- empty, and the bare recompute would write MAX over nothing -- sending a
+    -- reader on episode 3 back to 0. Measured 2026-09-06; two tabs is enough.
+    --
+    -- s.current_episode is read from the LATEST row version (READ COMMITTED
+    -- re-evaluates an UPDATE against the row the concurrent writer committed),
+    -- so it is the one value in this statement that is not snapshot-bound.
+    -- Taking the maximum of the two is exactly the contract stated above --
+    -- this statement unions, it never replaces -- applied to the number
+    -- DERIVED from the set as well as to the set itself. Lowering stays where
+    -- it belongs, in UnmarkEpisodeWatched, which recomputes without a floor.
+    SET current_episode = GREATEST(
+            s.current_episode,
+            (SELECT COALESCE(MAX(w.episode), 0) FROM watched w)
+        ),
         last_watched_at = CASE
                               WHEN EXISTS (SELECT 1 FROM inserted) THEN now()
                               ELSE s.last_watched_at
@@ -510,7 +530,27 @@ WITH target AS (
     SELECT i.episode FROM inserted i
 ), recomputed AS (
     UPDATE subscriptions s
-    SET current_episode = (SELECT COALESCE(MAX(w.episode), 0) FROM watched w),
+    -- GREATEST, not the bare recompute, and ` + "`" + `target` + "`" + ` is what makes it safe.
+    --
+    -- ` + "`" + `watched` + "`" + ` above closes this statement's OWN snapshot gap. It cannot
+    -- close a concurrent transaction's: two overlapping pushes serialise on
+    -- the FOR UPDATE in ` + "`" + `target` + "`" + `, and the loser then resumes on the snapshot
+    -- it took BEFORE it began waiting, where the winner's episode_watches
+    -- rows do not exist. Its own inserts all conflict, ` + "`" + `inserted` + "`" + ` comes back
+    -- empty, and the bare recompute would write MAX over nothing -- sending a
+    -- reader on episode 3 back to 0. Measured 2026-09-06; two tabs is enough.
+    --
+    -- s.current_episode is read from the LATEST row version (READ COMMITTED
+    -- re-evaluates an UPDATE against the row the concurrent writer committed),
+    -- so it is the one value in this statement that is not snapshot-bound.
+    -- Taking the maximum of the two is exactly the contract stated above --
+    -- this statement unions, it never replaces -- applied to the number
+    -- DERIVED from the set as well as to the set itself. Lowering stays where
+    -- it belongs, in UnmarkEpisodeWatched, which recomputes without a floor.
+    SET current_episode = GREATEST(
+            s.current_episode,
+            (SELECT COALESCE(MAX(w.episode), 0) FROM watched w)
+        ),
         last_watched_at = CASE
                               WHEN EXISTS (SELECT 1 FROM inserted) THEN now()
                               ELSE s.last_watched_at
@@ -622,6 +662,18 @@ WITH target AS (
     EXCEPT
     SELECT d.episode FROM deleted d
 ), recomputed AS (
+    -- No GREATEST here, deliberately: lowering is this statement's entire
+    -- job, and a floor would make removal unable to remove.
+    --
+    -- The consequence is that the snapshot exposure the two mark queries were
+    -- given a floor against is still open in this one, mirrored: an unmark
+    -- overlapping a mark of a HIGHER episode computes its maximum without
+    -- seeing that mark, and lands a value below the real set.  It is left
+    -- open rather than papered over, on three grounds -- it needs one reader
+    -- ticking and unticking the same title from two places at the same
+    -- instant; nothing is lost, since episode_watches still holds the mark;
+    -- and the next write of any kind recomputes over both.  A floor here
+    -- would trade a rare wrong number for a permanently unremovable one.
     UPDATE subscriptions s
     SET current_episode = (SELECT COALESCE(MAX(w.episode), 0) FROM watched w),
         updated_at      = CASE

--- a/go-api/internal/db/queries/subscriptions.sql
+++ b/go-api/internal/db/queries/subscriptions.sql
@@ -518,7 +518,27 @@ WITH target AS (
     SELECT i.episode FROM inserted i
 ), recomputed AS (
     UPDATE subscriptions s
-    SET current_episode = (SELECT COALESCE(MAX(w.episode), 0) FROM watched w),
+    -- GREATEST, not the bare recompute, and `target` is what makes it safe.
+    --
+    -- `watched` above closes this statement's OWN snapshot gap. It cannot
+    -- close a concurrent transaction's: two overlapping pushes serialise on
+    -- the FOR UPDATE in `target`, and the loser then resumes on the snapshot
+    -- it took BEFORE it began waiting, where the winner's episode_watches
+    -- rows do not exist. Its own inserts all conflict, `inserted` comes back
+    -- empty, and the bare recompute would write MAX over nothing -- sending a
+    -- reader on episode 3 back to 0. Measured 2026-09-06; two tabs is enough.
+    --
+    -- s.current_episode is read from the LATEST row version (READ COMMITTED
+    -- re-evaluates an UPDATE against the row the concurrent writer committed),
+    -- so it is the one value in this statement that is not snapshot-bound.
+    -- Taking the maximum of the two is exactly the contract stated above --
+    -- this statement unions, it never replaces -- applied to the number
+    -- DERIVED from the set as well as to the set itself. Lowering stays where
+    -- it belongs, in UnmarkEpisodeWatched, which recomputes without a floor.
+    SET current_episode = GREATEST(
+            s.current_episode,
+            (SELECT COALESCE(MAX(w.episode), 0) FROM watched w)
+        ),
         last_watched_at = CASE
                               WHEN EXISTS (SELECT 1 FROM inserted) THEN now()
                               ELSE s.last_watched_at
@@ -619,7 +639,27 @@ WITH target AS (
     SELECT i.episode FROM inserted i
 ), recomputed AS (
     UPDATE subscriptions s
-    SET current_episode = (SELECT COALESCE(MAX(w.episode), 0) FROM watched w),
+    -- GREATEST, not the bare recompute, and `target` is what makes it safe.
+    --
+    -- `watched` above closes this statement's OWN snapshot gap. It cannot
+    -- close a concurrent transaction's: two overlapping pushes serialise on
+    -- the FOR UPDATE in `target`, and the loser then resumes on the snapshot
+    -- it took BEFORE it began waiting, where the winner's episode_watches
+    -- rows do not exist. Its own inserts all conflict, `inserted` comes back
+    -- empty, and the bare recompute would write MAX over nothing -- sending a
+    -- reader on episode 3 back to 0. Measured 2026-09-06; two tabs is enough.
+    --
+    -- s.current_episode is read from the LATEST row version (READ COMMITTED
+    -- re-evaluates an UPDATE against the row the concurrent writer committed),
+    -- so it is the one value in this statement that is not snapshot-bound.
+    -- Taking the maximum of the two is exactly the contract stated above --
+    -- this statement unions, it never replaces -- applied to the number
+    -- DERIVED from the set as well as to the set itself. Lowering stays where
+    -- it belongs, in UnmarkEpisodeWatched, which recomputes without a floor.
+    SET current_episode = GREATEST(
+            s.current_episode,
+            (SELECT COALESCE(MAX(w.episode), 0) FROM watched w)
+        ),
         last_watched_at = CASE
                               WHEN EXISTS (SELECT 1 FROM inserted) THEN now()
                               ELSE s.last_watched_at
@@ -688,6 +728,18 @@ WITH target AS (
     EXCEPT
     SELECT d.episode FROM deleted d
 ), recomputed AS (
+    -- No GREATEST here, deliberately: lowering is this statement's entire
+    -- job, and a floor would make removal unable to remove.
+    --
+    -- The consequence is that the snapshot exposure the two mark queries were
+    -- given a floor against is still open in this one, mirrored: an unmark
+    -- overlapping a mark of a HIGHER episode computes its maximum without
+    -- seeing that mark, and lands a value below the real set.  It is left
+    -- open rather than papered over, on three grounds -- it needs one reader
+    -- ticking and unticking the same title from two places at the same
+    -- instant; nothing is lost, since episode_watches still holds the mark;
+    -- and the next write of any kind recomputes over both.  A floor here
+    -- would trade a rare wrong number for a permanently unremovable one.
     UPDATE subscriptions s
     SET current_episode = (SELECT COALESCE(MAX(w.episode), 0) FROM watched w),
         updated_at      = CASE

--- a/go-api/internal/subscriptions/pg_test.go
+++ b/go-api/internal/subscriptions/pg_test.go
@@ -834,6 +834,142 @@ func TestPG_Create_IfAbsentOmitted_StillUpserts(t *testing.T) {
 		"the explicit Subscribe button still overwrites status — only ifAbsent changes that")
 }
 
+// TestPG_MarkEpisodesWatched_ConcurrentPushCannotRewindProgress is the
+// regression test for the second half of the sandbox failure on 2026-09-05:
+// with the create race fixed, `library-watch-sync.spec.ts:274` still ended
+// with `currentEpisode: 0` where it had written three episodes, and the
+// service log shows two overlapping PUT .../episodes for that title, both 200.
+//
+// The query is careful about its own snapshot -- `watched` UNIONs `inserted`
+// precisely because a plain SELECT cannot see what the same statement just
+// wrote -- but that only covers this statement's writes, not a concurrent
+// transaction's.  `target` takes FOR UPDATE, so the two pushes serialise on
+// the subscription row; the loser then resumes on the snapshot it took before
+// it began waiting, where the winner's episode_watches rows do not exist.  Its
+// own inserts all conflict, `inserted` is empty, `watched` is empty, and the
+// recompute writes MAX over nothing.
+//
+// So a reader with two tabs open loses their progress to whichever push
+// carries the smaller set -- against a query whose own comment says, in
+// capitals, that it unions and never replaces.  The set really does only grow;
+// it is the number DERIVED from the set that went backwards.
+func TestPG_MarkEpisodesWatched_ConcurrentPushCannotRewindProgress(t *testing.T) {
+	h, pool := pgHandlers(t)
+	defer pool.Close()
+
+	ctx := context.Background()
+	user := seedUser(t, pool, "alice", "alice@example.com")
+	seedAnime(t, pool, 1, "A", "甲")
+	seedSubscription(t, pool, user, 1, "watching")
+
+	// The winner: three episodes, committed only once the loser is waiting.
+	holder, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = holder.Rollback(ctx) }()
+	held, err := dbgen.New(holder).MarkEpisodesWatched(ctx, user, 1, []int32{1, 2, 3})
+	require.NoError(t, err)
+	require.Equal(t, int32(3), held.CurrentEpisode, "the winner writes 3 inside its transaction")
+
+	// The loser: a push carrying an episode the winner already covers.
+	type res struct {
+		row dbgen.MarkEpisodesWatchedRow
+		err error
+	}
+	done := make(chan res, 1)
+	go func() {
+		row, err := h.Queries.MarkEpisodesWatched(context.Background(), user, 1, []int32{1})
+		done <- res{row, err}
+	}()
+
+	requireBlockedOnMark(t, pool, "MarkEpisodesWatched")
+	require.NoError(t, holder.Commit(ctx))
+
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		assert.Equal(t, int32(3), got.row.CurrentEpisode,
+			"the losing push must not report progress the reader never lost")
+	case <-time.After(20 * time.Second):
+		t.Fatal("the second push never returned")
+	}
+
+	ep, _ := readProgress(t, pool, user, 1)
+	assert.Equal(t, int32(3), ep, "a push of episode 1 cannot rewind a reader who is on 3")
+
+	var marks int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT count(*) FROM episode_watches WHERE user_id = $1 AND anilist_id = 1`, user).Scan(&marks))
+	assert.Equal(t, 3, marks, "the set itself was never in question")
+}
+
+// The single-episode door has the same exposure and the same fix: a checkbox
+// on one tab must not undo a sync on another.  It is a separate query, so it
+// needs a separate test — reverting either recompute on its own leaves the
+// other's test green.
+func TestPG_MarkEpisodeWatched_ConcurrentPushCannotRewindProgress(t *testing.T) {
+	h, pool := pgHandlers(t)
+	defer pool.Close()
+
+	ctx := context.Background()
+	user := seedUser(t, pool, "alice", "alice@example.com")
+	seedAnime(t, pool, 1, "A", "甲")
+	seedSubscription(t, pool, user, 1, "watching")
+
+	holder, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = holder.Rollback(ctx) }()
+	held, err := dbgen.New(holder).MarkEpisodesWatched(ctx, user, 1, []int32{1, 2, 3})
+	require.NoError(t, err)
+	require.Equal(t, int32(3), held.CurrentEpisode)
+
+	type res struct {
+		row dbgen.MarkEpisodeWatchedRow
+		err error
+	}
+	done := make(chan res, 1)
+	go func() {
+		row, err := h.Queries.MarkEpisodeWatched(context.Background(), user, 1, 1)
+		done <- res{row, err}
+	}()
+
+	requireBlockedOnMark(t, pool, "MarkEpisodeWatched")
+	require.NoError(t, holder.Commit(ctx))
+
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		assert.Equal(t, int32(3), got.row.CurrentEpisode,
+			"ticking episode 1 must not report the reader back at 1")
+	case <-time.After(20 * time.Second):
+		t.Fatal("the single-episode mark never returned")
+	}
+
+	ep, _ := readProgress(t, pool, user, 1)
+	assert.Equal(t, int32(3), ep, "ticking an episode already in the set cannot rewind progress")
+}
+
+// requireBlockedOnMark blocks until a backend other than this one is waiting
+// on a lock inside the named query.  sqlc keeps the `-- name:` header in the
+// statement text it sends, so the query is identifiable by name.
+func requireBlockedOnMark(t *testing.T, pool *pgxpool.Pool, queryName string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		var n int
+		require.NoError(t, pool.QueryRow(context.Background(), `
+			SELECT count(*)
+			FROM pg_stat_activity
+			WHERE pid <> pg_backend_pid()
+			  AND wait_event_type = 'Lock'
+			  AND query LIKE '%' || $1 || '%'`, queryName).Scan(&n))
+		if n > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("no backend ever blocked inside %s — the race this test needs did not happen", queryName)
+}
+
 func TestPG_Delete_RemovesRow(t *testing.T) {
 	h, pool := pgHandlers(t)
 	defer pool.Close()


### PR DESCRIPTION
## What this is

The other half of the sandbox failure. With #159's 500 fixed, `library-watch-sync.spec.ts:274` **still failed** — but differently: the subscription existed, status `watching`, `currentEpisode: 0` where three episodes had just been written.

That run's service log carries **no 500 at all** — #159 is working. What it carries is two overlapping `PUT /api/subscriptions/900201/episodes`, both 200:

```
16:09:55.088  PUT .../900201/episodes  404   (no subscription yet)
16:09:55.124  POST /api/subscriptions  201   (created)
16:09:55.279  PUT .../900201/episodes  200
16:09:55.281  PUT .../900201/episodes  200   ← and progress ends at 0
```

## The same snapshot problem, wrecking a number instead of a row count

`MarkEpisodesWatched` is careful about its own snapshot — `watched` UNIONs `inserted` precisely because a plain SELECT cannot see what the same statement just wrote. That covers *this statement's* writes. It cannot cover a concurrent transaction's.

```
target      SELECT ... FOR UPDATE                    ← the two pushes serialise here
inserted    INSERT ... ON CONFLICT DO NOTHING
watched     SELECT FROM episode_watches ∪ inserted   ← still its own snapshot
recomputed  UPDATE ... SET current_episode = MAX(watched)
```

The loser blocks on the row lock, then resumes on the snapshot it took **before** it began waiting, where the winner's `episode_watches` rows do not exist. Its own inserts all conflict, `inserted` is empty, `watched` is empty, and the recompute writes `MAX(∅) = 0`.

The set really does only grow. What went backwards is the number *derived* from the set — under a query whose own comment says, in capitals, that it unions and never replaces. **Two tabs is enough to lose your progress.**

## The fix

`s.current_episode` is the one value in the statement that is not snapshot-bound: READ COMMITTED re-evaluates an UPDATE against the row version the concurrent writer committed. Both mark queries now take

```sql
SET current_episode = GREATEST(s.current_episode, (SELECT COALESCE(MAX(...)) FROM watched))
```

which is that stated contract applied to the derived value as well as to the set. Lowering stays where it belongs, in `UnmarkEpisodeWatched`, which keeps no floor.

**Nothing is traded away.** Migration 0024 backfilled `1..current_episode` into the set, so `current_episode = MAX(set)` holds everywhere; `GREATEST` differs from the bare recompute only when the read is incomplete — that is, only in the race. `TestPG_UnmarkIsHowProgressComesDown` and `TestPG_Update_NonMonotonicNoLongerLowersProgress` both still pass.

## Tests hold the race open

Same technique as #159: a transaction writes 1/2/3 and hangs; the other push blocks on the row lock; the test polls `pg_stat_activity` until it can see that, then commits. **3 → 0 before the fix, 3 after** — the same number the sandbox reported.

The single-episode door is a separate query and gets a separate test: reverting either recompute alone leaves the other's test green. Both mutations are killed by their own test and only their own.

## Left open on purpose

`UnmarkEpisodeWatched` has the mirror exposure — an unmark overlapping a mark of a *higher* episode computes without seeing it. No floor there, deliberately: a floor would make removal unable to remove. The three reasons are written into the query: it needs one reader ticking and unticking the same title from two places at the same instant, nothing is lost because `episode_watches` still holds the mark, and the next write of any kind recomputes over both.

## Test plan

- [x] `go test ./...` — 35 packages
- [x] `go vet ./...` and `go vet -tags=integration ./test/...`
- [x] Both new PG concurrency tests red before / green after
- [x] Mutation testing: reverting each recompute is killed by its own test
- [ ] E2E Sandbox — this is the change that should stop `library-watch-sync.spec.ts:274` failing