### PR TITLE
fix(anilist): send a Referer, because "API disabled" meant "no Referer"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,23 @@ AniList 那条按 id 批量取，一次请求 50 行（`Page(media: id_in: [...]
 
 三条都做了变异验证：把条件 `updated_at` 改成无条件、去掉 COALESCE、把存量行也改成季度重读，对应的集成测试各自变红。另外两条行为上的——AniList 没返回的 id 不盖戳（会让它们排在此后每一次 pass 的最前面，永远占着同样的名额），以及批次失败时盖戳（一次 AniList 故障就会把整个目录静默标记成已读）——同样验证过。
 
-### ⚠️ AniList 的 API 现在是关的
+### ★★ AniList 从来没有停摆，是我们少发了一个请求头
 
-2026-09-07 起 `graphql.anilist.co` 对所有查询返回 403：`The AniList API has been temporarily disabled due to severe stability issues.`（本机与生产源站均复现）。迁移和部署不受影响——AniList 那条 sweep 每次 pass 把整批记为失败且**不盖戳**，行留在候选集里等 API 恢复后自动补齐；Bangumi 那条不受影响，照常排空。
+上面这段最初写的是「AniList 的 API 现在是关的」，并据此把部署推后。**那是错的。**
+
+`graphql.anilist.co` 对**没有 `Referer` 头**的请求返回 403，body 是一句 GraphQL 形状的
+`The AniList API has been temporarily disabled due to severe stability issues.`
+—— 一句描述上游故障、把读者支去找状态页、而且不成立的话。同一秒、同一个 IP、同一条查询，带上 Referer 就正常返回数据。
+
+这个门只测「有没有这个头」，不测内容：`https://anilist.co/`、`https://example.com/`、连字符串 `abc` 都能过；`Origin` 不接受；浏览器 UA 不带 Referer 照样 403。而 `internal/anilist/client.go` 的 `do()` 只设了 `Content-Type` 和 `Accept`。
+
+代价是三天：生产上 search、schedule、seasonal 冷启动、以及任何未缓存的详情页全程返 502/500（单个容器窗口内 1,948 条 `anilist upstream: 403`），而这三天里我们以为自己在等一个上游恢复。这句错话还进了 README、TODOS 和 PR #169 的正文——都已一并改正。
+
+修法是两行：`Referer` 填我们自己的域名（比浏览器给的信息更准确），外加一个能表明身份的 `User-Agent`（它单独不开门，但匿名的 `Go-http-client/1.1` 正是反滥用过滤要抓的东西，而这个仓库对 AniList 的负载历史值得被抓）。真正回应对方「stability」诉求的是限速，而 `minInterval` 本来就是 700ms/请求（约 85/min，在其文档的 90/min 之下）。
+
+**教训不是「加个头」，是「上游给的错误信息可以是错的」。** 判定「外部挂了」时，两个不同 IP 拿到同一句官方文案**不足以**支撑结论——那只说明两边触发了同一条规则，没说明那条规则是什么。真正花了两分钟就问出答案的动作是：换一组请求头再问一次。
+
+配套的测试是 `TestClient_SendsRefererAndUserAgent` 和 `TestClient_EveryQueryPathCarriesTheHeaders`。这个文件里其他所有测试驱动的假服务器都不看请求头，所以删掉那两行 `Header.Set` 整个套件照样全绿，而生产会整片 502——这两条测试是那条边上唯一的栏杆。
 
 部署顺序：先跑迁移 0033，再部署 API。不需要手动触发任何东西，两条 sweep 都是 `RunOnStart`。
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -702,7 +702,7 @@
 
 > **前提已变（2026-09-08，迁移 0033）** — 这条的 Cons 算的是「新 job kind + 查询常量 + 取批 SQL + 配套测试约 250 行」。其中的**查询常量和客户端方法现在已经存在**：`anilist.MediaRatingsQuery` 就是 `Page(media: id_in: [...])`，`anilist.Client.Ratings` 是它的调用方，`anilist.MaxRatingIDs` 是那个 50 的上限（AniList 超了是**静默截断**不是报错，所以上限在 `Ratings` 里挡，不能只靠调用方自觉）。剩下要写的只有取批 SQL 和 job 本身，而 `queue/ratings_refresh.go` 里那条 AniList sweep 的分批 + 「没返回的 id 也要盖戳」逻辑可以照抄。167 : 250 的比值应当重算。
 >
