### PR TITLE
Restamp the app tree before retrying a warmup 404

### DIFF
--- a/.github/workflows/e2e-sandbox.yml
+++ b/.github/workflows/e2e-sandbox.yml
@@ -267,6 +267,24 @@ jobs:
             for attempt in $(seq 1 10); do
               code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 120 "http://localhost:3000${route}")
               [ "$code" = "$want" ] && break
+              # Nudge the watcher before retrying, from the third attempt on -
+              # two clean tries first, so an ordinary slow boot is unaffected.
+              #
+              # The dev-server defect this loop documents is a segment under
+              # [lang] that never gets compiled: the router answers 404 without
+              # building it, and plain retries never change that because
+              # nothing has told Turbopack the tree is dirty. Restamping the
+              # page files does tell it, and that is the whole remedy -- no
+              # content changes, and a run that was going to pass is not
+              # affected because it has already broken out of this loop.
+              #
+              # A few dozen utimes calls against a tree already in page
+              # cache, and only from attempt 3, so the cost lands on runs that
+              # are failing anyway.
+              if [ "$attempt" -ge 3 ]; then
+                find next-app/src/app -name 'page.tsx' -o -name 'layout.tsx' \
+                  | xargs -r touch || true
+              fi
               sleep 3
             done
             echo "warmed ${route} -> ${code} (want ${want}, attempt ${attempt})"


### PR DESCRIPTION
## Why

The sandbox job's warmup step has failed on `/seasonal/spring/2026` on its first attempt in **6 of the last 11 runs** — on `main`, and on branches whose diffs are a Go test file and a SQL comment. It is the dev-server defect the loop already documents: a segment under `[lang]` is never compiled, and the router answers 404 without building it.

Retrying does not recover, and the reason is mechanical: nothing between one `curl` and the next tells Turbopack its tree is dirty.

```
33977729076  failure  [warmup]
33976572638  failure  [warmup, then the suite on rerun]
33975268204  failure  [warmup, green on rerun]
33974926843  failure  [warmup]
33970548064  failure  [warmup]   ← main, no PR involved
33970166313  failure  [suite]
33962760262  success
33962120966  success
33961967910  failure  [warmup]
33936053874  failure  [suite]
33933901211  success
```

## What this does

From the **third** attempt on, the loop restamps every `page.tsx` and `layout.tsx` (28 files) before retrying. No content changes.

- Two clean attempts run first, so an ordinary slow boot is unaffected.
- A run that was going to pass has already broken out of the loop and never pays for this.
- Cost when it does run is a few dozen `utimes` calls on a tree already in page cache — on a run that is failing anyway.

## What I am not claiming

That this fixes it. Restamping has recovered this state when done by hand, which is why it is worth trying, but one CI run cannot establish that and I am not going to report it as established. **If the warmup keeps failing at the same rate, the hypothesis is wrong and this should come back out** rather than accumulate more retries around it.

The same step's diagnostic text was corrected in #159 for the opposite reason: every log-shape rule tried so far has had a counter-example, so it now points the reader at running `next dev` locally instead of asserting a signature.

## Test plan

- [x] `yaml.safe_load` on the workflow
- [x] `find next-app/src/app -name page.tsx -o -name layout.tsx` matches 28 files at the repo root, which is where this step runs
- [ ] The warmup failure rate over the next several sandbox runs — the only thing that can actually answer this
