### PR TITLE
fix(ratings): restore the four UniqueOpts states river refuses to run without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,23 @@
 
 ## [未发布]
 
-### ★ 一次部署，能让 sweep 静默停一小时——而且它看起来和「没活可干」一模一样
+### ★★ 一次部署能让 sweep 静默停一小时，而「拿掉 running」把一小时变成了永久
 
-三次部署之后回头看 river：`anilist_ratings` 和 `bangumi_ratings` 各有一条作业卡在 `running`，**59 分钟**，期间零条 sweep 日志。
+**上半段（成立）**：三次部署之后 river 里 `anilist_ratings`、`bangumi_ratings`、`hant_backfill` 各有一条作业卡在 `running`，**59 分钟**，期间零条 sweep 日志。原因是 `UniqueOpts.ByState` 里有 `running`，而 **`running` 不代表有 pass 在跑** —— 它代表「上次写这行时它在跑」，部署直接杀进程不改状态，river 只能靠 rescuer 回收（默认一小时）。这一小时里那行和真实 pass 无法区分，开机的 `RunOnStart` 入队被**部署刚杀掉的那次 pass 的尸体**压制。
 
-原因是我给它们设的 `UniqueOpts` 把 `running` 算成「已在飞行中」。**但 `running` 不代表有 pass 在跑** —— 它代表「上一次写这行时它在跑」，而部署直接把进程杀掉，不会改这个状态。river 只能靠 rescuer 回收，默认窗口是一小时。这一小时里那行和一次真实的 pass 完全无法区分，于是开机的 `RunOnStart` 自动入队**被部署刚杀掉的那次 pass 的尸体压制了**。
+★★ **它没有症状**：被压制的 sweep 什么都不产出，而这也正是「已经追平」的样子。
 
-★★ **最坏的部分是它没有症状**：sweep 什么都不产出，而这也正是「已经追平、没活可干」的样子。没有报错、没有告警，两者从外面看一模一样。
+**下半段（我修错了，并且上了生产）**：拿掉 `running` 看起来是显而易见的修法。**它是错的。** river 的 `UniqueOpts.validate` **强制要求** available / pending / running / scheduled 四个状态都在；少任何一个，`PeriodicJobEnqueuer` 对这个 kind **整个失败** —— 只在日志里留一行 ERROR，服务照常启动、照常服务流量、**再也不排队这个 sweep**。于是一小时的压制变成了永久停摆，直到下一次部署。
 
-`running` 从集合里拿掉。真正防止两次并发 pass 的不是它，是队列 —— `ratings` 的 `MaxWorkers` 从 2 改回 **1**，于是同一时刻只有一个 ratings 作业在执行；孤儿 `running` 行不占 worker 槽位（槽位在进程内）。而且**紧接着跑第二次 pass 并不是重复劳动**：候选资格就是那个读取时间戳，第一次盖过戳的行已经不是候选，第二次接着往下走。
+★★★ **这条约束就写在我读过并引用过的那段注释里**（`hantBackfillUniqueStates`：「available/pending/running/scheduled are required by river」）。读了、在 PR 里引了、然后照样删掉了其中一个。
 
-MaxWorkers 从 2 退回 1 推翻了我三小时前写的理由（「不让 4 分钟的 Bangumi pass 挡在 30 秒的 AniList pass 前面」）。那个理由对成本判断是对的，**对「槽位数是干什么用的」判断是错的**。批量降到 500 之后代价也小了：AniList pass ~21 秒、Bangumi ~4 分钟，串行起来每小时约占用一个槽位五分钟。
+★★ **测试也没抓住，而且是因为断言的东西不对**：那版测试断言集合「有 4 个元素」，而坏掉的集合**恰好也是 4 个** —— 它留下了可选的 `retryable`，删掉的是必需的 `running`。**数数不是那个性质，成员资格才是。** 新的 `TestRatingsUniqueStatesMatchRiver` 逐个断言 river 要求的四个状态在场，变异验证过。
 
-守卫是 `TestRatingsUniqueStatesExcludeRunning` —— 因为「少了一项」是读代码看不出来的，而把它加回去是个看起来像在收紧约束的单词级改动。变异验证过。
+★ 变异验证本身也犯过一次同样形状的错：第一次的变异脚本按状态序列做文本替换，而 `hantBackfillUniqueStates` 的顺序和 ratings **完全一样**，于是替换命中了文件里更靠前的那个块，ratings 根本没被改。测试报绿是对的，是探针错了。重做时把变异限定在 `ratingsUniqueStates` 的块内，并**分别打印「ratings 块已改」和「hant 块未动」**才继续。
 
