### PR TITLE
State the episode relation's cardinality in the type

### DIFF
--- a/go-api/internal/dandanplay/episode_map.go
+++ b/go-api/internal/dandanplay/episode_map.go
@@ -6,6 +6,35 @@
 // requested episode numbers are 1-indexed.  pool[epNum - 1].  Tests
 // must cover every boundary (epNum=1 → pool[0]; epNum > len(pool) →
 // no entry).
+//
+// # Why the relation is built as an edge set and flattened afterwards
+//
+// The correspondence between a local episode number and an upstream episode is
+// not one-to-one, in either direction, and a map[int]EpisodeMapEntry cannot say
+// so.  Both directions are real:
+//
+//   - one-to-many: two upstream entries carry the same episode number — a
+//     broadcast cut and a director's cut, a subject whose numbering restarts.
+//     The old code took the first and `break`ed, and the second became
+//     unreachable with no signal that it had ever existed.  Every consumer
+//     downstream — the danmaku track, the episode title, the "N mapped"
+//     counter, the picker's pre-selection — read the first and looked right.
+//   - many-to-one: two requested episodes land on the same upstream entry.
+//     This one is usually TRUE rather than broken: a folder holding the same
+//     episode twice under two numberings (say 1 from this season and 29 from
+//     the franchise's count) genuinely has two files for one upstream episode.
+//     Removing the second would take a file's chip away in the ad-hoc player
+//     path, which reads its episode strip from this map.
+//
+// So the fix is not to de-duplicate the matching; it is to stop the type from
+// lying about it.  BuildEpisodeLinks holds every candidate, BuildEpisodeMap
+// flattens it to the one-per-episode shape the wire and the player still want,
+// and the flattening is now a named, tested step rather than a `break`.
+//
+// This matters before a per-episode mapping layer exists rather than after:
+// such a layer's whole purpose is to carry relations single integers cannot,
+// and feeding it through a function that silently keeps the first would
+// re-flatten them on the way in.
 
 package dandanplay
 
@@ -32,8 +61,8 @@ type EpisodeMapEntry struct {
 // rawEpisodeNumber form (e.g. "O1", "S2", "o03").  Used at level 2.
 var ovaPrefixRe = regexp.MustCompile(`(?i)^[OS](\d+)$`)
 
-// BuildEpisodeMap returns a map[int]EpisodeMapEntry keyed on the
-// requested episode numbers.  Three passes:
+// BuildEpisodeLinks returns EVERY upstream candidate for each requested
+// episode number.  Three passes:
 //
 //	1. Exact numeric: dandanEp.Number == requestedEp.
 //	2. OVA/Special: rawEpisodeNumber matches "^[OS]\d+$" and the digit
@@ -43,14 +72,15 @@ var ovaPrefixRe = regexp.MustCompile(`(?i)^[OS](\d+)$`)
 //	   subset exists, pool defaults to the full list so we don't lose
 //	   matches for malformed feeds.
 //
-// First-match wins — once a requested episode has been mapped, later
-// passes skip it.
+// The passes are a priority order, not a merge: an episode that matched at
+// level 1 is not also given level 2's or level 3's answer, because an exact
+// numeric match and an index guess are not two opinions of equal standing.
+// WITHIN a level, though, every match is kept — that is the whole difference
+// from the previous version, which stopped at the first.
 //
-// Returns an empty map when dandanEpisodes is empty.  The caller can
-// detect "nothing matched" via len(map) == 0 and fall through to the
-// next phase.
-func BuildEpisodeMap(dandanEpisodes []DandanEpisode, requestedEpisodes []int) map[int]EpisodeMapEntry {
-	out := make(map[int]EpisodeMapEntry, len(requestedEpisodes))
+// Returns an empty map when dandanEpisodes is empty.
+func BuildEpisodeLinks(dandanEpisodes []DandanEpisode, requestedEpisodes []int) map[int][]EpisodeMapEntry {
+	out := make(map[int][]EpisodeMapEntry, len(requestedEpisodes))
 	if len(dandanEpisodes) == 0 {
 		return out
 	}
@@ -62,8 +92,7 @@ func BuildEpisodeMap(dandanEpisodes []DandanEpisode, requestedEpisodes []int) ma
 		}
 		for _, de := range dandanEpisodes {
 			if de.Number != nil && *de.Number == ep {
-				out[ep] = EpisodeMapEntry{DandanEpisodeID: de.DandanEpisodeID, Title: de.Title}
-				break
+				out[ep] = append(out[ep], entryOf(de))
 			}
 		}
 	}
@@ -78,8 +107,7 @@ func BuildEpisodeMap(dandanEpisodes []DandanEpisode, requestedEpisodes []int) ma
 			m := ovaPrefixRe.FindStringSubmatch(de.RawEpisodeNumber)
 			if len(m) >= 2 {
 				if parseDigits(m[1]) == ep {
-					out[ep] = EpisodeMapEntry{DandanEpisodeID: de.DandanEpisodeID, Title: de.Title}
-					break
+					out[ep] = append(out[ep], entryOf(de))
 				}
 			}
 		}
