### PR TITLE
The Bangumi branch never withdrew what it stopped holding

### DIFF
--- a/go-api/internal/db/gen/anime_cache.sql.go
+++ b/go-api/internal/db/gen/anime_cache.sql.go
@@ -2479,6 +2479,57 @@ func (q *Queries) ListDescriptionCnLlmCandidates(ctx context.Context, retryAfter
 	return items, nil
 }
 
+const listEpisodeTitleEpisodesBySource = `-- name: ListEpisodeTitleEpisodesBySource :many
+SELECT episode
+  FROM anime_episode_titles
+ WHERE anime_id = $1::int
+   AND (name_cn_source = $2::text
+        OR name_source = $2::text)
+ ORDER BY episode
+`
+
+// The episode numbers one source currently holds a field on, for one anime.
+//
+// ClearEpisodeTitlesBySourceOutside decides what to withdraw from the kept-set
+// alone: everything this source owns and the caller did not re-state goes.
+// That is the right rule for a writer that fetches a whole subject every time
+// and can therefore treat its own silence as a retraction.  It is the wrong
+// rule for one whose list is routinely INCOMPLETE rather than shorter: on
+// 2026-09-06 production held 90,241 Bangumi-sourced rows across 6,041 anime,
+// of which 1,219 already hold fewer rows than their own season's episode
+// count and 282 have holes in the middle.  Sparse is the normal shape, so a
+// fetch that comes back with six of twelve episodes is not evidence that the
+// other six stopped existing.
+//
+// Reading the held set first is what lets the caller tell the two apart
+// without guessing: an episode outside the kept-set AND outside the season's
+// window cannot belong to this entry whatever upstream is doing today, while
+// one outside the kept-set but INSIDE the window is exactly the row a partial
+// fetch would erase.  The first is withdrawn; the second is added back to the
+// kept-set and survives.  See internal/queue/episode_titles_retract.go.
+//
+// Ordered so the caller's set arithmetic and the logs it emits are stable
+// between passes; the scan is anime_id-prefixed on the primary key.
+func (q *Queries) ListEpisodeTitleEpisodesBySource(ctx context.Context, animeID int32, source string) ([]int32, error) {
+	rows, err := q.db.Query(ctx, listEpisodeTitleEpisodesBySource, animeID, source)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []int32{}
+	for rows.Next() {
+		var episode int32
+		if err := rows.Scan(&episode); err != nil {
+			return nil, err
+		}
+		items = append(items, episode)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listEpisodesBgmCandidates = `-- name: ListEpisodesBgmCandidates :many
 SELECT
     ac.anilist_id,

--- a/go-api/internal/db/gen/querier.go
+++ b/go-api/internal/db/gen/querier.go
@@ -1266,6 +1266,29 @@ type Querier interface {
 	// LIMIT 500 caps abuse (Express has no limit; we add one because
 	// pulling 50k rows on a popular episode would blow the response).
 	ListEpisodeComments(ctx context.Context, anilistID int32, episode int32, viewerUserID *uuid.UUID) ([]ListEpisodeCommentsRow, error)
+	// The episode numbers one source currently holds a field on, for one anime.
+	//
+	// ClearEpisodeTitlesBySourceOutside decides what to withdraw from the kept-set
+	// alone: everything this source owns and the caller did not re-state goes.
+	// That is the right rule for a writer that fetches a whole subject every time
+	// and can therefore treat its own silence as a retraction.  It is the wrong
+	// rule for one whose list is routinely INCOMPLETE rather than shorter: on
+	// 2026-09-06 production held 90,241 Bangumi-sourced rows across 6,041 anime,
+	// of which 1,219 already hold fewer rows than their own season's episode
+	// count and 282 have holes in the middle.  Sparse is the normal shape, so a
+	// fetch that comes back with six of twelve episodes is not evidence that the
+	// other six stopped existing.
+	//
+	// Reading the held set first is what lets the caller tell the two apart
+	// without guessing: an episode outside the kept-set AND outside the season's
+	// window cannot belong to this entry whatever upstream is doing today, while
+	// one outside the kept-set but INSIDE the window is exactly the row a partial
+	// fetch would erase.  The first is withdrawn; the second is added back to the
+	// kept-set and survives.  See internal/queue/episode_titles_retract.go.
+	//
+	// Ordered so the caller's set arithmetic and the logs it emits are stable
+	// between passes; the scan is anime_id-prefixed on the primary key.
+	ListEpisodeTitleEpisodesBySource(ctx context.Context, animeID int32, source string) ([]int32, error)
 	// Rows whose episode count is unknown to AniList and whose Bangumi binding
 	// might be able to supply one.
 	//

--- a/go-api/internal/db/queries/anime_cache.sql
+++ b/go-api/internal/db/queries/anime_cache.sql
@@ -1924,6 +1924,36 @@ DELETE FROM anime_episode_titles
    AND name_cn IS NULL
    AND name IS NULL;
 
+-- name: ListEpisodeTitleEpisodesBySource :many
+-- The episode numbers one source currently holds a field on, for one anime.
+--
+-- ClearEpisodeTitlesBySourceOutside decides what to withdraw from the kept-set
+-- alone: everything this source owns and the caller did not re-state goes.
+-- That is the right rule for a writer that fetches a whole subject every time
+-- and can therefore treat its own silence as a retraction.  It is the wrong
+-- rule for one whose list is routinely INCOMPLETE rather than shorter: on
+-- 2026-09-06 production held 90,241 Bangumi-sourced rows across 6,041 anime,
+-- of which 1,219 already hold fewer rows than their own season's episode
+-- count and 282 have holes in the middle.  Sparse is the normal shape, so a
+-- fetch that comes back with six of twelve episodes is not evidence that the
+-- other six stopped existing.
+--
+-- Reading the held set first is what lets the caller tell the two apart
+-- without guessing: an episode outside the kept-set AND outside the season's
+-- window cannot belong to this entry whatever upstream is doing today, while
+-- one outside the kept-set but INSIDE the window is exactly the row a partial
+-- fetch would erase.  The first is withdrawn; the second is added back to the
+-- kept-set and survives.  See internal/queue/episode_titles_retract.go.
+--
+-- Ordered so the caller's set arithmetic and the logs it emits are stable
+-- between passes; the scan is anime_id-prefixed on the primary key.
+SELECT episode
+  FROM anime_episode_titles
+ WHERE anime_id = sqlc.arg(anime_id)::int
+   AND (name_cn_source = sqlc.arg(source)::text
+        OR name_source = sqlc.arg(source)::text)
+ ORDER BY episode;
+
 -- name: ListReleasingEpisodeTitleCandidates :many
 -- The airing shows whose episode titles are due another look.
 --

--- a/go-api/internal/queue/episode_titles_releasing.go
+++ b/go-api/internal/queue/episode_titles_releasing.go
@@ -174,7 +174,7 @@ func (w *EpisodeTitlesWorker) Work(ctx context.Context, _ *river.Job[EpisodeTitl
 		return nil
 	}
 
-	var accepted, written, retracted, rejected, empty, failed int
+	var accepted, written, retracted, shielded, rejected, empty, failed int
 	for _, row := range rows {
 		if row.BgmID == nil {
 			continue // the query's predicate guarantees this
@@ -185,6 +185,7 @@ func (w *EpisodeTitlesWorker) Work(ctx context.Context, _ *river.Job[EpisodeTitl
 			accepted++
 			written += res.written
 			retracted += res.retracted
+			shielded += res.shielded
 		case sweepRejected:
 			rejected++
 			w.stampAttempt(ctx, row.AnilistID, *row.BgmID)
@@ -201,6 +202,7 @@ func (w *EpisodeTitlesWorker) Work(ctx context.Context, _ *river.Job[EpisodeTitl
 		"accepted", accepted,
 		"titlesWritten", written,
 		"rowsRetracted", retracted,
+		"rowsShielded", shielded,
 		"rejected", rejected,
 		"empty", empty,
 		"failed", failed,
@@ -221,6 +223,12 @@ type sweepResult struct {
 	class     sweepClass
 	written   int
 	retracted int
+	// shielded counts rows the withdrawal declined to take because they sit
+	// inside the season's window -- the number that says how often a Bangumi
+	// fetch came back shorter than what we already hold.  It is reported and
+	// not acted on: a review queue for these is only worth building once the
+	// pass has shown the number is not zero.
+	shielded int
 }
 
 // sweepOne handles a single anime, applying the same identity rule the CLI
@@ -402,10 +410,30 @@ func (w *EpisodeTitlesWorker) sweepViaBangumi(ctx context.Context, anilistID, bg
 		slog.WarnContext(ctx, "episode_titles bangumi fallback partial",
 			"anilistId", anilistID, "bgmId", bgmID, "written", written, "failures", failures)
 	}
+
+	// The withdrawal the dandanplay branch has always done, on the branch that
+	// never did it.  Best-effort like the write it follows: it runs in its own
+	// transaction after the upserts have landed, so a failure here costs the
+	// withdrawal and not the titles, and the row is still stamped -- an
+	// un-stamped row would come back at the head of every batch and re-spend
+	// two Bangumi requests to retry an optional cleanup.
+	retracted, shielded, rerr := episodeTitleRetractor{pool: w.pool, q: w.q}.
+		retract(ctx, anilistID, keptEpisodes(titles), total)
+	if rerr != nil {
+		slog.WarnContext(ctx, "episode_titles bangumi retract failed",
+			"anilistId", anilistID, "bgmId", bgmID, "err", rerr)
+	}
+
 	slog.InfoContext(ctx, "episode_titles via bangumi",
-		"anilistId", anilistID, "bgmId", bgmID, "written", written)
+		"anilistId", anilistID, "bgmId", bgmID,
+		"written", written, "retracted", retracted, "shielded", shielded)
 	w.stampAttempt(ctx, anilistID, bgmID)
-	return sweepResult{class: sweepWritten, written: written}
+	return sweepResult{
+		class:     sweepWritten,
+		written:   written,
+		retracted: retracted,
+		shielded:  shielded,
+	}
 }
 
 // episodeTitlesSweepEnabled reads the kill switch.

--- a/go-api/internal/queue/episode_titles_retract.go
+++ b/go-api/internal/queue/episode_titles_retract.go
@@ -1,0 +1,261 @@
+// episode_titles_retract.go — the withdrawal half of the Bangumi episode-title
+// write, and the guard that decides how much of it may happen unattended.
+//
+// # What was missing
+//
+// An upsert states what a source now holds and says nothing about what it used
+// to hold.  internal/episodetitles.Apply has closed that gap on the dandanplay
+// side since it was written: upsert, then ClearEpisodeTitlesBySourceOutside to
+// withdraw this source's rows the fetch no longer covers, then
+// DeleteEmptyEpisodeTitles for the rows the withdrawal emptied.  The Bangumi
+// writer (episode_titles_write.go) only ever upserted.  So a Bangumi list that
+// shrank left its old tail sitting under the fresh rows, invisible to the
+// writer and indistinguishable, in the table, from titles we had confirmed.
+//
+// That tail is not hypothetical.  On 2026-09-05 production held 21,001 rows
+// across 960 anime past their own season's episode count, 13,426 of them from
+// the Bangumi side; removing them took a hand-written DELETE because no writer
+// could reach them.  #156 stopped new ones being made.  This file is what
+// stops the next batch needing a human.
+//
+// # Why the withdrawal cannot simply be copied over from the dandanplay side
+//
+// Apply's rule is "everything this source owns and the fetch did not re-state
+// is withdrawn".  That is sound for a writer whose fetch is either whole or
+// obviously absent.  The Bangumi list is neither.  Measured 2026-09-06 over
+// the 90,241 Bangumi-sourced rows on 6,041 anime: 1,219 anime already hold
+// FEWER rows than their season's episode count, 466 do not start at episode 1,
+// and 282 have holes in the middle.  Sparse is the normal shape of this data,
+// not a symptom.  A fetch that comes back with six episodes of twelve is
+// therefore not evidence that the other six stopped existing — it is the same
+// answer a healthy sparse subject gives, and cardinality(kept) > 0, the guard
+// the query already carries, cannot see the difference because both are
+// non-empty.
+//
+// # The guard is the window, not a threshold
+//
+// The tempting guard is a count: refuse when the new set is materially smaller
+// than what we hold.  It is the wrong instrument twice over.  It would refuse
+// exactly the repair this file exists to perform — a four-episode ONA bound to
+// a 3,528-episode subject shrinks by 99% and that shrink is the fix — and a
+// cardinality comparison is an idiom this codebase does not otherwise use:
+// every existing guard compares a RANK (source label, bangumi_version) or a
+// SET (GREATEST over a union), never a count.
+//
+// So the question a row is asked is not "how many" but "could this episode
+// belong to this entry at all":
+//
+//	outside the kept-set AND above the season's episode count
+//	    → cannot be this entry's whatever upstream is doing today, because
+//	      the grid renders 1..episodes and the writer will not produce it
+//	      again.  Withdrawn.
+//	outside the kept-set and INSIDE the window
+//	    → this is precisely the row a partial fetch erases.  Added back to
+//	      the kept-set, so the retraction passes over it, and counted so the
+//	      pass can say how often it happened.
+//	window unknown (anime_cache.episodes IS NULL)
+//	    → no question can be asked, so none is answered: every held row is
+//	      shielded and the withdrawal degenerates to a no-op.  This is the
+//	      whole population the episodes_bgm worker writes, which is why that
+//	      writer is deliberately not wired to this file.
+//
+// The shape is borrowed from MarkEpisodesBgmAttempted (anime_cache.sql), which
+// clears a stored count only for the outcome that positively repudiates it and
+// leaves it alone for the three that are merely absence of evidence.  A short
+// list is absence of evidence.  The cost of being wrong in the conservative
+// direction is one stale title on an episode the entry does not have; the cost
+// in the other direction is deleting rows nobody can tell were ever there.
+//
+// # Why its own transaction
+//
+// The Bangumi title write is best-effort by contract: both callers reach it
+// after their authoritative write has committed, and failing the job there
+// would re-spend the upstream requests that produced it.  Adopting Apply's
+// all-or-nothing transaction would change that — a failure at the withdrawal
+// would roll the upserts back too.  So the withdrawal is its own transaction,
+// after the upserts, and a failure costs the withdrawal only.  The pairing of
+// clear and delete does need to be atomic: a clear without its delete leaves
+// rows holding two NULLs and no source, which no later retraction can reach,
+// because the WHERE that finds them matches on the source it just erased.
+// That is how the 2,369 orphan rows the 2026-09-05 audit found were made.
+package queue
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	dbgen "github.com/lawrenceli0228/animego/go-api/internal/db/gen"
+)
+
+// retractionPlan is the decision taken before any row is touched.
+//
+// protected is what ClearEpisodeTitlesBySourceOutside is handed as its
+// kept-set: the episodes upstream re-stated, plus the ones the guard is
+// unwilling to withdraw on this evidence.  Passing the shielded rows through
+// the kept-set rather than filtering the retraction afterwards is deliberate —
+// the query withdraws everything outside the set it is given, so the only way
+// to spare a row is to name it, and naming it keeps the decision in one place
+// instead of splitting it between a plan and a second predicate.
+type retractionPlan struct {
+	protected []int32
+	withdraw  int
+	shielded  int
+}
+
+// planRetraction sorts the rows this source holds into the three answers above.
+//
+// kept is the episode set upstream listed for this entry after windowing;
+// window is the catalogue episode count, 0 when AniList has none.
+//
+// Worth being exact about what decides the outcome, because the shape invites
+// the wrong reading: WHAT IS WITHDRAWN IS DECIDED BY THE WINDOW ALONE.  The
+// normaliser windows its list to the season before this function sees it, so
+// kept can never contain an episode above the window, so a held row above the
+// window is never in kept, so it is withdrawn whether or not this particular
+// fetch mentioned it -- and a held row below the window is shielded on the
+// same terms.  A mutation that fed the raw kept-set to the retraction instead
+// of the protected one survived the first round of tests for exactly this
+// reason: on an anime with no tail, the plan returns before the statement runs.
+//
+// That independence is a feature, not an accident to be tidied away.  It means
+// a degraded fetch cannot widen the withdrawal, only narrow it to nothing.
+// kept's own composition -- including the episodes upstream listed but has not
+// named, which the writer skips because the row would be two NULLs -- is
+// therefore a statement of what "this source holds" means rather than a lever
+// on today's outcome.  It becomes a lever the moment the guard is loosened to
+// allow any withdrawal inside the window, which is why it is stated here and
+// pinned by a test rather than left to be re-derived then.
+func planRetraction(kept, held []int32, window int32) retractionPlan {
+	if len(kept) == 0 {
+		return retractionPlan{}
+	}
+
+	keptSet := make(map[int32]struct{}, len(kept))
+	for _, e := range kept {
+		keptSet[e] = struct{}{}
+	}
+
+	protected := make([]int32, 0, len(kept)+len(held))
+	for e := range keptSet {
+		protected = append(protected, e)
+	}
+
+	plan := retractionPlan{}
+	seen := make(map[int32]struct{}, len(held))
+	for _, e := range held {
+		if _, ok := keptSet[e]; ok {
+			continue
+		}
+		// The held set comes back ordered and PK-unique, but a duplicate
+		// would double-count both the shield and the withdrawal, and the
+		// counts are what the pass reports.
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+
+		if window > 0 && e > window {
+			plan.withdraw++
+			continue
+		}
+		plan.shielded++
+		protected = append(protected, e)
+	}
+
+	sort.Slice(protected, func(i, j int) bool { return protected[i] < protected[j] })
+	plan.protected = protected
+	return plan
+}
+
+// episodeTitleRetractor is the write surface the withdrawal needs.
+//
+// Concrete rather than an interface on purpose: the pair of statements has to
+// run inside one transaction, and WithTx is a method on *dbgen.Queries, not
+// something a hand-written double can supply.  The worker that calls this
+// already holds both the pool and the generated queries for the same reason —
+// see EpisodeTitlesWorker, which was built that way so the sweep is exercised
+// by the integration suite rather than by an in-memory double.
+type episodeTitleRetractor struct {
+	pool *pgxpool.Pool
+	q    *dbgen.Queries
+}
+
+// retractEpisodeTitles withdraws the Bangumi rows this entry can no longer
+// hold, and reports how many it refused to withdraw on the evidence available.
+//
+// A zero-length kept-set returns immediately: it means the fetch produced
+// nothing usable, which is the one case where withdrawing everything would be
+// catastrophic and is already the reason the query carries its own cardinality
+// guard.  Reaching the query at all in that state would be relying on this
+// caller's convention, and a convention is the wrong place for the difference
+// between "nothing changed" and "everything erased".
+func (r episodeTitleRetractor) retract(
+	ctx context.Context,
+	anilistID int32,
+	kept []int32,
+	window int32,
+) (withdrawn, shielded int, err error) {
+	if len(kept) == 0 {
+		return 0, 0, nil
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("episode titles retract: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	qtx := r.q.WithTx(tx)
+
+	// Read the held set inside the transaction the withdrawal runs in, so the
+	// set the plan was made from is the set the UPDATE sees.
+	held, err := qtx.ListEpisodeTitleEpisodesBySource(ctx, anilistID, episodeTitleSourceBangumi)
+	if err != nil {
+		return 0, 0, fmt.Errorf("episode titles retract: read held: %w", err)
+	}
+
+	plan := planRetraction(kept, held, window)
+	if plan.withdraw == 0 {
+		// Nothing provably stale.  Returning before the UPDATE keeps the
+		// no-op case free of write locks on a table the detail page reads.
+		return 0, plan.shielded, nil
+	}
+
+	cleared, err := qtx.ClearEpisodeTitlesBySourceOutside(
+		ctx, episodeTitleSourceBangumi, anilistID, plan.protected)
+	if err != nil {
+		return 0, 0, fmt.Errorf("episode titles retract: clear: %w", err)
+	}
+	if len(cleared) > 0 {
+		if _, err := qtx.DeleteEmptyEpisodeTitles(ctx, anilistID, cleared); err != nil {
+			return 0, 0, fmt.Errorf("episode titles retract: delete emptied: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, 0, fmt.Errorf("episode titles retract: commit: %w", err)
+	}
+	return len(cleared), plan.shielded, nil
+}
+
+// keptEpisodes is the episode set to hand the withdrawal after a write.
+//
+// Derived from the normalised list rather than from what the upsert actually
+// landed: writeEpisodeTitles skips episodes with no title in either language,
+// and an episode upstream lists without a name yet is still an episode
+// upstream lists.  The sweep runs on airing shows, where that is the ordinary
+// state of the next two or three episodes.
+//
+// Under today's guard the distinction changes no row -- an unnamed episode is
+// inside the window and would be shielded anyway (see planRetraction).  It is
+// kept honest because the alternative is a definition of "held" that is wrong
+// on its own terms and happens to be harmless.
+func keptEpisodes(titles []epTitle) []int32 {
+	out := make([]int32, 0, len(titles))
+	for _, t := range titles {
+		out = append(out, t.episode)
+	}
+	return out
+}

--- a/go-api/internal/queue/episode_titles_retract_test.go
+++ b/go-api/internal/queue/episode_titles_retract_test.go
@@ -1,0 +1,173 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// planRetraction is the entire policy of the Bangumi withdrawal, so these are
+// the tests that decide what it will and will not delete in production.
+//
+// The cases are written as pairs wherever a boundary exists, because the one
+// mutation that survived the #156 round was an off-by-one on a bound whose
+// only test passed a value where both sides of the branch agreed.  An episode
+// exactly ON the window and one exactly past it must therefore appear
+// together, and so must "held equals kept" against "held has one extra".
+func TestPlanRetraction(t *testing.T) {
+	tests := []struct {
+		name      string
+		kept      []int32
+		held      []int32
+		window    int32
+		withdraw  int
+		shielded  int
+		protected []int32
+	}{
+		{
+			name:      "an empty kept-set decides nothing and protects nothing",
+			kept:      nil,
+			held:      []int32{1, 2, 3},
+			window:    12,
+			withdraw:  0,
+			shielded:  0,
+			protected: nil,
+		},
+		{
+			name:      "a fetch that re-states everything held withdraws nothing",
+			kept:      []int32{1, 2, 3},
+			held:      []int32{1, 2, 3},
+			window:    3,
+			withdraw:  0,
+			shielded:  0,
+			protected: []int32{1, 2, 3},
+		},
+		{
+			name:      "a tail past the season is withdrawn",
+			kept:      []int32{1, 2, 3},
+			held:      []int32{1, 2, 3, 4, 5},
+			window:    3,
+			withdraw:  2,
+			shielded:  0,
+			protected: []int32{1, 2, 3},
+		},
+		{
+			name:      "★ the last episode of the season is not a tail",
+			kept:      []int32{1, 2},
+			held:      []int32{1, 2, 3},
+			window:    3,
+			withdraw:  0,
+			shielded:  1,
+			protected: []int32{1, 2, 3},
+		},
+		{
+			name:      "★ one past the season is",
+			kept:      []int32{1, 2},
+			held:      []int32{1, 2, 4},
+			window:    3,
+			withdraw:  1,
+			shielded:  0,
+			protected: []int32{1, 2},
+		},
+		{
+			name:      "★ a half-answered fetch loses nothing",
+			kept:      []int32{1, 2, 3, 4, 5, 6},
+			held:      []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+			window:    12,
+			withdraw:  0,
+			shielded:  6,
+			protected: []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+		},
+		{
+			name:      "★ an unknown season length asks no question and answers none",
+			kept:      []int32{1, 2},
+			held:      []int32{1, 2, 3, 400},
+			window:    0,
+			withdraw:  0,
+			shielded:  2,
+			protected: []int32{1, 2, 3, 400},
+		},
+		{
+			name:      "the two verdicts are reached independently on the same anime",
+			kept:      []int32{1, 2, 3},
+			held:      []int32{1, 2, 3, 5, 13, 26},
+			window:    12,
+			withdraw:  2,
+			shielded:  1,
+			protected: []int32{1, 2, 3, 5},
+		},
+		{
+			name:      "an episode upstream lists but has not named is kept, not withdrawn",
+			kept:      []int32{1, 2, 3, 4},
+			held:      []int32{1, 2},
+			window:    4,
+			withdraw:  0,
+			shielded:  0,
+			protected: []int32{1, 2, 3, 4},
+		},
+		{
+			name:      "holding nothing yet is not a withdrawal",
+			kept:      []int32{1, 2, 3},
+			held:      nil,
+			window:    12,
+			withdraw:  0,
+			shielded:  0,
+			protected: []int32{1, 2, 3},
+		},
+		{
+			name:      "a repeated held episode is counted once",
+			kept:      []int32{1},
+			held:      []int32{5, 5, 5},
+			window:    3,
+			withdraw:  1,
+			shielded:  0,
+			protected: []int32{1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := planRetraction(tc.kept, tc.held, tc.window)
+
+			require.Equal(t, tc.withdraw, got.withdraw, "rows to withdraw")
+			require.Equal(t, tc.shielded, got.shielded, "rows the guard spared")
+			require.Equal(t, tc.protected, nilIfEmpty(got.protected),
+				"the kept-set handed to the retraction")
+		})
+	}
+}
+
+// TestPlanRetractionProtectedSetIsAscending pins the ordering the SQL argument
+// is built from.  ClearEpisodeTitlesBySourceOutside does not care about order,
+// but the logs and the integration assertions compare slices, and an unstable
+// order would make a passing test a coin flip -- the protected set is built by
+// ranging over a map.
+func TestPlanRetractionProtectedSetIsAscending(t *testing.T) {
+	got := planRetraction([]int32{9, 3, 1}, []int32{2, 7}, 12)
+
+	require.Equal(t, []int32{1, 2, 3, 7, 9}, got.protected)
+	require.Equal(t, 0, got.withdraw)
+	require.Equal(t, 2, got.shielded)
+}
+
+// TestKeptEpisodesCountsTheUnnamed is the seam between the write and the
+// withdrawal.  writeEpisodeTitles skips a title with no name in either
+// language; the kept-set must not, or every unaired episode of an airing show
+// would look like a row upstream had dropped.
+func TestKeptEpisodesCountsTheUnnamed(t *testing.T) {
+	name := "Sea of Trees"
+	titles := []epTitle{
+		{episode: 1, nameCN: &name},
+		{episode: 2},
+		{episode: 3, name: &name},
+	}
+
+	require.Equal(t, []int32{1, 2, 3}, keptEpisodes(titles))
+}
+
+func nilIfEmpty(v []int32) []int32 {
+	if len(v) == 0 {
+		return nil
+	}
+	return v
+}

--- a/go-api/test/integration/episode_titles_bangumi_retract_test.go
+++ b/go-api/test/integration/episode_titles_bangumi_retract_test.go
@@ -1,0 +1,303 @@
+//go:build integration
+
+// episode_titles_bangumi_retract_test.go — what the Bangumi branch of the
+// sweep withdraws, and what it refuses to withdraw.
+//
+// The dandanplay branch has retracted since it was written; the Bangumi branch
+// only ever upserted, so a list that shrank left its old tail in place under
+// the fresh rows.  Wiring the withdrawal in is the easy half.  The half that
+// needs pinning against a real database is the guard: Bangumi's list is
+// routinely INCOMPLETE rather than shorter — measured 2026-09-06, 1,219 of the
+// 6,041 anime holding Bangumi rows already hold fewer than their own season's
+// episode count, and 282 have holes in the middle — so "the fetch did not
+// mention it" cannot mean "delete it".
+//
+// Each test below is one row of that decision, end to end through the exported
+// Work(), because the decision is made of a plan (a pure function, tested in
+// internal/queue) AND two SQL statements whose scoping is the other half of the
+// answer.  A test of either alone would pass while the pair deleted the wrong
+// rows.
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/bangumi"
+	"github.com/lawrenceli0228/animego/go-api/internal/testutil"
+)
+
+// The anilist_id block this file owns.
+const (
+	retAnilistID = 700301
+	retBgmID     = 9401
+)
+
+// retSeedCandidate is swSeedCandidate with a nullable episode count: the
+// "AniList has no number for this entry" case is one of the answers under
+// test, and it is the whole population the episodes_bgm worker writes.
+func retSeedCandidate(t *testing.T, ctx context.Context, pool *pgxpool.Pool,
+	anilistID, bgmID int32, episodes *int32,
+) {
+	t.Helper()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO anime_cache (
+			anilist_id, title_romaji, title_native, bgm_id, status, episodes,
+			bgm_match_source, episode_titles_at
+		) VALUES ($1, 'retract fixture', 'リトラクト', $2, 'RELEASING', $3, 'manual', NULL)`,
+		anilistID, bgmID, episodes,
+	)
+	require.NoError(t, err, "seed retraction candidate %d", anilistID)
+}
+
+// retSeedBangumiRows writes episodes lo..hi as rows this source already holds,
+// the state a previous pass would have left behind.
+func retSeedBangumiRows(t *testing.T, ctx context.Context, pool *pgxpool.Pool,
+	anilistID int32, lo, hi int32, prefix string,
+) {
+	t.Helper()
+	src := "bangumi"
+	for n := lo; n <= hi; n++ {
+		name := prefix + string(rune('0'+n%10))
+		etSeedTitle(t, ctx, pool, anilistID, n, nil, nil, &name, &src)
+	}
+}
+
+// retBGMEpisodes builds a Bangumi response listing main episodes lo..hi.
+func retBGMEpisodes(lo, hi int, prefix string) *bangumi.EpisodesResponse {
+	r := &bangumi.EpisodesResponse{}
+	for n := lo; n <= hi; n++ {
+		r.Eps = append(r.Eps, bangumi.Episode{
+			Sort: float64(n), Type: 0, Name: prefix + string(rune('0'+n%10)),
+		})
+	}
+	return r
+}
+
+func retI32(v int32) *int32 { return &v }
+
+// ---------------------------------------------------------------------------
+// What is withdrawn
+// ---------------------------------------------------------------------------
+
+// A tail past the season's episode count cannot belong to this entry whatever
+// upstream is doing today: the grid renders 1..episodes, so those rows are
+// invisible, and the writer will not produce them again.
+//
+// This is the population that took a hand-written DELETE in September 2026 —
+// 21,001 rows across 960 anime — because no writer could reach it.
+func TestBangumiSweepWithdrawsTheTailPastTheSeason(t *testing.T) {
+	ctx := context.Background()
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+
+	retSeedCandidate(t, ctx, pool, retAnilistID, retBgmID, retI32(3))
+	retSeedBangumiRows(t, ctx, pool, retAnilistID, 1, 6, "stale-ep")
+
+	ddp := &swDDP{} // no entry for that id — routes to the Bangumi branch
+	bgm := &swBGM{
+		subject: &bangumi.Subject{ID: retBgmID, Name: "リトラクト"},
+		eps:     retBGMEpisodes(1, 3, "fresh-ep"),
+	}
+	swRun(t, ctx, pool, ddp, bgm)
+
+	assert.Equal(t, 3, etCountTitles(t, ctx, pool, retAnilistID),
+		"the three rows past the season must be gone, not merely emptied")
+
+	for _, ep := range []int32{4, 5, 6} {
+		assert.False(t, etRead(t, ctx, pool, retAnilistID, ep).present,
+			"episode %d is past the season and must not survive the pass", ep)
+	}
+
+	kept := etRead(t, ctx, pool, retAnilistID, 1)
+	require.True(t, kept.present, "the season's own episodes must survive")
+	etAssertField(t, "ep1 name", kept.name, kept.nameSource, "fresh-ep1", "bangumi")
+
+	assert.True(t, swSwept(t, ctx, pool, retAnilistID), "the row must still be stamped")
+}
+
+// The withdrawal is scoped to one source, and the row is only removed once
+// nothing is left standing in it.  A row whose other column another upstream
+// filled must survive with that column intact.
+//
+// Asserting the surviving row rather than just the count is the point: a
+// retraction that deleted outright would pass a count-only assertion on the
+// rows it was allowed to take and silently take this one with them.
+func TestBangumiSweepWithdrawalSparesAnotherSourcesField(t *testing.T) {
+	ctx := context.Background()
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+
+	retSeedCandidate(t, ctx, pool, retAnilistID, retBgmID, retI32(2))
+	retSeedBangumiRows(t, ctx, pool, retAnilistID, 1, 2, "stale-ep")
+
+	// Episode 5 is past the season and holds one field from each source.
+	bgmCn, bgmSrc := "撤回中文", "bangumi"
+	ddpName, ddpSrc := "ddp-ep5", "ddp"
+	etSeedTitle(t, ctx, pool, retAnilistID, 5, &bgmCn, &bgmSrc, &ddpName, &ddpSrc)
+
+	ddp := &swDDP{}
+	bgm := &swBGM{
+		subject: &bangumi.Subject{ID: retBgmID, Name: "リトラクト"},
+		eps:     retBGMEpisodes(1, 2, "fresh-ep"),
+	}
+	swRun(t, ctx, pool, ddp, bgm)
+
+	got := etRead(t, ctx, pool, retAnilistID, 5)
+	require.True(t, got.present,
+		"a row still holding another source's value must not be deleted")
+	etAssertField(t, "ep5 name_cn", got.nameCn, got.nameCnSource, "", "")
+	etAssertField(t, "ep5 name", got.name, got.nameSource, "ddp-ep5", "ddp")
+}
+
+// ---------------------------------------------------------------------------
+// What is refused — the guard
+// ---------------------------------------------------------------------------
+
+// ★ The failure the guard exists to prevent.
+//
+// Bangumi answers six of twelve episodes — a subject mid-edit, a degraded
+// upstream, or simply a sparse entry, and the three are the same value here.
+// cardinality(kept) > 0, the guard the retraction query already carries, sees
+// a non-empty list and lets it through; only the season's window can tell that
+// episodes 7-12 are inside the entry and therefore not disprovable.
+//
+// Getting this wrong deletes rows nobody can tell were ever there: they are
+// single-source, so the clear empties them and the delete removes them.
+func TestBangumiSweepRefusesToWithdrawInsideTheSeason(t *testing.T) {
+	ctx := context.Background()
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+
+	retSeedCandidate(t, ctx, pool, retAnilistID, retBgmID, retI32(12))
+	retSeedBangumiRows(t, ctx, pool, retAnilistID, 1, 12, "stale-ep")
+
+	ddp := &swDDP{}
+	bgm := &swBGM{
+		subject: &bangumi.Subject{ID: retBgmID, Name: "リトラクト"},
+		eps:     retBGMEpisodes(1, 6, "fresh-ep"),
+	}
+	swRun(t, ctx, pool, ddp, bgm)
+
+	assert.Equal(t, 12, etCountTitles(t, ctx, pool, retAnilistID),
+		"a half-answered fetch must cost nothing")
+
+	unanswered := etRead(t, ctx, pool, retAnilistID, 12)
+	require.True(t, unanswered.present, "episode 12 must survive a fetch that stopped at 6")
+	etAssertField(t, "ep12 name", unanswered.name, unanswered.nameSource, "stale-ep2", "bangumi")
+
+	answered := etRead(t, ctx, pool, retAnilistID, 6)
+	require.True(t, answered.present)
+	etAssertField(t, "ep6 name", answered.name, answered.nameSource, "fresh-ep6", "bangumi")
+}
+
+// ★ With no episode count on the entry there is no window, so there is no
+// question the withdrawal can answer — and it answers none.
+//
+// This is not a corner case: it is the entire population the episodes_bgm
+// worker writes, which selects `WHERE ac.episodes IS NULL` precisely because
+// deriving that number is its job.  A withdrawal that treated a missing count
+// as zero would take every row those passes have ever written.
+func TestBangumiSweepWithdrawsNothingWithoutASeasonLength(t *testing.T) {
+	ctx := context.Background()
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+
+	retSeedCandidate(t, ctx, pool, retAnilistID, retBgmID, nil)
+	retSeedBangumiRows(t, ctx, pool, retAnilistID, 1, 6, "stale-ep")
+
+	ddp := &swDDP{}
+	bgm := &swBGM{
+		subject: &bangumi.Subject{ID: retBgmID, Name: "リトラクト"},
+		eps:     retBGMEpisodes(1, 3, "fresh-ep"),
+	}
+	swRun(t, ctx, pool, ddp, bgm)
+
+	assert.Equal(t, 6, etCountTitles(t, ctx, pool, retAnilistID),
+		"an unknown season length must protect every row this source holds")
+
+	survivor := etRead(t, ctx, pool, retAnilistID, 6)
+	require.True(t, survivor.present)
+	etAssertField(t, "ep6 name", survivor.name, survivor.nameSource, "stale-ep6", "bangumi")
+}
+
+// An episode Bangumi lists but has not named yet is still an episode Bangumi
+// lists.  The writer skips it — the row would be two NULLs — but the kept-set
+// must carry it, or every unaired episode of an airing show would look like a
+// row upstream had dropped.
+//
+// The sweep runs on airing shows, so this is the ordinary case, not the exotic
+// one.
+func TestBangumiSweepKeepsAnEpisodeListedWithoutAName(t *testing.T) {
+	ctx := context.Background()
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+
+	retSeedCandidate(t, ctx, pool, retAnilistID, retBgmID, retI32(4))
+	retSeedBangumiRows(t, ctx, pool, retAnilistID, 1, 4, "stale-ep")
+
+	ddp := &swDDP{}
+	bgm := &swBGM{
+		subject: &bangumi.Subject{ID: retBgmID, Name: "リトラクト"},
+		eps: &bangumi.EpisodesResponse{Eps: []bangumi.Episode{
+			{Sort: 1, Type: 0, Name: "fresh-ep1"},
+			{Sort: 2, Type: 0, Name: "fresh-ep2"},
+			{Sort: 3, Type: 0}, // aired, not yet titled
+			{Sort: 4, Type: 0}, // not aired
+		}},
+	}
+	swRun(t, ctx, pool, ddp, bgm)
+
+	assert.Equal(t, 4, etCountTitles(t, ctx, pool, retAnilistID),
+		"an unnamed episode is not a withdrawn episode")
+
+	untitled := etRead(t, ctx, pool, retAnilistID, 3)
+	require.True(t, untitled.present, "episode 3 must not be taken for a row upstream dropped")
+	etAssertField(t, "ep3 name", untitled.name, untitled.nameSource, "stale-ep3", "bangumi")
+}
+
+// ★ Both verdicts on one anime, which is the only shape that proves the two
+// are reached independently.
+//
+// Every case above exercises one verdict at a time, and one verdict at a time
+// is not enough: with no tail to take, the withdrawal returns before it issues
+// a statement at all, so a version that handed the retraction the raw fetch
+// instead of the protected set — deleting every row inside the season the
+// fetch did not happen to mention — passes all of them.  Found by mutation on
+// 2026-09-06; this is the assertion that kills it.
+func TestBangumiSweepTakesTheTailAndSparesTheGapInOnePass(t *testing.T) {
+	ctx := context.Background()
+	pool := newPGPool(t, ctx)
+	testutil.TruncateAll(t, ctx, pool)
+
+	retSeedCandidate(t, ctx, pool, retAnilistID, retBgmID, retI32(6))
+	retSeedBangumiRows(t, ctx, pool, retAnilistID, 1, 6, "stale-ep")
+	retSeedBangumiRows(t, ctx, pool, retAnilistID, 20, 20, "tail-ep")
+
+	// A short answer: the season is six episodes and Bangumi named three.
+	ddp := &swDDP{}
+	bgm := &swBGM{
+		subject: &bangumi.Subject{ID: retBgmID, Name: "リトラクト"},
+		eps:     retBGMEpisodes(1, 3, "fresh-ep"),
+	}
+	swRun(t, ctx, pool, ddp, bgm)
+
+	assert.Equal(t, 6, etCountTitles(t, ctx, pool, retAnilistID),
+		"the tail goes and the six in-season rows stay")
+
+	assert.False(t, etRead(t, ctx, pool, retAnilistID, 20).present,
+		"episode 20 is past a six-episode season and must go")
+
+	spared := etRead(t, ctx, pool, retAnilistID, 6)
+	require.True(t, spared.present,
+		"episode 6 is inside the season and the fetch's silence is not evidence against it")
+	etAssertField(t, "ep6 name", spared.name, spared.nameSource, "stale-ep6", "bangumi")
+
+	refreshed := etRead(t, ctx, pool, retAnilistID, 3)
+	require.True(t, refreshed.present)
+	etAssertField(t, "ep3 name", refreshed.name, refreshed.nameSource, "fresh-ep3", "bangumi")
+}