-同一形状的问题 `hant_backfill` 也有（当晚同样卡了 59 分钟），但它是季度作业，一小时不算什么。已记进 TODOS。
+**那一小时的窗口保留，接受它**：它靠 rescuer 自愈，而且 `hantBackfillUniqueStates` 一直是同一个形状。TODOS 里记了真正能消除它的做法 —— 干脆不要唯一性，靠 `MaxWorkers=1` 加读取时间戳，因为候选资格就是那个戳，紧接着的第二次 pass 只会往下取下一批，本来就不是重复劳动。
 
+`ratings` 队列的 `MaxWorkers` 从 2 改回 **1** 保留：它是让并发 pass 不可达的那个东西，代价在批量降到 500 之后也小了（AniList ~21 秒、Bangumi ~4 分钟，串行每小时约占一个槽位五分钟）。
 
 ### 详情页可以看预告片了，而且不是把 YouTube 播放器搬进关键路径
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -805,16 +805,18 @@
 
 ---
 
-## hant_backfill 也会被部署杀出的孤儿作业压制
+## 部署杀出的孤儿作业会压制 sweep 一小时（三个 sweep 都有）
 
-**What** — 把 `hantBackfillUniqueStates` 里的 `running` 拿掉，理由和 `ratingsUniqueStates` 一样（见 `args.go` 里那段注释）。
+**What** — 让周期 sweep 不再依赖 `UniqueOpts` 去防重：去掉唯一性，改为靠队列的 `MaxWorkers: 1` 加候选查询的读取时间戳。或者调低 river 的 `RescueStuckJobsAfter`（默认 1 小时），但要先确认没有作业的正常时长会撞上这个窗口。
 
-**Why** — 2026-09-08 当晚实测：一次部署之后 `hant_backfill` 和两条 ratings sweep 一起卡在 `running` 59 分钟。同一个机制 —— `running` 行是被杀进程留下的尸体，river 的 rescuer 一小时后才回收，而在那之前它会把新的入队压制掉。
+**Why** — `running` 行不代表有 pass 在跑，部署杀进程不改它，rescuer 一小时后才回收。这一小时里 `RunOnStart` 的入队被自己的尸体压制，而且**没有症状**（不产出 = 追平了，两者同形）。2026-09-08 实测：一次部署后 `anilist_ratings` / `bangumi_ratings` / `hant_backfill` 同时卡 59 分钟。
 
-**Pros** — 三个 sweep 用同一条规则，不会有人照着 `hant_backfill` 抄一份新的坑。
+⚠️ **不要用「把 running 从 ByState 拿掉」来修**。已经在生产上试过并回滚：river 的 `UniqueOpts.validate` 强制要求 available/pending/running/scheduled 四个都在，少一个会让 `PeriodicJobEnqueuer` 对该 kind 整个失败——只留一行 ERROR 日志，服务照常跑，sweep 再也不入队，一小时的压制变成永久。守卫见 `TestRatingsUniqueStatesMatchRiver`。
 
-**Cons** — 它是**季度**作业，一小时的延迟对它毫无影响，所以这条纯粹是为了一致性。而且要顺带确认它的队列同样是 `MaxWorkers: 1`（是），否则拿掉 `running` 会打开并发的口子。
+**Pros** — 三个 sweep 一起受益；ratings 是每小时跑的，一小时的窗口对它最不能忍。而且去掉唯一性对 ratings 本来就安全：候选资格是读取时间戳，紧接着的第二次 pass 取的是下一批，不是重复劳动。
 
-**Context** — 2026-09-08 修 ratings 时顺带发现。
+**Cons** — 去掉唯一性后 river 行会累积（每小时一条，24 条/天，completed 会被 river 自己清理）；如果 worker 卡住，作业会堆积而不是被合并。`hant_backfill` 是**整表**pass，对它去掉唯一性要更谨慎——两次并发全表 pass 是真的重复劳动，它依赖的是 `MaxWorkers: 1`。
+
+**Context** — 2026-09-08。ratings 每小时跑所以最疼；`hant_backfill` 是季度作业，一小时对它无所谓。
 
 **Depends on / blocked by** — 无。