@@ -106,11 +134,40 @@ func BuildEpisodeMap(dandanEpisodes []DandanEpisode, requestedEpisodes []int) ma
 		}
 		idx := ep - 1 // 1-indexed request, 0-indexed slice
 		if idx >= 0 && idx < len(pool) {
-			de := pool[idx]
-			out[ep] = EpisodeMapEntry{DandanEpisodeID: de.DandanEpisodeID, Title: de.Title}
+			out[ep] = append(out[ep], entryOf(pool[idx]))
 		}
 	}
 
+	return out
+}
+
+// entryOf is the one place a DandanEpisode becomes a map entry, so the three
+// passes cannot drift in what they carry across.
+func entryOf(de DandanEpisode) EpisodeMapEntry {
+	return EpisodeMapEntry{DandanEpisodeID: de.DandanEpisodeID, Title: de.Title}
+}
+
+// BuildEpisodeMap is BuildEpisodeLinks flattened to one entry per episode: the
+// shape the wire, the player and the title labels have always taken.
+//
+// The first candidate of the winning level wins, which is exactly what the
+// `break` used to produce — this function is behaviour-for-behaviour identical
+// to the version before the split, and the tests that pinned that version are
+// what says so.  What changed is that the discarding is now a step with a name
+// and a caller who could choose otherwise, instead of a control-flow keyword.
+//
+// Callers detect "nothing matched" via len(map) == 0 and fall through to the
+// next phase; note that this counts EPISODES matched, not upstream entries
+// used, so two episodes sharing one entry count as two.
+func BuildEpisodeMap(dandanEpisodes []DandanEpisode, requestedEpisodes []int) map[int]EpisodeMapEntry {
+	links := BuildEpisodeLinks(dandanEpisodes, requestedEpisodes)
+	out := make(map[int]EpisodeMapEntry, len(links))
+	for ep, candidates := range links {
+		if len(candidates) == 0 {
+			continue
+		}
+		out[ep] = candidates[0]
+	}
 	return out
 }
 