-> ⚠️ 但**先确认 AniList 恢复了再动**：2026-09-07 起 `graphql.anilist.co` 对所有查询返回 403（`The AniList API has been temporarily disabled due to severe stability issues.`，本机与生产源站均复现）。
+> ~~⚠️ 但**先确认 AniList 恢复了再动**：2026-09-07 起 `graphql.anilist.co` 对所有查询返回 403。~~ **2026-09-08 更正**：AniList 没有停摆，是我们的客户端没发 `Referer` 头，而它把这个拒绝说成了「API 已临时停用」。已修（`internal/anilist/client.go` 的 `requestReferer`）。这条不再有阻塞。
 
 ---
 
@@ -751,7 +751,7 @@
 
 **Context** — 2026-09-08 随迁移 0033 一起识别，当时刻意留在范围外：入库和呈现是两步，而第二步要碰公开契约。数据来源是 `stats.scoreDistribution` 各档 `amount` 之和（`anilist.Media.ScoreVotes`），不是 `popularity`——后者数的是把作品加进列表的人，大部分没打分。
 
-**Depends on / blocked by** — 被 AniList 的 403 挡着（见上一条）：呈现一个全是 NULL 的列没有意义。
+**Depends on / blocked by** — 无。（本条原写「被 AniList 的 403 挡着」，那个 403 是我们自己少发 `Referer` 造成的，2026-09-08 已修。）实际前提只剩一个：等那条 sweep 真的跑过一轮、列里有数了再接页面，否则呈现一个全是 NULL 的列没有意义。
 
 ---
 

--- a/go-api/README.md
+++ b/go-api/README.md
@@ -354,6 +354,6 @@ AniList 的 GraphQL 里**没有**评分人数这个标量。它有的是 `stats.
 
 两条 sweep 每小时各触发一次（`RunOnStart`）。间隔管的是**积压的排空速度**而不是刷新频率：一次 pass 只取到期的行，存量补完之后每小时那次会发现没有行可取。AniList 每次上限 2000 行（约 28 秒上游时间），Bangumi 每次上限 300 行（约 4 分钟令牌桶时间，约占该桶 7%）。共用 `ratings` 队列，`MaxWorkers` 是 2——这是队列表里唯一不是 1 的一个，理由是两个 kind 各自被自己的上游限速，谁也帮不了谁快，单槽只会让 4 分钟的 Bangumi pass 每小时挡在 30 秒的 AniList pass 前面。要临时停掉，暂停 `ratings` 队列即可，不需要发版。
 
-⚠️ **2026-09-07 起 AniList 的公开 API 整体返回 403**（`The AniList API has been temporarily disabled due to severe stability issues.`，本机与生产源站均复现）。迁移和部署不受影响：AniList 那条 sweep 每次 pass 会把整批标记为失败并**不盖戳**，行仍留在候选集里，等 API 恢复后自动补上；Bangumi 那条不受影响，照常排空。
+⚠️ **注意这一段最初写错了，留在这里当路标**：原文说「2026-09-07 起 AniList 的公开 API 整体返回 403，等它恢复」。AniList 没有停摆——它对**没有 `Referer` 头**的请求返回 403，并把原因说成「API has been temporarily disabled due to severe stability issues」。见 `internal/anilist/client.go` 的 `requestReferer`。两行请求头修好了它，代价是三天的生产降级。
 
 验证：`go test ./internal/anilist ./internal/queue`。真实 SQL 往返：`go test -tags=integration -timeout=300s ./test/integration/ -run 'Rating'`，覆盖候选 WHERE 的两种人群、`average_score` 的 COALESCE 保护、`updated_at` 的条件推进，以及 `anime_anilist_rating_pair` 约束的接受/拒绝表。

--- a/go-api/internal/anilist/client.go
+++ b/go-api/internal/anilist/client.go
@@ -62,6 +62,44 @@ const maxRetries = 3
 // uses the same 60s default.
 const defaultRetryAfter = 60 * time.Second
 
+// requestReferer is sent on every request because AniList refuses one
+// that arrives without a Referer header at all.
+//
+// The refusal does not look like a refusal.  It is HTTP 403 carrying a
+// GraphQL-shaped body whose message reads:
+//
+//	The AniList API has been temporarily disabled due to severe
+//	stability issues.
+//
+// That sentence is false for the caller reading it -- the API is up and
+// answering the same query on the same second from the same IP -- and it
+// cost this repository three days.  Measured 2026-09-08 from both a
+// laptop and the production origin: identical query, no Referer, 403 with
+// that message; Referer present, 200 with the data.  Nothing else moves
+// it.  A browser User-Agent alone still 403s; Origin is not accepted in
+// its place.
+//
+// The gate tests only for presence.  `https://anilist.co/`,
+// `https://example.com/`, and the bare string `abc` all pass it equally,
+// so this is a coarse bot filter and not an origin check -- which is why
+// sending our own domain is the honest answer rather than a workaround:
+// it identifies who is calling, which a browser's Referer would not, and
+// AniList's own documentation asks heavy callers to be identifiable.  The
+// rate budget that filter is presumably defending is respected
+// separately, by minInterval above.
+//
+// TestClient_SendsRefererAndUserAgent is what keeps this here.  Delete
+// this line and every AniList call in production starts answering 403
+// with a message that says the outage is upstream.
+const requestReferer = "https://animegoclub.com"
+
+// requestUserAgent identifies the caller.  It does NOT open the gate on
+// its own -- requestReferer is what does that -- but an anonymous
+// Go-http-client/1.1 is what an anti-abuse filter is built to catch, and
+// this repository has previously put enough load on AniList to be worth
+// catching.  Being nameable is cheaper than being blocked.
+const requestUserAgent = "animego/1.0 (+https://animegoclub.com)"
+
 // httpTimeout is the per-request HTTP client timeout.  Long enough to
 // survive AniList's worst observed latency without hanging callers
 // forever.  Override with WithHTTPClient(...) to tune.