### PR DESCRIPTION
## What

The dandanplay write path has retracted since it was written: upsert, clear this source's rows the fetch no longer covers, delete what the clear emptied, stamp — one transaction. The Bangumi path only ever upserted. A list that shrank left its old tail under the fresh rows, and the last batch of those took a hand-written `DELETE` because no writer could reach it.

This wires the withdrawal into the sweep's Bangumi branch and adds the guard that has to come with it.

## The guard is the window, not a threshold

Bangumi's list is routinely **incomplete rather than shorter**. Of the 6,041 anime holding Bangumi-sourced rows, 1,219 already hold fewer rows than their own season's episode count and 282 have holes in the middle. Sparse is the normal shape, so "the fetch did not mention it" cannot mean "delete it" — and `cardinality(kept) > 0`, the guard the retraction query already carries, cannot see the difference because both cases are non-empty.

A count comparison was the tempting answer and it is wrong twice: it would refuse exactly the repair this exists for (a four-episode ONA bound to a 3,528-episode subject shrinks by 99%, and that shrink *is* the fix), and no other guard in this repo compares a cardinality — they compare a rank (source label, `bangumi_version`) or a set (`GREATEST` over a union).

So the question a row is asked is not *how many* but *could this episode belong to this entry at all*:

| held row | verdict |
|---|---|
| outside the kept-set **and past the season** | withdrawn |
| outside the kept-set, **inside** the season | added back to the kept-set, and counted as `rowsShielded` |
| entry has no episode count | nothing is withdrawn |