--- a/go-api/internal/queue/args.go
+++ b/go-api/internal/queue/args.go
@@ -386,34 +386,39 @@ func (EpisodeTitlesArgs) InsertOpts() river.InsertOpts {
 // would read the same head-of-queue candidates and spend the same
 // upstream budget twice.
 //
-// ★ `running` is deliberately NOT in the set, and that is the one entry
-// worth explaining, because putting it there is the obvious choice.
+// ★ `running` is in the set because river REQUIRES it, and this is the
+// second thing to know about it rather than the first.
 //
-// A `running` row does not mean a pass is running.  It means a pass was
-// running when its row was last written, and a deploy kills the process
-// mid-pass without changing it.  River only reclaims such a row through
-// its rescuer, whose default window is an hour.  For that hour the row
-// is indistinguishable from a live pass, so a `running` entry here makes
-// the boot-time RunOnStart insert suppress itself against the corpse of
-// the pass the deploy just killed.
+// The first is that a `running` row does not mean a pass is running.  It
+// means one was running when the row was last written, and a deploy kills
+// the process without changing it; river reclaims such a row only through
+// its rescuer, an hour later by default.  For that hour the row is
+// indistinguishable from a live pass, so the boot-time RunOnStart insert
+// suppresses itself against the corpse of the pass the deploy just
+// killed.  Measured on prod 2026-09-08: after one deploy both sweeps sat
+// in `running` for 59 minutes producing nothing — which is also exactly
+// what a caught-up sweep looks like, so nothing reported it.
 //
-// Measured on prod 2026-09-08: three deploys in one evening, and after
-// the last one `anilist_ratings` and `bangumi_ratings` each sat in
-// `running` for 59 minutes with zero sweep log lines, while the rescuer
-// counted down.  Nothing reported it — the sweeps simply produced
-// nothing, which is also what a caught-up sweep looks like.
+// Removing `running` to fix that is the obvious move and it is WRONG.
+// UniqueOpts.validate requires available, pending, running and scheduled;
+// a set missing any of them makes PeriodicJobEnqueuer fail for this kind
+// entirely.  It fails at ERROR level in the log and nowhere else — the
+// service starts, serves traffic, and simply never enqueues the sweep
+// again.  That was tried on prod the same evening and turned a one-hour
+// suppression into a permanent one.  TestRatingsUniqueStatesMatchRiver
+// now holds the requirement so the next attempt fails in CI.
 //
-// What actually prevents two concurrent passes is the queue: ratings
-// runs MaxWorkers=1 (see cmd/server/main.go), so only one ratings job
-// executes at a time regardless of how many are enqueued.  An orphaned
-// `running` row holds no worker slot, because slots are in-process.  And
-// a second pass that runs right after a first is not duplicated work:
-// candidacy is the read stamp, so the first pass's rows are no longer
-// candidates and the second one picks up where it left off.
+// The one-hour window after a deploy therefore stands, and is accepted:
+// it self-heals through the rescuer, and the same shape has always been
+// true of hantBackfillUniqueStates.  TODOS.md carries what would remove
+// it — dropping uniqueness altogether and leaning on MaxWorkers=1 plus
+// the read stamp, which already makes a duplicate pass harmless because
+// candidacy is the stamp and a second pass picks up the next batch.
 var ratingsUniqueStates = []rivertype.JobState{
 	rivertype.JobStateAvailable,
 	rivertype.JobStatePending,
 	rivertype.JobStateRetryable,
+	rivertype.JobStateRunning,
 	rivertype.JobStateScheduled,
 }
 

--- a/go-api/internal/queue/args_ratings_unique_test.go
+++ b/go-api/internal/queue/args_ratings_unique_test.go
@@ -7,39 +7,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestRatingsUniqueStatesExcludeRunning pins the one entry that is absent
-// on purpose, because absence is not something a reader can see.
+// TestRatingsUniqueStatesMatchRiver pins the four states river's
+// UniqueOpts.validate refuses to run without.
 //
-// A `running` row does not mean a pass is running -- it means one was
-// running when the row was last written, and a deploy kills the process
-// without changing it.  River reclaims such a row only through its
-// rescuer, an hour later by default.  With `running` in this set, the
-// boot-time RunOnStart insert suppresses itself against the corpse of the
-// pass the deploy just killed: measured on prod 2026-09-08, both sweeps
-// sat in `running` for 59 minutes producing nothing, which is also what a
-// caught-up sweep looks like, so nothing reported it.
+// This test exists because removing one of them is an attractive idea
+// with a silent failure.  `running` looks like the cause of a real
+// problem — a deploy that kills a pass leaves the row behind and the
+// next boot's insert suppresses itself against it for the hour it takes
+// river's rescuer to reclaim the orphan — so taking it out reads like
+// the fix.  It is not: PeriodicJobEnqueuer then fails for this kind
+// entirely, at ERROR level in the log and nowhere else.  The service
+// starts, serves traffic, and never enqueues the sweep again.
 //
-// Adding it back is a one-word edit that reads like tightening the
-// constraint.  This test is what says otherwise.
-func TestRatingsUniqueStatesExcludeRunning(t *testing.T) {
-	assert.NotContains(t, ratingsUniqueStates, rivertype.JobStateRunning,
-		"a `running` row can be an orphan from a killed deploy for up to an hour; "+
-			"suppressing on it silently stops the sweep for that hour. "+
-			"Concurrency is prevented by the ratings queue's MaxWorkers=1, not by this set")
-
-	// The rest of the set is the point of having one at all: without
-	// these, a periodic insert would stack a second pass behind one that
-	// has not started yet.
-	for _, want := range []rivertype.JobState{
+// That was done on production on 2026-09-08 and turned a one-hour
+// suppression into a permanent one.  Nothing caught it: the previous
+// version of this test asserted the slice had four entries, which was
+// true of the broken set — it kept the optional `retryable` and dropped
+// the required `running`.  Counting is not the property; membership is.
+func TestRatingsUniqueStatesMatchRiver(t *testing.T) {
+	for _, required := range []rivertype.JobState{
 		rivertype.JobStateAvailable,
 		rivertype.JobStatePending,
-		rivertype.JobStateRetryable,
+		rivertype.JobStateRunning,
 		rivertype.JobStateScheduled,
 	} {
-		assert.Contains(t, ratingsUniqueStates, want)
+		assert.Contains(t, ratingsUniqueStates, required,
+			"river's UniqueOpts.validate requires %s; without it PeriodicJobEnqueuer "+
+				"fails for this kind and the sweep is never enqueued again — an ERROR "+
+				"log line and no other symptom", required)
 	}
 
-	// river validates that its four required states are present; a set
-	// missing one is rejected at insert time, in production, not here.
-	assert.Len(t, ratingsUniqueStates, 4)
+	// retryable is ours, not river's: a pass in backoff after a failed
+	// attempt is still this sweep in flight.
+	assert.Contains(t, ratingsUniqueStates, rivertype.JobStateRetryable)
+
+	// completed is deliberately absent — river keeps completed rows for
+	// 24h, so including it would let an hourly job fire once a day.
+	assert.NotContains(t, ratingsUniqueStates, rivertype.JobStateCompleted,
+		"river keeps completed rows for 24h; suppressing on them would make an hourly sweep daily")
 }


### PR DESCRIPTION
## 生产现在是坏的，这个 PR 修它

上一个 PR（#175）为了解决「部署留下的孤儿 `running` 作业压制 sweep 一小时」，把 `running` 从 `ratingsUniqueStates` 拿掉了。

**river 的 `UniqueOpts.validate` 强制要求 available / pending / running / scheduled 四个状态都在。** 少任何一个，`PeriodicJobEnqueuer` 对这个 kind **整个失败**：

```
ERROR maintenance.PeriodicJobEnqueuer: Internal error generating periodic job
error: "UniqueOpts.ByState must contain all required..."
```

**只有这一行 ERROR，没有别的症状。** 服务照常启动、照常服务流量、再也不排队这个 sweep。生产从 03:57 起就是这个状态 —— 我把一小时的压制换成了永久的。

## 三个值得记下来的地方

**1. 这条约束就写在同一个文件里，我读过还引用过。**
`hantBackfillUniqueStates` 的注释原文：「available/pending/running/scheduled are required by river (UniqueOpts.validate)」。#175 的 commit message 引用了这段注释，同时删掉了它点名的其中一个状态。

**2. 测试没抓住，因为断言的东西不对。**
那版测试断言集合「有 4 个元素」—— 而**坏掉的集合恰好也是 4 个**：它留下了可选的 `retryable`，删掉的是必需的 `running`。**数数不是那个性质，成员资格才是。** 新的 `TestRatingsUniqueStatesMatchRiver` 逐个点名 river 要求的四个状态。

**3. 变异验证本身也犯了同一形状的错。**
第一次的变异脚本按「状态序列」做文本替换，而 `hantBackfillUniqueStates` 列的状态**顺序完全一样**，于是替换命中了文件里更靠前的那个块 —— ratings 根本没被改。测试报绿是**对的**，是探针错了。

重做时把变异限定在 `ratingsUniqueStates` 的块内，并在跑测试前**分别打印**：

```
变异后 ratings 块含 Running: False (应为 False)
hant 块未被动: True (应为 True)
MUTATION[ratings 块删 running] -> RED (good)
```

「变异真打进去了没有」和「打在了哪个块上」是两个都要证的问题。

## 保留 / 不保留

- **保留** `MaxWorkers: 1`（#175 的另一半）—— 它是让并发 pass 不可达的那个东西，代价在批量降到 500 之后也小了
- **接受**那一小时的部署窗口 —— 靠 rescuer 自愈，而且 `hant_backfill` 一直是同一形状。TODOS 记了真正能消除它的做法（去掉唯一性、靠 `MaxWorkers=1` 加读取时间戳，因为候选资格就是那个戳，第二次 pass 只会往下取下一批），并且**明确标注了不要再试「拿掉 running」这条路**

## 验证

`go build` / `go vet ./...` / `go test ./internal/queue`。部署后核对：启动日志里**不再有** `PeriodicJobEnqueuer` 的 ERROR，且 sweep 重新产出 pass 日志、入库数字继续增长。