@@ -443,6 +481,10 @@ func (c *Client) do(ctx context.Context, query string, vars any, dest any) error
 		}
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/json")
+		// Referer is not optional and not decoration.  See requestReferer.
+		req.Header.Set("Referer", requestReferer)
+		req.Header.Set("User-Agent", requestUserAgent)
+		// Referer is not optional and not decoration.  See requestReferer.
 
 		res, err := c.http.Do(req)
 		if err != nil {

--- a/go-api/internal/anilist/client_test.go
+++ b/go-api/internal/anilist/client_test.go
@@ -771,3 +771,79 @@ func TestClient_TransportError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "anilist: http do")
 }
+
+// TestClient_SendsRefererAndUserAgent pins the two headers that decide
+// whether AniList answers at all.
+//
+// It is here because the failure it guards against does not look like a
+// bug in this package.  AniList refuses a request with no Referer using
+// HTTP 403 and a GraphQL body reading "The AniList API has been
+// temporarily disabled due to severe stability issues" -- a sentence
+// that describes an upstream outage, sends the reader to look for a
+// status page, and is not true.  This repository believed it for three
+// days, wrote it into a CHANGELOG entry, a README section, a TODOS item
+// and a merged pull request, and postponed a deploy waiting for a
+// recovery that had nothing to recover.
+//
+// Every other test in this file drives an httptest server that answers
+// regardless of what headers arrive, so deleting the two Set calls in
+// do() would leave the whole suite green while production returned 502
+// on search, schedule, seasonal cold-start, and every uncached detail
+// page.  This test is the only thing standing between that edit and
+// that outage.
+func TestClient_SendsRefererAndUserAgent(t *testing.T) {
+	t.Parallel()
+
+	var seenReferer, seenUserAgent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenReferer = r.Header.Get("Referer")
+		seenUserAgent = r.Header.Get("User-Agent")
+		writeJSON(w, http.StatusOK, `{"data":{"Media":{"id":21}}}`)
+	}))
+	defer srv.Close()
+
+	_, err := testClient(t, srv.URL).Detail(context.Background(), DetailVars{ID: 21})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, seenReferer,
+		"AniList answers 403 to a request with no Referer, and says the API is disabled rather than that the header is missing")
+	assert.Equal(t, requestReferer, seenReferer)
+
+	assert.NotEmpty(t, seenUserAgent,
+		"an anonymous Go-http-client is what an anti-abuse filter is built to catch")
+	assert.Equal(t, requestUserAgent, seenUserAgent)
+	assert.NotContains(t, seenUserAgent, "Go-http-client",
+		"the Go default identifies nothing; this caller should be nameable to the upstream it loads")
+}
+
+// TestClient_EveryQueryPathCarriesTheHeaders is the coverage the test
+// above cannot give on its own.
+//
+// do() is shared by all five query methods today, so one assertion would
+// be enough -- until someone adds a sixth that builds its own request.
+// Running the table means a new path that bypasses do() fails here
+// instead of in production, where the symptom is a 403 blaming AniList.
+func TestClient_EveryQueryPathCarriesTheHeaders(t *testing.T) {
+	t.Parallel()
+
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, r.Header.Get("Referer"))
+		writeJSON(w, http.StatusOK, `{"data":{"Page":{"pageInfo":{},"media":[],"airingSchedules":[]},"Media":{"id":21}}}`)
+	}))
+	defer srv.Close()
+
+	c := testClient(t, srv.URL)
+	ctx := context.Background()
+	search := "x"
+	_, _ = c.Search(ctx, SearchVars{Page: 1, PerPage: 1, Search: &search})
+	_, _ = c.Seasonal(ctx, SeasonalVars{Page: 1, PerPage: 1, Season: "FALL", SeasonYear: 2026})
+	_, _ = c.Detail(ctx, DetailVars{ID: 21})
+	_, _ = c.Schedule(ctx, ScheduleVars{WeekStart: 1, WeekEnd: 2, Page: 1})
+	_, _ = c.Ratings(ctx, RatingsVars{IDs: []int{21}})
+
+	require.Len(t, seen, 5, "all five query methods must reach the server")
+	for i, ref := range seen {
+		assert.Equal(t, requestReferer, ref, "query path %d sent no Referer and would 403 in production", i)
+	}
+}