The last row is not a corner case — it is the entire population `episodes_bgm` writes (`WHERE ac.episodes IS NULL`), which is why that writer is deliberately left on the upsert-only path. `BangumiV2Worker` is left alone too: it holds no pool, and reaching one means changing `WorkersWithBangumiAndNormalizer`'s signature and six test doubles.

`rowsShielded` is the number worth watching. It says how often a Bangumi fetch came back shorter than what we already hold, and it is what decides whether a review queue for those is worth building.

## Its own transaction, on purpose

The withdrawal runs after the upserts rather than wrapping them, so the best-effort contract stays intact: a failure costs the withdrawal and not the titles, and the row is still stamped — an un-stamped row returns to the head of every batch and re-spends two Bangumi requests to retry an optional cleanup. The clear/delete pair does need to be atomic: a clear without its delete leaves rows with two NULLs and no source, which no later retraction can reach, because the `WHERE` that would find them matches on the source it just erased.

## Expected effect on landing: close to nothing, and that is the point

Simulated against production on a stratified 40-anime sample, fetching each subject from bgm.tv and running the real normalisation: **1 row withdrawn, 335 added.** Nothing currently sits past its season's episode count — the last cleanup removed it and #156 stopped new ones being written. This is insurance, not a repair: the next time a tail appears it costs a sweep pass instead of a hand-written `DELETE`.

## Test plan

- [x] `go build ./...`, `go vet -tags=integration ./test/integration/...`
- [x] `go test ./...` — 35 packages
- [x] `go test -tags=integration ./test/integration/...` — full suite, including the six new cases
- [x] 11 table cases on the plan (`TestPlanRetraction`), boundary pairs on every bound
- [x] 6 mutations. **One survived the first round** — handing the retraction the raw kept-set instead of the protected one — because with no tail to take the plan returns before the statement runs, so every single-verdict test passed it. `TestBangumiSweepTakesTheTailAndSparesTheGapInOnePass` is the case that kills it.
- [ ] After deploy: watch `rowsShielded` in the `episode_titles pass done` line. A non-zero number that stays non-zero is the argument for a review queue; zero means the in-window case is theoretical.