### PR TITLE
Record which numbering an episode number is in

### DIFF
--- a/next-app/src/app/[lang]/library/_hooks/episodeParser.js
+++ b/next-app/src/app/[lang]/library/_hooks/episodeParser.js
@@ -34,24 +34,44 @@ function stripTechTokens(s) {
     .replace(/\b\d{3,4}[Pp]\b/g, '');        // 1080P, 720p, 2160P, etc.
 }
 
-export function parseEpisodeNumber(filename) {
-  const patterns = [
-    /\bS\d+E(\d+)/i,                // S01E03
-    // `\b` is load-bearing — without it, `e 2` inside prose like
-    // "Class de 2-banme" matched and stole the episode number across all 7
-    // files in the cluster, collapsing them onto ep2 in the import flow.
-    /\bEP?\s*(\d+)/i,               // EP03, E03, EP 03
-    /第(\d+)[話话集]/,               // 第03話, 第3集
-    /\s-\s(\d+)\s/,                 // " - 03 "
-    /\[(\d+)(?:v\d+)?\]/,          // [03], [03v2]
-  ];
+/**
+ * 集号的六个来源。哪一条命中,决定了这个数字属于哪套编号 —— 见
+ * `resolveNumberSpace`。
+ *
+ * 这张表就是原来 `parseEpisodeNumber` 里的内联数组,顺序一字未动;
+ * 唯一的新增是 `origin`,因为「这个 3 是第几季的第 3 集,还是整个系列的
+ * 第 3 集」这个问题,答案只存在于**是哪条正则匹配到它的**,而原来的写法
+ * 在 `return num` 的那一刻就把它扔了。
+ *
+ * @type {ReadonlyArray<{ origin: string, re: RegExp }>}
+ */
+const EPISODE_NUMBER_PATTERNS = [
+  { origin: 'seasonEpisode', re: /\bS\d+E(\d+)/i },       // S01E03
+  // `\b` is load-bearing — without it, `e 2` inside prose like
+  // "Class de 2-banme" matched and stole the episode number across all 7
+  // files in the cluster, collapsing them onto ep2 in the import flow.
+  { origin: 'epLabel',       re: /\bEP?\s*(\d+)/i },      // EP03, E03, EP 03
+  { origin: 'cjkEpisode',    re: /第(\d+)[話话集]/ },        // 第03話, 第3集
+  { origin: 'dashed',        re: /\s-\s(\d+)\s/ },         // " - 03 "
+  { origin: 'bracketed',     re: /\[(\d+)(?:v\d+)?\]/ },  // [03], [03v2]
+];
 
-  for (const re of patterns) {
+/**
+ * `parseEpisodeNumber` 的内部形态:除了数字,还交代这个数字是谁匹配到的。
+ *
+ * 分成两个函数而不是改 `parseEpisodeNumber` 的返回值,是因为后者有调用方,
+ * 而这次要的是**多一个事实**,不是换一个契约。
+ *
+ * @param {string} filename
+ * @returns {{ number: number, origin: string } | null}
+ */
+function matchEpisodeNumber(filename) {
+  for (const { origin, re } of EPISODE_NUMBER_PATTERNS) {
     const m = filename.match(re);
     if (m) {
       const num = parseInt(m[1], 10);
       if (RESOLUTIONS.has(num)) continue;
-      return num;
+      return { number: num, origin };
     }
   }
 
@@ -62,10 +82,15 @@ export function parseEpisodeNumber(filename) {
   const fallback = stripTechTokens(filename).match(/(?:^|\D)(\d{2,3})(?:\D|$)/);
   if (fallback) {
     const num = parseInt(fallback[1], 10);
-    if (!RESOLUTIONS.has(num)) return num;
+    if (!RESOLUTIONS.has(num)) return { number: num, origin: 'digits' };
   }
 
   return null;
+}
+
+export function parseEpisodeNumber(filename) {
+  const m = matchEpisodeNumber(filename);
+  return m ? m.number : null;
 }
 
 const TAG_RE = /^(\d{2,4}[Pp]?\b|HEVC|AVC|x26[45]|H\.?26[45]|AAC|FLAC|WEB-?DL|WebRip|BDRip|Blu-?[Rr]ay|CHS|CHT|JPN?|ENG?|BIG5|GB|S\d+E?\d*|\d{1,3}(?:v\d+)?|SP\d*|OVA|OAD|NCOP|NCED|Commentary|Audio\s+Commentary|[A-Z0-9 ]+\d{3,4}[Pp])$/i;
@@ -327,6 +352,56 @@ export function parseAbsoluteEpisode(filename) {
   return m ? parseInt(m[1], 10) : null;
 }
 
+// ─── 编号空间 ─────────────────────────────────────────────────────────────
+
+/**
+ * 一个集号属于哪套编号。
+ *
+ * `perSeason` —— 本季自己的 1..N,和站点 `(anilist_id, episode)` 用的是同一套。
+ * `absolute`  —— 整个系列连续递增(《海贼王》第 1091 集那种)。
+ * `unknown`   —— **文件名没说**。不是「大概是本季的」,是没有证据。
+ *
+ * 为什么绝大多数文件只能是 `unknown`:字幕组写 `[03]`、`第03話`、` - 03 `
+ * 的时候,两套编号长得一模一样。第二季第 3 集和整部第 15 集,同样是一个
+ * `[03]` 或者一个 `[15]`,取决于这个组的习惯,而习惯不写在文件名里。
+ * 站点那边曾经为此付过账:21,001 行分集标题落在本季集数之外,靠的正是
+ * 「看起来像本季的数字」这个推断。
+ *
+ * 所以这里只认两种证据:
+ *
+ *  1. `S01E03` —— 这套写法**在构造上**就把季和集分开了,E 后面的数字按
+ *     定义是本季内的序号。这是唯一一条自证的格式。
+ *  2. `總第67` —— 文件名自己声明了一个系列级的数字。它和我们读到的数字
+ *     相等,说明我们读的就是那个系列级数字;不相等,说明这个文件同时给出
+ *     了两套数,而我们读到的是另一套 —— 也就是本季的。
+ *
+ * 其余一律 `unknown`,包括「文件名里有第 2 季字样」这种。`第二季 + 第87話`
+ * 完全可能是连续编号的第 87 集 —— 季度标记说明这一集属于哪一季,说明不了
+ * 那个数字是从哪儿开始数的。**没有证据必须读作 unknown,绝不能默认成
+ * perSeason**:这和 `episodeOffset` 那里「0 是答案、undefined 不是」是同一
+ * 条纪律,反过来那一半。
+ *
+ * 一处已知的钝角:第一季里 `第03話` 和 `總第03` 是同一个数,于是会判成
+ * `absolute`。这不产生错误答案 —— 两套编号在第一季本来就重合,任何消费方
+ * 用 offset 0 从 absolute 换算回来得到的还是 3。
+ *
+ * @typedef {'perSeason'|'absolute'|'unknown'} NumberSpace
+ */
+
+/**
+ * @param {{ number: number, origin: string } | null} match
+ * @param {number|null} episodeAlt
+ * @returns {NumberSpace}
+ */
+function resolveNumberSpace(match, episodeAlt) {
+  if (!match) return 'unknown';
+  if (match.origin === 'seasonEpisode') return 'perSeason';
+  if (episodeAlt !== null) {
+    return match.number === episodeAlt ? 'absolute' : 'perSeason';
+  }
+  return 'unknown';
+}
+
 const RESOLUTION_LABEL_MAP = {
   '4k': '2160p',
 };
@@ -337,21 +412,26 @@ const RESOLUTION_LABEL_MAP = {
  *
  * `season` 表示这一集**所在季**(从文件名 4th / S2 / 第N季 / 罗马数字推断,null 表示未识别)。
  * `episodeAlt` 是繁中字幕组的"总集号" (`總第N`) — 跨季全局递增。
- * `number` 是文件名表面的集号 (本季内的 01..N),与 `episodeAlt` 互不冲突,可同时存在。
+ * `number` 是文件名表面的集号,`numberSpace` 说的是**那个数字属于哪套编号**
+ * (`perSeason` / `absolute` / `unknown`,判据见 NumberSpace 的注释)。
+ * 注意 `number` 与 `episodeAlt` 互不冲突,可同时存在 —— 那正是能判出
+ * `perSeason` 的少数情形之一。
  *
  * @param {string} filename
- * @returns {{ title: string|null, number: number|null, kind: 'main'|'sp'|'ova'|'movie'|'pv'|'commentary'|'ncop'|'nced'|'bonus'|'trailer'|'interview'|'wp'|'cm'|'unknown', group: string|null, resolution: '480p'|'720p'|'1080p'|'2160p'|null, season: number|null, episodeAlt: number|null }}
+ * @returns {{ title: string|null, number: number|null, numberSpace: NumberSpace, kind: 'main'|'sp'|'ova'|'movie'|'pv'|'commentary'|'ncop'|'nced'|'bonus'|'trailer'|'interview'|'wp'|'cm'|'unknown', group: string|null, resolution: '480p'|'720p'|'1080p'|'2160p'|null, season: number|null, episodeAlt: number|null }}
  */
 export function parseEpisodeMeta(filename) {
   if (!filename) {
-    return { title: null, number: null, kind: 'unknown', group: null, resolution: null, season: null, episodeAlt: null };
+    return { title: null, number: null, numberSpace: 'unknown', kind: 'unknown', group: null, resolution: null, season: null, episodeAlt: null };
   }
 
   const title      = parseAnimeKeyword(filename);
-  const number     = parseEpisodeNumber(filename);
+  const match      = matchEpisodeNumber(filename);
+  const number     = match ? match.number : null;
   const kind       = parseEpisodeKind(filename);
   const season     = parseSeason(filename);
   const episodeAlt = parseAbsoluteEpisode(filename);
+  const numberSpace = resolveNumberSpace(match, episodeAlt);
 
   const groupMatch = filename.match(GROUP_RE);
   const group      = groupMatch ? groupMatch[1].trim() : null;
@@ -367,5 +447,5 @@ export function parseEpisodeMeta(filename) {
     if (!['480p', '720p', '1080p', '2160p'].includes(resolution)) resolution = null;
   }
 
-  return { title, number, kind, group, resolution, season, episodeAlt };
+  return { title, number, numberSpace, kind, group, resolution, season, episodeAlt };
 }

--- a/next-app/src/app/[lang]/library/_hooks/episodeParser.test.js
+++ b/next-app/src/app/[lang]/library/_hooks/episodeParser.test.js
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseAbsoluteEpisode,
+  parseEpisodeMeta,
+  parseEpisodeNumber,
+  parseSeason,
+} from "./episodeParser";
+
+// episodeParser is where every local episode number in the product is born,
+// and until now it had no tests at all. Five ordered regexes, a resolution
+// blacklist and a scrubbed digit fallback decide what `Episode.number` is for
+// every file anyone imports, and nothing pinned any of it.
+//
+// Two jobs here. The first block is a regression net for behaviour that
+// already existed: the pattern table was lifted out of `parseEpisodeNumber`
+// into a module constant so each entry could carry which numbering it proves,
+// and a refactor of the one function nobody was testing is exactly the kind
+// that goes wrong quietly. The second block pins the new fact — `numberSpace`
+// — and most of its cases assert that the parser says "unknown", because
+// admitting ignorance is the whole point of the field.
+
+describe("parseEpisodeNumber — the behaviour the pattern table has to preserve", () => {
+  test("S01E03 reads the episode, not the season", () => {
+    expect(parseEpisodeNumber("[Sakurato] Frieren [S02E03][1080p].mkv")).toBe(3);
+  });
+
+  test("EP03 / E03 / EP 03 all read 3", () => {
+    expect(parseEpisodeNumber("Show EP03.mkv")).toBe(3);
+    expect(parseEpisodeNumber("Show E03.mkv")).toBe(3);
+    expect(parseEpisodeNumber("Show EP 03.mkv")).toBe(3);
+  });
+
+  test("★ the word boundary before E is load-bearing", () => {
+    // Without `\b`, the `e 2` inside this title matched and collapsed all
+    // seven files of the cluster onto episode 2.
+    expect(parseEpisodeNumber("[Group] Class de 2-banme [05][1080p].mkv")).toBe(5);
+  });
+
+  test("第03話 / 第3集 read the CJK episode marker", () => {
+    expect(parseEpisodeNumber("[NC-Raws] 鬼滅 [第03話][WebRip 1080p].mkv")).toBe(3);
+    expect(parseEpisodeNumber("某番 第3集.mp4")).toBe(3);
+  });
+
+  test("a dash-delimited number reads, including a four-digit one", () => {
+    expect(parseEpisodeNumber("[Lilith-Raws] One Piece - 1091 [1080p].mkv")).toBe(1091);
+  });
+
+  test("a bracketed number reads, with or without a version suffix", () => {
+    expect(parseEpisodeNumber("[VCB] Steins Gate [12][Ma10p_1080p].mkv")).toBe(12);
+    expect(parseEpisodeNumber("[Group] Show [07v2][1080p].mkv")).toBe(7);
+  });
+
+  test("★ a resolution is never an episode number", () => {
+    // The blacklist skips to the NEXT pattern rather than giving up, so the
+    // real number behind a resolution-shaped match still has to be found.
+    expect(parseEpisodeNumber("[Group] Show [1080][BDRip].mkv")).toBeNull();
+    expect(parseEpisodeNumber("[Group] Show [1080p][05].mkv")).toBe(5);
+  });
+
+  test("★ codec tokens are scrubbed before the bare-digit fallback", () => {
+    // `10bit` → episode 10 would let a BD extra steal the main lane's slot.
+    expect(parseEpisodeNumber("[NCOP1][1080P][HEVC-10bit][FLAC].mkv")).toBeNull();
+    expect(parseEpisodeNumber("Show 24 [x265][FLAC].mkv")).toBe(24);
+  });
+
+  test("a filename with no number at all is null, not zero", () => {
+    expect(parseEpisodeNumber("[Group] Show [Menu][1080p].mkv")).toBeNull();
+  });
+});
+
+describe("numberSpace — what the filename can actually prove", () => {
+  test("★ S01E03 is the one format that proves its own numbering", () => {
+    const meta = parseEpisodeMeta("[Sakurato] Frieren [S02E03][1080p].mkv");
+    expect(meta.number).toBe(3);
+    expect(meta.numberSpace).toBe("perSeason");
+  });
+
+  test("★ a bare bracketed number proves nothing", () => {
+    // This is the dominant fansub form and the one continuous numbering hides
+    // in: [03] of season two and [15] of the whole run look identical.
+    expect(parseEpisodeMeta("[VCB] Steins Gate [12][Ma10p_1080p].mkv").numberSpace)
+      .toBe("unknown");
+  });
+
+  test("★ a season in the name does NOT make the number per-season", () => {
+    // 第二季 + 第87話 is routinely a continuously numbered 87. The season
+    // token says which season the episode belongs to; it says nothing about
+    // where its numbering starts.
+    const meta = parseEpisodeMeta("[Group] 進撃の巨人 第二季 [第87話][1080p].mkv");
+    expect(meta.season).toBe(2);
+    expect(meta.number).toBe(87);
+    expect(meta.numberSpace).toBe("unknown");
+  });
+
+  test("★ 總第N alongside a different number means ours is the season's", () => {
+    const meta = parseEpisodeMeta("[千夏字幕組][哆啦A夢][總第67][第03話][1080P].mkv");
+    expect(meta.number).toBe(3);
+    expect(meta.episodeAlt).toBe(67);
+    expect(meta.numberSpace).toBe("perSeason");
+  });
+
+  test("★ 總第N as the only number means we read the franchise's own count", () => {
+    const meta = parseEpisodeMeta("[Sakura][Doraemon][總第67][BIG5][1080P].mp4");
+    expect(meta.number).toBe(67);
+    expect(meta.episodeAlt).toBe(67);
+    expect(meta.numberSpace).toBe("absolute");
+  });
+
+  test("a continuously numbered long-runner is unknown, not absolute", () => {
+    // 1091 IS absolute in fact — but the filename never says so, and a guess
+    // that happens to be right is still a guess. The whole reason this field
+    // exists is that the last inference of this shape put 21,001 episode-title
+    // rows past their own season's episode count.
+    const meta = parseEpisodeMeta("[Lilith-Raws] One Piece - 1091 [1080p].mkv");
+    expect(meta.number).toBe(1091);
+    expect(meta.numberSpace).toBe("unknown");
+  });
+
+  test("no number at all is unknown", () => {
+    const meta = parseEpisodeMeta("[Group] Show [Menu][1080p].mkv");
+    expect(meta.number).toBeNull();
+    expect(meta.numberSpace).toBe("unknown");
+  });
+
+  test("an empty filename answers unknown rather than throwing", () => {
+    expect(parseEpisodeMeta("").numberSpace).toBe("unknown");
+    expect(parseEpisodeMeta(null).numberSpace).toBe("unknown");
+  });
+
+  test("every meta carries the field, so absent can never be mistaken for a verdict", () => {
+    for (const name of [
+      "[Group] Show [03][1080p].mkv",
+      "[Group] Show [S01E03][1080p].mkv",
+      "[Group] Show [Menu].mkv",
+      "Show - 12 .mkv",
+    ]) {
+      expect(parseEpisodeMeta(name)).toHaveProperty("numberSpace");
+    }
+  });
+});
+
+describe("the two signals numberSpace is derived from", () => {
+  test("parseSeason reads the season, in priority order", () => {
+    expect(parseSeason("[Group] Show [S02E03].mkv")).toBe(2);
+    expect(parseSeason("[Group] Show Season 4 [03].mkv")).toBe(4);
+    expect(parseSeason("[Group] Show 3rd Season [03].mkv")).toBe(3);
+    expect(parseSeason("[Group] Show S2 [03].mkv")).toBe(2);
+    expect(parseSeason("[Group] 某番 第4季 [03].mkv")).toBe(4);
+    expect(parseSeason("[Group] 某番 第四季 [03].mkv")).toBe(4);
+    expect(parseSeason("[Group][Show II][03].mkv")).toBe(2);
+    expect(parseSeason("[Group] Show [03].mkv")).toBeNull();
+  });
+
+  test("★ a Roman numeral only counts in a season-tail position", () => {
+    // The rule is deliberately narrow so a numeral inside a title — the
+    // comment names "FF VII Remake" — is not read as a season. Mid-name is
+    // therefore null, and that is the answer, not a miss.
+    expect(parseSeason("[Group] Show II [03].mkv")).toBeNull();
+    expect(parseSeason("[Group] Final Fantasy VII Remake [03].mkv")).toBeNull();
+    expect(parseSeason("[Group] Show III - 03 .mkv")).toBe(3);
+  });
+
+  test("parseAbsoluteEpisode reads 總第N and 总第N, and nothing else", () => {
+    expect(parseAbsoluteEpisode("[Group][總第67][03].mkv")).toBe(67);
+    expect(parseAbsoluteEpisode("[Group][总第 67][03].mkv")).toBe(67);
+    // Its own doc is explicit that a null means "the name has no such marker",
+    // never "this file has no absolute number".
+    expect(parseAbsoluteEpisode("[Group] Show [67].mkv")).toBeNull();
+  });
+});

--- a/next-app/src/app/[lang]/library/_hooks/useVideoFiles.ts
+++ b/next-app/src/app/[lang]/library/_hooks/useVideoFiles.ts
@@ -39,6 +39,22 @@ export interface ParsedEpisodeItem {
   parsedResolution?: string;
   parsedSeason?: number;
   parsedEpisodeAlt?: number;
+  /**
+   * Which numbering `episode` is in — "perSeason" | "absolute" | "unknown",
+   * decided by episodeParser from the filename alone.
+   *
+   * Carried, not acted on. The consumers that would use it (the grid's
+   * offset inference, the danmaku match request, watchSync's translation)
+   * each infer a space today from `episodeOffset` + `totalEpisodes`, and
+   * changing what they infer from is a separate change with its own
+   * regressions. This lane exists so that when they do, the evidence is
+   * already alongside the number instead of having to be re-derived from a
+   * filename nobody kept.
+   *
+   * Absent means unknown — never assume perSeason for a field that was not
+   * written.
+   */
+  parsedNumberSpace?: "perSeason" | "absolute" | "unknown";
 }
 
 export interface ProcessFilesOptions {
@@ -148,6 +164,7 @@ export function useVideoFiles(): UseVideoFilesResult {
           parsedResolution: meta.resolution,
           parsedSeason: meta.season,
           parsedEpisodeAlt: meta.episodeAlt,
+          parsedNumberSpace: meta.numberSpace,
         };
       });
 

--- a/next-app/src/lib/library/types.js
+++ b/next-app/src/lib/library/types.js
@@ -18,6 +18,9 @@
  * @property {number}  [parsedNumber]       - 从文件名解析出的集号(本季内)
  * @property {number}  [parsedSeason]       - 从文件名解析出的季号(4th / S2 / 第N季 / 罗马数字),null 表示未识别
  * @property {number}  [parsedEpisodeAlt]   - 繁中字幕组的"總第N"总集号,跨季全局递增;null 表示无此标记
+ * @property {'perSeason'|'absolute'|'unknown'} [parsedNumberSpace] - `episode` 属于哪套编号。
+ *   只在文件名自证时才不是 unknown(`S01E03`,或同时出现 `總第N`);缺失一律读作 unknown。
+ *   目前只携带不消费 —— 见 useVideoFiles.ts 上的说明。
  * @property {'main'|'sp'|'ova'|'movie'|'pv'|'commentary'|'ncop'|'nced'|'bonus'|'trailer'|'interview'|'wp'|'cm'|'menu'|'unknown'} parsedKind - 集类型
  * @property {string}  [parsedGroup]        - 字幕组(从括号标签提取)
  * @property {'480p'|'720p'|'1080p'|'2160p'} [parsedResolution]   - 分辨率标签


### PR DESCRIPTION
## Why

Every local episode number in the product is born in `parseEpisodeNumber`, and that function had **no tests at all** and discarded the one fact a per-episode mapping layer needs: whether the number it read is the season's own 1..N or the whole series' continuous count.

The two are indistinguishable as values. `[03]`, `第03話` and ` - 03 ` produce the same string for season two's third episode and for the franchise's third, and which one a group means is a habit rather than anything in the filename. The site has already paid for guessing: **21,001 episode-title rows landed past their own season's episode count**, produced by code that assumed a number which looked like a season's was one.

## What counts as evidence

`parseEpisodeMeta` now returns `numberSpace`, and it admits ignorance by default.

| filename | `number` | `numberSpace` | why |
|---|---|---|---|
| `[Sakurato] Frieren [S02E03]` | 3 | `perSeason` | the format splits season from episode by construction |
| `[千夏][哆啦A夢][總第67][第03話]` | 3 | `perSeason` | the file carries both counts; ours is the other one |
| `[Sakura][Doraemon][總第67]` | 67 | `absolute` | we read the franchise's own declared count |
| `[VCB] Steins Gate [12]` | 12 | `unknown` | the dominant fansub form proves nothing |
| `[Group] 進撃の巨人 第二季 [第87話]` | 87 | `unknown` | a season marker says which season, not where numbering starts |
| `One Piece - 1091` | 1091 | `unknown` | it *is* absolute in fact, but the name never says so |

That last row is the discipline: a guess that happens to be right is still a guess. **Absent reads as `unknown`, never as `perSeason`** — the same rule `episodeOffset`'s "0 is an answer, `undefined` is not" encodes, from the other side.

## How

`parseEpisodeNumber`'s inline pattern array became a module constant whose entries carry what each pattern can prove. Ordering, regexes, the resolution blacklist and the scrubbed-digit fallback are unchanged, and `parseEpisodeNumber` keeps its signature so no caller moves.

## Carried, not consumed

The field rides `ParsedEpisodeItem` and nothing reads it yet. The three consumers that would — the grid's offset inference, the danmaku match request, `watchSync`'s translation — each infer a space today from `episodeOffset` + `totalEpisodes`, and changing what they infer from is a separate change with its own regressions. This puts the evidence beside the number so that when they do, it is not re-derived from a filename nobody kept.

## Test plan

- [x] `bun test` — 1921 pass / 0 fail
- [x] `bunx tsc --noEmit` clean, `eslint-ratchet` OK
- [x] **21 new tests, the module's first.** Nine are a regression net for behaviour that already existed — refactoring the one function nobody was testing is exactly the kind that goes wrong quietly: the `\b` before `E` that stopped `Class de 2-banme` collapsing seven files onto ep2, the resolution blacklist skipping to the *next* pattern rather than giving up, `10bit` not becoming episode 10.
- [x] One of my own assertions was wrong and the code was right: `parseSeason` deliberately reads a Roman numeral only in a season-tail position, so `Show II [03]` is `null`. Now pinned in both directions, with `FF VII Remake` as the case the narrowness exists for.