### PR TITLE
fix(nginx): scope cross-origin isolation off the route that frames a trailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## [未发布]
 
+### 预告片放不了：拦它的是我们自己的跨源隔离
+
+CSP 那行 `frame-src https://www.youtube-nocookie.com` 是对的，线上也确实生效了。真正拦住 iframe 的是另外两个头：`Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: credentialless`。
+
+**`credentialless` 对子资源放宽，对 iframe 不放宽。** 跨源 iframe 必须自己**强制**带 COEP，而 YouTube 的 embed 只带 `Cross-Origin-Embedder-Policy-Report-Only`（外加一个正确的 `Cross-Origin-Resource-Policy: cross-origin`）—— report-only 不算数。
+
+2026-09-08 用真浏览器对着生产量的：详情页 `crossOriginIsolated === true`，youtube-nocookie 的请求 `net::ERR_BLOCKED_BY_RESPONSE`。★ **顺带一个会骗人的信号：那个 iframe 的 `onload` 照样触发了** —— 在错误页上触发的。判据是失败的那个请求，不是 onload。
+
+这两个头不能删：播放器要靠跨源隔离拿 SharedArrayBuffer 跑 jassub（`.ass` 字幕），没有就退化成纯文本 VTT。所以**隔离改成按路由决定**：`map $uri` 让详情页（`/anime/`、`/en/anime/`、`/zh-Hant/anime/`，zh 是裸前缀）不发这两个头，其余路由一律照旧。详情页是唯一嵌预告片的路由，也是唯一从来不需要 SharedArrayBuffer 的路由。
+
+nginx 对空值的 `add_header` 会整条略过；就算哪天这个行为变了，空的 COOP/COEP 不是合法策略、浏览器会退回 unsafe-none —— 同样的结果，所以这条改动不会 fail closed。
+
+三份 nginx 配置都改了，并在 VPS 上用一次性容器 `nginx -t` 验过语法再部署（配置写坏会让整站起不来，不能等 `restart nginx` 才发现）。
+
+
 ### sweep 占住共享限速器的那 130 秒，让 /schedule 超时了
 
 限流修好之后的第一次干净 pass（`batches:40 rowsWritten:2000 rowsFailed:0`）跑了 **130 秒**，而生产在这 130 秒里记下一条 `/api/anime/schedule` 500、耗时 19.568s。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ## [未发布]
 
+### 详情页可以看预告片了，而且不是把 YouTube 播放器搬进关键路径
+
+迁移 0032（#167）把预告片元数据存进了目录，但**在此之前没有任何界面读它**——那次改动交付的是一列数据，不是一个功能。这次补上呈现层。
+
+页面默认只加载一张缩略图。真正的 iframe 是**点击之后**才在对话框里创建的，所以 YouTube 的播放器脚本、cookie 和体积不进详情页的首屏——详情页是这个站 SEO 的主力页面，它的关键路径不该为一个大多数人不会点的东西付费。
+
+所有 YouTube URL 的构造收在同一个校验边界后面（`asYouTubeTrailer`），11 位 id 的正则和 Go 侧、和迁移 0032 的 CHECK 是同一条规则。**客户端仍然校验一遍，尽管 Go 侧已经拦过**——理由不是不信任后端，是**混合版本部署窗口**：id 会被插进 iframe 的 URL，而这个窗口里前后端版本可以不一致，fail closed 比信任上游便宜。
+
+CSP 的 `frame-src` 从 `'none'` 放开到 **`https://www.youtube-nocookie.com` 一个域**，不是 `youtube.com`，更不是通配。
+
+三语文案齐全，`e2e/specs/sandbox/anime-detail.spec.ts` 补了 217 行覆盖。
+
+
 ### 预告片放不了：拦它的是我们自己的跨源隔离
 
 CSP 那行 `frame-src https://www.youtube-nocookie.com` 是对的，线上也确实生效了。真正拦住 iframe 的是另外两个头：`Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: credentialless`。

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,3 +1,40 @@
+# Cross-origin isolation is a per-route decision, not a site-wide one.
+#
+# COOP + COEP make a document cross-origin isolated, which is what exposes
+# SharedArrayBuffer.  jassub needs it on /player and /library to render ASS
+# subtitles -- without it jassubOverlay.ts warns and falls back to plain VTT.
+#
+# The same two headers block every cross-origin IFRAME whose own document does
+# not ENFORCE COEP.  `credentialless` relaxes that for subresources.  It does
+# not relax it for frames.  YouTube's embed sends
+# `Cross-Origin-Resource-Policy: cross-origin` but only
+# `Cross-Origin-Embedder-Policy-Report-Only`, and report-only does not count.
+#
+# Measured against production 2026-09-08 with a real browser: the detail page
+# reported crossOriginIsolated === true and the youtube-nocookie request failed
+# with net::ERR_BLOCKED_BY_RESPONSE.  Note the iframe's `onload` fired anyway --
+# on the error page -- so onload is not the signal here; the failed request is.
+#
+# The detail page is the only route that frames a trailer and the only one that
+# never wanted SharedArrayBuffer, so it is the route that opts out.  Everything
+# else keeps the isolation, including /player and /library which depend on it.
+#
+# nginx omits an add_header whose value is empty.  Even if that ever changed,
+# an empty COOP/COEP value is not a valid policy and browsers fall back to
+# unsafe-none -- the same outcome -- so this cannot fail closed.
+#
+# The prefix group is the locale segment: LANGS is ["zh", "en", "zh-Hant"] and
+# zh is served bare, so /anime/, /en/anime/ and /zh-Hant/anime/ are one route.
+map $uri $coop_policy {
+    default                          "same-origin";
+    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
+}
+
+map $uri $coep_policy {
+    default                          "credentialless";
+    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
+}
+
 upstream app {
     server app:5001;
 }