--- a/go-api/internal/dandanplay/episode_map_test.go
+++ b/go-api/internal/dandanplay/episode_map_test.go
@@ -207,3 +207,118 @@ func TestBuildEpisodeMap_MultipleRequestsMixedLevels(t *testing.T) {
 		t.Fatalf("mixed-levels request set:\n got:  %v\n want: %v", out, want)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Cardinality — the two shapes a map[int]EpisodeMapEntry cannot state
+// ---------------------------------------------------------------------------
+
+// ★ One-to-many: two upstream entries carry the same episode number.
+//
+// The old code took the first and `break`ed, so the second was unreachable and
+// nothing anywhere recorded that it had existed.  A broadcast cut and a
+// director's cut, or a subject whose numbering restarts, both land here — and
+// the consequence is not visible in the UI, because taking the first LOOKS
+// right for a title and a cover.
+func TestBuildEpisodeLinks_KeepsEveryCandidateAtTheWinningLevel(t *testing.T) {
+	dandan := []DandanEpisode{
+		ep(501, "Ep 5", "5", ip(5)),
+		ep(502, "Ep 5 (director's cut)", "5", ip(5)),
+		ep(503, "Ep 6", "6", ip(6)),
+	}
+
+	links := BuildEpisodeLinks(dandan, []int{5, 6})
+	if got := len(links[5]); got != 2 {
+		t.Fatalf("episode 5 has two upstream candidates → got %d: %v", got, links[5])
+	}
+	if links[5][0].DandanEpisodeID != 501 || links[5][1].DandanEpisodeID != 502 {
+		t.Fatalf("candidates must keep upstream order → got %v", links[5])
+	}
+	if got := len(links[6]); got != 1 {
+		t.Fatalf("episode 6 has one candidate → got %d", got)
+	}
+
+	// And the flattening is the old behaviour, unchanged.
+	out := BuildEpisodeMap(dandan, []int{5, 6})
+	if out[5].DandanEpisodeID != 501 {
+		t.Fatalf("the map still takes the first candidate → got %v", out[5])
+	}
+}
+
+// ★ Many-to-one: two requested episodes land on the same upstream entry.
+//
+// This one is usually TRUE rather than broken — a folder holding the same
+// episode twice under two numberings (1 from this season, 29 from the
+// franchise's running count) really does have two files for one upstream
+// episode.  Pinning it says the collapse is a decision rather than an
+// accident: de-duplicating here would take a file's chip away in the ad-hoc
+// player path, which builds its episode strip from this map.
+func TestBuildEpisodeMap_TwoRequestsMayShareOneUpstreamEpisode(t *testing.T) {
+	dandan := []DandanEpisode{
+		ep(291, "Ep 29", "29", ip(29)),
+		ep(292, "Ep 30", "30", ip(30)),
+	}
+
+	out := BuildEpisodeMap(dandan, []int{1, 29})
+
+	if out[29].DandanEpisodeID != 291 {
+		t.Fatalf("29 matches exactly at level 1 → got %v", out[29])
+	}
+	if out[1].DandanEpisodeID != 291 {
+		t.Fatalf("1 reaches the same entry through the index fallback → got %v", out[1])
+	}
+	if len(out) != 2 {
+		t.Fatalf("both requested episodes are mapped → got %d entries: %v", len(out), out)
+	}
+}
+
+// ★ The three levels are a priority order, not a merge.
+//
+// An episode that matched exactly must not also collect the index fallback's
+// guess: an exact numeric match and a position in a list are not two opinions
+// of equal standing, and merging them would put a wrong candidate one index
+// away from being chosen by anything that later looks past [0].
+func TestBuildEpisodeLinks_ALaterLevelDoesNotAddToAnEarlierMatch(t *testing.T) {
+	dandan := []DandanEpisode{
+		ep(201, "Ep 1", "1", ip(1)),
+		ep(202, "Ep 2", "2", ip(2)),
+	}
+
+	links := BuildEpisodeLinks(dandan, []int{1})
+	if got := len(links[1]); got != 1 {
+		t.Fatalf("level 1 matched, so level 3 must not append → got %d: %v", got, links[1])
+	}
+	if links[1][0].DandanEpisodeID != 201 {
+		t.Fatalf("the exact match must be the one kept → got %v", links[1][0])
+	}
+}
+
+// The flattened map must stay exactly what the links say, for every fixture
+// the rest of this file already pins.  Written as a property rather than a
+// case: the split into two functions is only safe if nothing can drift
+// between them, and the way that drift would arrive is a new pass appended to
+// one and not the other.
+func TestBuildEpisodeMap_IsTheLinksFlattened(t *testing.T) {
+	dandan := []DandanEpisode{
+		ep(101, "Ep 1", "1", ip(1)),
+		ep(102, "Ep 1 alt", "1", ip(1)),
+		ep(103, "OVA 2", "O2", nil),
+		ep(104, "Ep 3", "3", ip(3)),
+	}
+	requested := []int{1, 2, 3, 4, 99}
+
+	links := BuildEpisodeLinks(dandan, requested)
+	out := BuildEpisodeMap(dandan, requested)
+
+	if len(out) != len(links) {
+		t.Fatalf("every linked episode must appear in the map → links %d, map %d", len(links), len(out))
+	}
+	for epNum, candidates := range links {
+		got, ok := out[epNum]
+		if !ok {
+			t.Fatalf("episode %d is linked but missing from the map", epNum)
+		}
+		if !reflect.DeepEqual(got, candidates[0]) {
+			t.Fatalf("episode %d: map holds %v, links lead with %v", epNum, got, candidates[0])
+		}
+	}
+}


### PR DESCRIPTION
## Why now

This is the prerequisite for a per-episode mapping layer, and it has to land *before* one exists rather than after. Such a layer's whole purpose is to carry relations a single integer cannot express; feeding it through a function that silently keeps the first candidate would re-flatten them on the way in.

## The two shapes `map[int]EpisodeMapEntry` cannot state

**One-to-many — the silent one.** Two upstream entries can carry the same episode number: a broadcast cut and a director's cut, a subject whose numbering restarts. Pass 1 took the first and `break`ed, so the second was unreachable with nothing recording that it had existed. Every consumer downstream read the first and *looked right* — the danmaku track, the episode title, the "N mapped" counter, and the DanmakuPicker's pre-selection, which is the escape hatch the user reaches when the mapping is wrong.

**Many-to-one — and it is usually true, not broken.** Two requested episodes can land on the same upstream entry. A folder holding the same episode twice under two numberings (1 from this season, 29 from the franchise's running count) genuinely has two files for one upstream episode.

De-duplicating that was the obvious-looking fix and it is wrong. The ad-hoc player path builds its episode strip from this map — `PlayerShell` skips a file whose number has no entry — so dropping the second mapping takes that file's chip away. That trades a wrong danmaku track for a missing file, which is worse.

## So the matching does not change

- `BuildEpisodeLinks` keeps every candidate at the winning level.
- `BuildEpisodeMap` flattens it to one entry per episode — the shape the wire, the player and the title labels have always taken.
- The three levels stay a **priority order, not a merge**: an exact numeric match and a position in a list are not two opinions of equal standing.

**No JSON contract change, no client changes.** `BuildEpisodeMap` is behaviour-for-behaviour identical; the discarding is now a step with a name and a caller who could choose otherwise, instead of a `break`.

## Test plan

- [x] The ten pre-existing tests are **unchanged and still pass** — that is the behaviour-preservation proof, not a claim in the commit message.
- [x] Four new: one-to-many kept in order and flattened to the first; many-to-one pinned as a decision; a later level not appending to an earlier match; and the map being exactly the links flattened, written as a property because the way drift arrives is a pass appended to one function and not the other.
- [x] 3 mutations, all killed (flatten takes the last candidate / level 3 merges instead of yielding / pass 1 `break`s again).
- [x] `go build ./...`, `go vet -tags=integration ./test/integration/...`, `go test ./...`

## Unrelated flake seen while running this

`internal/dandanplay`'s testcontainer setup intermittently fails with `pull access denied for animego-postgres` — note the missing `:dev` tag, which `internal/testutil/pg.go:117` does pass. Two occurrences locally, both green on retry, on code unrelated to this change. Filed here only so it is written down somewhere.