### PR TITLE
Give the source-map upload a destination, not just a key

### DIFF
--- a/.env.production.template
+++ b/.env.production.template
@@ -165,8 +165,19 @@ NEXT_PUBLIC_SENTRY_DSN=
 
 # [SECRET] [BUILD] [N]  optional. Used by @sentry/nextjs at build to upload
 # sourcemaps. To change, you MUST rebuild the next-app image.
-# Generate at https://your-org.sentry.io/settings/account/api/auth-tokens/
+# Generate an ORGANIZATION token at
+# https://your-org.sentry.io/settings/auth-tokens/ — its fixed org:ci scope
+# set (Source Map Upload, Release Creation, Code Mappings) is exactly what
+# the upload needs, and it is not tied to one person's account.
 SENTRY_AUTH_TOKEN=
+
+# [INFRA] [BUILD] [N]  optional, but REQUIRED whenever SENTRY_AUTH_TOKEN is
+# set: next.config.ts names neither, so the bundler plugin reads both from
+# the environment to decide where to upload. A token without them is a
+# credential with no destination. Values are the slugs in the Sentry URL:
+# https://<SENTRY_ORG>.sentry.io/projects/<SENTRY_PROJECT>/
+SENTRY_ORG=
+SENTRY_PROJECT=
 
 # [INFRA] [E N G]  optional. Server-side DSN for Express, next-app server,
 # and go-api. Runtime read — restart is enough to pick up changes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,11 @@ services:
       # client bundle. Empty default keeps a build-without-env working.
       args:
         NEXT_PUBLIC_SENTRY_DSN: ${NEXT_PUBLIC_SENTRY_DSN:-}
+        # The token says who may upload; these two say where to. All three
+        # have to reach the build or the source-map step cannot run.
         SENTRY_AUTH_TOKEN: ${SENTRY_AUTH_TOKEN:-}
+        SENTRY_ORG: ${SENTRY_ORG:-}
+        SENTRY_PROJECT: ${SENTRY_PROJECT:-}
         # Set by deploy.sh from `git rev-parse HEAD`; empty elsewhere.
         GIT_SHA: ${GIT_SHA:-}
     restart: unless-stopped

--- a/next-app/Dockerfile
+++ b/next-app/Dockerfile
@@ -35,10 +35,21 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # falsy DSN). SENTRY_AUTH_TOKEN drives source-map upload via
 # next.config.ts's `sourcemaps.disable: !process.env.SENTRY_AUTH_TOKEN`
 # gate — without it, the upload step skips and the build still passes.
+#
+# SENTRY_ORG / SENTRY_PROJECT are the other half of that gate and were the
+# reason a token alone would not have worked: next.config.ts does not name
+# an org or project, so the plugin resolves both from the environment. With
+# the token set and these two absent, the upload has a credential and no
+# destination — it fails at build rather than skipping, which is the loud
+# half of a footgun whose quiet half (no token at all) had been hiding it.
 ARG NEXT_PUBLIC_SENTRY_DSN=
 ARG SENTRY_AUTH_TOKEN=
+ARG SENTRY_ORG=
+ARG SENTRY_PROJECT=
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
+ENV SENTRY_ORG=$SENTRY_ORG
+ENV SENTRY_PROJECT=$SENTRY_PROJECT
 
 # The commit this image was built from. next.config.ts turns it into
 # NEXT_PUBLIC_BUILD_ID, which is how a tab opened before a deploy learns it


### PR DESCRIPTION
Production has never uploaded source maps, so no client stack frame Sentry holds can be symbolicated. Today's errors on the detail route arrived as `:2:186 (Function.u)` with numeric module ids and there was no way to tell which of our lines threw.

The cause is not just the missing token. `next.config.ts` gates the upload on `SENTRY_AUTH_TOKEN` alone, and neither it nor the build wiring names an org or project — the bundler plugin resolves both from the environment. Only the token crossed the image boundary (`next-app/Dockerfile` ARG, `docker-compose.yml` build arg), so setting a token on its own would have produced a credential with nowhere to upload to: that fails at build rather than skipping, and the skip — no token anywhere, which is the state production has always been in — was hiding it.

## What changed

- `next-app/Dockerfile`: `SENTRY_ORG` / `SENTRY_PROJECT` as ARG + ENV beside the existing token.
- `docker-compose.yml`: both passed as build args from the env file.
- `.env.production.template`: documented as required *whenever* the token is set, not optional next to it, with the org-token URL (the `org:ci` scope set — Source Map Upload, Release Creation, Code Mappings — is exactly what the upload needs and is not tied to one person's account).

## Behaviour

None until all three values are present on the host. The existing gate still skips the upload when the token is empty, so builds without them keep passing exactly as before.

## Validation

- `docker compose config` parses.
- Real verification is post-deploy and cannot be done from CI: with the three values set, the build log should show the artifact upload, the release should list artifacts in Sentry, and a fresh client error should resolve to a `.tsx` file and line.