@@ -433,8 +470,8 @@ server {
     # which is only exposed in a cross-origin isolated context.
     # credentialless (not require-corp) so AniList/Bangumi cover CDNs
     # (which don't send CORP) still load as no-cors no-credentials.
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Embedder-Policy "credentialless" always;
+    add_header Cross-Origin-Opener-Policy $coop_policy always;
+    add_header Cross-Origin-Embedder-Policy $coep_policy always;
     add_header Cross-Origin-Resource-Policy "same-origin" always;
     # script-src directives explained:
     #   'wasm-unsafe-eval' — jassub WebAssembly.compile / .instantiate (player)

--- a/nginx/default.legacy.conf
+++ b/nginx/default.legacy.conf
@@ -57,6 +57,43 @@
 # the P6.9 / P7 / P9 commits and rebuild the legacy `app` image. That is
 # outside this conf's responsibility.
 
+# Cross-origin isolation is a per-route decision, not a site-wide one.
+#
+# COOP + COEP make a document cross-origin isolated, which is what exposes
+# SharedArrayBuffer.  jassub needs it on /player and /library to render ASS
+# subtitles -- without it jassubOverlay.ts warns and falls back to plain VTT.
+#
+# The same two headers block every cross-origin IFRAME whose own document does
+# not ENFORCE COEP.  `credentialless` relaxes that for subresources.  It does
+# not relax it for frames.  YouTube's embed sends
+# `Cross-Origin-Resource-Policy: cross-origin` but only
+# `Cross-Origin-Embedder-Policy-Report-Only`, and report-only does not count.
+#
+# Measured against production 2026-09-08 with a real browser: the detail page
+# reported crossOriginIsolated === true and the youtube-nocookie request failed
+# with net::ERR_BLOCKED_BY_RESPONSE.  Note the iframe's `onload` fired anyway --
+# on the error page -- so onload is not the signal here; the failed request is.
+#
+# The detail page is the only route that frames a trailer and the only one that
+# never wanted SharedArrayBuffer, so it is the route that opts out.  Everything
+# else keeps the isolation, including /player and /library which depend on it.
+#
+# nginx omits an add_header whose value is empty.  Even if that ever changed,
+# an empty COOP/COEP value is not a valid policy and browsers fall back to
+# unsafe-none -- the same outcome -- so this cannot fail closed.
+#
+# The prefix group is the locale segment: LANGS is ["zh", "en", "zh-Hant"] and
+# zh is served bare, so /anime/, /en/anime/ and /zh-Hant/anime/ are one route.
+map $uri $coop_policy {
+    default                          "same-origin";
+    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
+}
+
+map $uri $coep_policy {
+    default                          "credentialless";
+    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
+}
+
 upstream app {
     server app:5001;
 }
@@ -217,8 +254,8 @@ server {
     add_header X-Frame-Options DENY always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Embedder-Policy "credentialless" always;
+    add_header Cross-Origin-Opener-Policy $coop_policy always;
+    add_header Cross-Origin-Embedder-Policy $coep_policy always;
     add_header Cross-Origin-Resource-Policy "same-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; media-src 'self' blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' blob: wss://$host https://cloudflareinsights.com https://*.ingest.us.sentry.io; frame-src https://www.youtube-nocookie.com; object-src 'none'; base-uri 'self';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), local-fonts=(self)" always;

--- a/nginx/default.p9.conf
+++ b/nginx/default.p9.conf
@@ -21,6 +21,43 @@
 # next-app upstream. After the P11 cutover + legacy retirement, EVERY
 # user-facing route is served by next-app (see the location blocks below).
 # The old Express `app` upstream is gone.
+# Cross-origin isolation is a per-route decision, not a site-wide one.
+#
+# COOP + COEP make a document cross-origin isolated, which is what exposes
+# SharedArrayBuffer.  jassub needs it on /player and /library to render ASS
+# subtitles -- without it jassubOverlay.ts warns and falls back to plain VTT.
+#
+# The same two headers block every cross-origin IFRAME whose own document does
+# not ENFORCE COEP.  `credentialless` relaxes that for subresources.  It does
+# not relax it for frames.  YouTube's embed sends
+# `Cross-Origin-Resource-Policy: cross-origin` but only
+# `Cross-Origin-Embedder-Policy-Report-Only`, and report-only does not count.
+#
+# Measured against production 2026-09-08 with a real browser: the detail page
+# reported crossOriginIsolated === true and the youtube-nocookie request failed
+# with net::ERR_BLOCKED_BY_RESPONSE.  Note the iframe's `onload` fired anyway --
+# on the error page -- so onload is not the signal here; the failed request is.
+#
+# The detail page is the only route that frames a trailer and the only one that
+# never wanted SharedArrayBuffer, so it is the route that opts out.  Everything
+# else keeps the isolation, including /player and /library which depend on it.
+#
+# nginx omits an add_header whose value is empty.  Even if that ever changed,
+# an empty COOP/COEP value is not a valid policy and browsers fall back to
+# unsafe-none -- the same outcome -- so this cannot fail closed.
+#
+# The prefix group is the locale segment: LANGS is ["zh", "en", "zh-Hant"] and
+# zh is served bare, so /anime/, /en/anime/ and /zh-Hant/anime/ are one route.
+map $uri $coop_policy {
+    default                          "same-origin";
+    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
+}
+
+map $uri $coep_policy {
+    default                          "credentialless";
+    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
+}
+
 upstream next_app {
     server next-app:3000;
 }
@@ -505,8 +542,8 @@ server {
     # which is only exposed in a cross-origin isolated context.
     # credentialless (not require-corp) so AniList/Bangumi cover CDNs
     # (which don't send CORP) still load as no-cors no-credentials.
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Cross-Origin-Embedder-Policy "credentialless" always;
+    add_header Cross-Origin-Opener-Policy $coop_policy always;
+    add_header Cross-Origin-Embedder-Policy $coep_policy always;
     add_header Cross-Origin-Resource-Policy "same-origin" always;
     # script-src directives explained:
     #   'wasm-unsafe-eval' — jassub WebAssembly.compile / .instantiate (player)


### PR DESCRIPTION
预告片上线后放不了。

**不是 CSP。** `frame-src https://www.youtube-nocookie.com` 在线上确实生效。拦它的是 `Cross-Origin-Opener-Policy: same-origin` + `Cross-Origin-Embedder-Policy: credentialless`。

`credentialless` 对**子资源**放宽，对 **iframe 不放宽** —— 跨源 iframe 必须自己**强制**带 COEP，而 YouTube 的 embed 只带 `Cross-Origin-Embedder-Policy-Report-Only`（外加一个正确的 `Cross-Origin-Resource-Policy: cross-origin`）。report-only 不算数。

## 用真浏览器量的，不是照着规范推的

```
crossOriginIsolated = true
iframe → net::ERR_BLOCKED_BY_RESPONSE
```

★ 一个会骗人的信号：那个 iframe 的 **`onload` 照样触发了** —— 在错误页上触发。只看 onload 会得出「加载成功」的结论。判据是失败的那个请求。

## 改法

两个头都不能删：跨源隔离是 SharedArrayBuffer 的前提，播放器要靠它跑 jassub 渲染 `.ass` 字幕（没有就退化成纯文本 VTT，`jassubOverlay.ts` 里有这条告警）。

所以隔离改成**按路由决定**。`map $uri` 只在详情页不发这两个头 —— `/anime/`、`/en/anime/`、`/zh-Hant/anime/`（zh 是裸前缀，LANGS 是 `["zh","en","zh-Hant"]`）。详情页既是唯一嵌预告片的路由，也是唯一从来不需要 SharedArrayBuffer 的路由。其余路由一律照旧。

nginx 对空值的 `add_header` 会整条略过。就算哪天这个行为变了，空的 COOP/COEP 不是合法策略、浏览器退回 unsafe-none —— 同样的结果，**这条改动不会 fail closed**。

## 验证

三份 nginx 配置都改了。候选配置已在 VPS 上用一次性容器（接到 compose 网络、挂真证书）跑过 `nginx -t`：

```
nginx: configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```

先验语法是因为配置写坏不会让站点降级，是让 nginx **起不来** —— 等 `restart nginx` 才发现就晚了。

部署后会用同一个浏览器探针复验：详情页 `crossOriginIsolated === false` 且 iframe 加载成功，`/player` 仍然 `=== true`。