### PR DESCRIPTION
## 生产已经掉了三天，原因是少发一个请求头

`graphql.anilist.co` 对**没有 `Referer` 头**的请求返回 403，body 是一句 GraphQL 形状的：

```
The AniList API has been temporarily disabled due to severe stability issues.
```

这句话描述的是上游故障、把读者支去找状态页、而且**不成立**。同一秒、同一个 IP、同一条查询：

```
无 Referer: {"errors":[{"message":"The AniList API has been temporarily disabled..."}]}
带 Referer: {"data":{"Media":{"id":21}}}
```

（上面这组是在**生产源站**上跑的，不是本机。）

而 `internal/anilist/client.go` 的 `do()` 只设了 `Content-Type` 和 `Accept`。

### 代价

单个容器窗口内 **1,948 条** `anilist upstream: 403`。这三天里 search、schedule、seasonal 冷启动、以及任何未缓存的详情页全部返 502/500 —— 而我们以为自己在等一个上游恢复。CI 里那条一直红的 `robots-posture.spec.ts`（不存在的番剧期望 404 得到 500）也是它。

### 这个门认什么

实测过的组合：

| 请求 | 结果 |
|---|---|
| 默认 curl UA，无 Referer | 403 |
| 浏览器 UA，无 Referer | 403 |
| `Go-http-client/1.1`，无 Referer | 403 |
| 空 UA，无 Referer | 403 |
| **默认 curl UA + `Referer: https://anilist.co/`** | **200** |
| **+ `Referer: https://animegoclub.com/`** | **200** |
| **+ `Referer: https://example.com/`** | **200** |
| **+ `Referer: abc`** | **200** |
| `Origin: https://anilist.co`，无 Referer | 403 |

只测「有没有这个头」，不测内容；`Origin` 不接受；UA 无关。

所以这是个粗糙的机器人过滤而不是来源校验 —— 填我们自己的域名是**如实回答**而不是绕过：它比浏览器给的 Referer 更能说明是谁在调用。`User-Agent` 一并加上（它单独不开门，但匿名的 `Go-http-client/1.1` 正是这类过滤要抓的东西，而这个仓库对 AniList 的负载历史值得被抓）。真正回应对方「stability」诉求的是限速，`minInterval` 本来就是 700ms/请求 ≈ 85/min，在其文档的 90/min 之下。

## 测试才是这次改动的重点

`client_test.go` 里现有的每一条测试驱动的假服务器**都不看请求头**，所以删掉那两行 `Header.Set`，整个套件照样全绿，而生产会整片 502。

新增两条：
- `TestClient_SendsRefererAndUserAgent` —— 钉住两个头
- `TestClient_EveryQueryPathCarriesTheHeaders` —— 走完全部五个查询方法，这样将来有人加第六个、自己构造请求绕过 `do()`，红在这里而不是红在生产

**变异验证**：单独删 Referer、单独删 User-Agent，两次各自变红。

> 补一句过程：第一次做变异用了 `/tmp` 存备份，而这个环境写不进 `/tmp`，于是 `cp` 还原**静默失败**、把文件留在被改坏的状态，第二次变异是在已经坏掉的文件上跑的。重做时改成写可写目录 + `diff -q` 验证还原 + 数 `Header.Set` 行数。「变异真打进去了没有」和「还原真回来了没有」是两个都要证的问题。

## 一并改正的错话

CHANGELOG、`go-api/README.md`、TODOS 三处都写着「AniList 的 API 整个是关的，等它恢复」，PR #169 的正文也是。全部改正。

CHANGELOG 那条留了值得留的部分：**两个不同 IP 拿到同一句官方文案，不足以证明上游挂了** —— 那只说明两边触发了同一条规则，没说明那条规则是什么。两分钟就问出答案的动作是换一组请求头再问一次，而我三天没做。

## 验证

`go build` / `go vet ./...`（带与不带 integration tag）/ 单元测试。唯一失败是 `internal/bgmidmap` 的 `TestSeed_RealPG`，报错原文 `rootless Docker not found` —— 本机 Docker 按要求关着，CI 会跑到它。

预期这个 PR 会让 `E2E Sandbox` 那条一直红的 `robots-posture` 变绿。
