### PR TITLE
feat(queue): a validated registry for background jobs, and a gate that runs river's own rules

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -48,6 +48,18 @@
 
 **为什么这次没做** — 它属于运维能力，不属于「看见进度」这个需求。分开做两边都更干净。
 
+**2026-09-08 更新：后端已落地，只剩前端按钮。** river 注册表那轮把这条的后端做完了，而且比这里设想的更宽：不是「加一对同形函数」，是一组通用的
+`queue.PauseQueue / ResumeQueue / QueuePaused / StatusAll`，队列名按注册表白名单校验，八条专用队列全部可停可看。HTTP 面是
+`POST /api/admin/queues/{name}/pause`、`/resume` 和 `GET /api/admin/queues`。
+
+白名单显式排除 river 的 `default`——那条队列同时装着 V1、V2、warm_season、orphan_scan，停它就等于停掉页面在等的富化；river 的 `"*"` 通配同样被拒。
+未知名字返回 400 而不是 500（操作者要了个不存在的东西，和 river 挂了是两回事）。
+
+顺带修掉一个：`PauseHeal` / `ResumeHeal` 在 `QueueCtrl` 为 nil 时会返回 `200 {"paused":true}` 却什么也没暂停。现在返回 503。
+
+**还剩什么** — 只有前端：`EnrichmentBar` 的「中文简介」区块加按钮，照抄 `_actions/enrichment-queue.ts` 里的 `pauseHealCn` / `resumeHealCn`，
+把路径换成 `/api/admin/queues/description_backfill/pause`。`GET /api/admin/queues` 已经把可停队列名和各自的暂停态一起返回，前端不需要硬编码队列列表。
+
 ## anime-relations:字幕组连番号的精确重定向表
 
 - **What:** 接入 [`erengy/anime-relations`](https://github.com/erengy/anime-relations),把字幕组连续编号的
@@ -618,6 +630,12 @@
 **Why** — 「一个 bgm subject 对应一部番」这个假设全仓到处在用，但数据库不保证它，而且**已经被破坏了 541 次**（541 个 bgm_id 被 2 行以上持有，共 1,161 行）。直接后果：`GetAnimeByBgmID` 是 `:one` 查询，对这 1,161 行返回的是任意一行——`resolveSiteAnime` 第 2 腿和 `findSiteAnime` 第 3 腿都走它，所以 `/match` 的 siteAnime 结果对这批番是不确定的。任何「按 bgm_id 拉数据写回」的作业也会把同一份中文名和简介写到多部番上。顺带一提这一列**连普通索引都没有**，每次按 bgm_id 查都是全表扫（实测 18,009 行）。
 
 **Context** — 2026-09-03 写 `bgm_bind_idmap` sweep 时量到。⚠️ **不是所有重复都是错的**：Bangumi 有时用一个 subject 覆盖 AniList 拆成两季的内容，那种重复是数据模型差异不是绑定错误。所以不能一刀切去重，得先按「同一 subject 的两行是不是同一部作品的不同季」分类。新 sweep 自己不会让这个数字变大——它拒绝任何已被占用的 subject，也拒绝两行争同一个 subject 的情况——但它也修不了存量。
+
+**2026-09-08 补** — river 注册表那轮的跨模型评审从另一头撞上了同一件事，结论是这条 TODO 的措辞比那边的假设更准，记一下差在哪：
+
+评审提出的是「`bgm_bind` 队列的 `MaxWorkers: 1` 陈述了一个正确性不变量，而 `cmd/bgmbackfill` / `cmd/hantbackfill` 是进程外的第二个写入方，所以那个保证不成立」。核实为真，但只对了一半——**这条不变量不是「离假只有一个 `--apply` 标志的距离」，它已经假了 541 次**。单槽位买到的是「这个 sweep 不会让这个数字变大」，不是「这个数字是 0」。
+
+已经做了的是措辞那一半：`internal/queue/registry.go` 的 `FixedConcurrency` 文档现在明说 MaxWorkers 是**进程内**保证、理由必须按「这个槽位买到了什么」来写；`registry_default.go` 里 `bgm_bind` 那条按本 TODO 的实测重写了。机制那一半就是本条，前提仍然是先裁定那 1,161 行——唯一索引加不上去不是因为没想到，是因为数据现在过不了。
 
 **Depends on / blocked by** — 无。与 `## 绑定覆盖率` 和 `## 分割放送会 50% 概率绑错` 同属绑定质量。
 

--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -307,22 +307,23 @@ func main() {
 			// it.  A single slot is what makes the race unreachable, and it
 			// is why every writer of anime_cache.bgm_id shares this queue.
 			queue.BgmBindQueueName: {MaxWorkers: 1},
-			// Rating refresh: MaxWorkers MUST stay 1, and this replaces
-			// an earlier 2 that was chosen so a four-minute Bangumi pass
-			// would not sit in front of a thirty-second AniList one.
+			// Rating refresh: MaxWorkers 1, replacing an earlier 2 that
+			// was chosen so a four-minute Bangumi pass would not sit in
+			// front of a thirty-second AniList one.
 			//
-			// That reasoning was right about the cost and wrong about
-			// what the slot count is for.  The single slot is now what
-			// makes two concurrent passes of the SAME kind unreachable,
-			// which is what lets ratingsUniqueStates leave `running`
-			// out -- and leaving it out is what stops a deploy that
-			// kills a pass mid-flight from suppressing the sweep for the
-			// hour it takes river's rescuer to reclaim the orphan.  See
-			// that comment for the incident.
+			// An intermediate version of this comment justified the 1 as
+			// what let ratingsUniqueStates leave `running` out of its
+			// state set.  That premise is dead: `running` is back in the
+			// set, because river's UniqueOpts.validate REQUIRES it and
+			// removing it stopped the sweep enqueueing at all.  The slot
+			// count neither grants nor needs that freedom.
 			//
-			// The cost it buys back is small at this cadence: with
-			// anilistRatingsBatch at 500 the AniList pass is ~21s and
-			// the Bangumi pass ~4 minutes, so serialising them spends
+			// What it does buy is that two passes of the same kind cannot
+			// overlap even if uniqueness is ever relaxed, which is the
+			// direction TODOS.md points at for closing the post-deploy
+			// suppression window.  The cost is small at this cadence:
+			// with anilistRatingsBatch at 500 the AniList pass is ~21s
+			// and the Bangumi pass ~4 minutes, so serialising them spends
 			// about five minutes of one slot per hour.
 			queue.RatingsQueueName: {MaxWorkers: 1},
 		},

--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -195,163 +195,34 @@ func main() {
 	}
 	defer dandanClient.Close()
 
-	workers := queue.WorkersWithBangumiAndNormalizer(
-		bangumiClient,
-		anilistClient,
-		q,
-		enqueuer,
-		anime.NormalizeMainRow,
-	)
-	// LLM translation sweep registers separately so the bundle builder's
-	// signature (and its test doubles) stay untouched.  With a nil
-	// translator this registers a disabled scan + a defensive no-op row
-	// worker — see AddDescriptionLlmWorkers.
-	queue.AddDescriptionLlmWorkers(workers, llmTranslator, q, enqueuer)
-	// zh-Hant sweep.  Registers separately for the same reason: it shares
-	// none of the bundle builder's dependencies and needs one nothing else
-	// does — the vendored dataset directory, which the image bakes at
-	// /usr/local/share/animego/hant and a checkout has at data/hant.
-	// Empty string here means "read HANT_DATA_DIR, default data/hant";
-	// docker-compose sets it for the container.
-	queue.AddHantBackfillWorker(workers, q, "")
-	// Inferred-episode-count sweep.  Registers separately for the same
-	// reason as the two above — it needs none of V12DB and V12DB needs
-	// none of it — and takes the SAME bangumiClient every other worker
-	// holds so its two-requests-per-row draw from the one token bucket
-	// rather than opening a second one beside it.
-	queue.AddEpisodesBgmWorkers(workers, bangumiClient, q, enqueuer)
-	// Airing-show episode-title top-up.  Takes the shared dandanplay client
-	// for the same reason the sweep above takes the shared bangumiClient, and
-	// the pool because its write is a four-statement transaction shared with
-	// cmd/bgmbackfill (internal/episodetitles).  Gated at work time by
-	// EPISODE_TITLES_SWEEP_ENABLED; registering it is not the same as running
-	// it.
-	queue.AddEpisodeTitlesWorker(workers, pool, q, dandanClient, bangumiClient)
+	workers := buildWorkers(workerDeps{
+		bangumi:   bangumiClient,
+		anilist:   anilistClient,
+		dandan:    dandanClient,
+		llm:       llmTranslator,
+		db:        q,
+		pool:      pool,
+		enqueuer:  enqueuer,
+		normalize: anime.NormalizeMainRow,
+	})
 
-	// The id-map bind sweep.  Takes the pool because its unit of work is a
-	// transaction spanning a binding write and that binding's V2 dispatch --
-	// a bound row with no enrichment queued behind it would drop out of the
-	// sweep's own candidate set and never be looked at again.  Takes the
-	// enqueuer for the same reason; `enqueuer` is late-bound above and is
-	// wired to river before any job can run.  Gated at work time by
-	// BGM_BIND_IDMAP_SWEEP_ENABLED.
-	queue.AddBindIdMapWorker(workers, pool, q, enqueuer)
-
-	// The two rating-refresh sweeps.  Register separately for the reason
-	// every sweep above does -- they need the AniList client, which the
-	// bundle builder holds but does not hand to any worker of its own --
-	// and the Bangumi half takes the SAME bangumiClient so its one
-	// request per row draws from the shared token bucket rather than
-	// opening a second one beside it.
-	queue.AddRatingsWorkers(workers, anilistClient, bangumiClient, q)
-
+	// Queues and schedules come from internal/queue's registry, which owns
+	// every one of them in a single declaration and validates the set at
+	// package init.  The 90-line map literal and the ten
+	// Periodic<Name>Job constructors that used to live here are gone; what
+	// justified each worker count moved with it, into
+	// registry_default.go, so the number and its reason cannot drift apart
+	// again.
+	//
+	// See registry.go for why the registry reads InsertOpts() rather than
+	// replacing it, and test/integration/queue_registry_test.go for the
+	// gate that boots this exact configuration against a real Postgres.
+	registry := queue.Default()
 	riverClient, err := queue.Boot(pool, queue.Config{
-		Workers: workers,
-		// Queues: default for V1+V2+warm_season+orphan_scan, bangumi_v3
-		// for V3 only, description_backfill for the Chinese-description
-		// sweep.  The dedicated V3 queue is what makes the admin
-		// /heal-cn/pause endpoint isolate the heal-CN workload — pausing
-		// the default queue would also freeze enrichment and seasonal
-		// warming.  MaxWorkers=1 across the board matches the
-		// conservative serial throttle the workers use to respect
-		// Bangumi's 800ms-per-request budget (only one worker per queue).
-		Queues: map[string]river.QueueConfig{
-			river.QueueDefault:       {MaxWorkers: 1},
-			queue.BangumiV3QueueName: {MaxWorkers: 1},
-			// Chinese-description backfill: MaxWorkers MUST stay 1.
-			// This is a long-running sweep over ~17k existing rows, and
-			// its only cost is Bangumi API time — which is metered by a
-			// token bucket on the single shared *bangumi.Client above.
-			// Extra workers would therefore not drain the backlog any
-			// faster; they would just queue up on the same bucket while
-			// stealing dispatch slots from on-demand enrichment.  The
-			// separate queue is for isolation and pausability, not for
-			// parallelism.
-			queue.DescriptionBackfillQueueName: {MaxWorkers: 1},
-			// LLM translation sweep: 4 workers is the one queue here
-			// that genuinely parallelises — its budget is DeepSeek
-			// round-trips (seconds each, no shared token bucket), and
-			// 4-way keeps a 600-row batch under ~15 minutes without
-			// hammering the API.
-			queue.DescriptionLlmQueueName: {MaxWorkers: 4},
-			// zh-Hant sweep: MaxWorkers MUST stay 1.  One job is the
-			// whole table, so a second worker has nothing to do except
-			// run a duplicate pass — and HantBackfillArgs is unique
-			// across every non-terminal state precisely to stop that.
-			// The separate queue is so a pass that reads all ~17.5k rows
-			// and issues two dozen 500-row UPDATEs cannot sit in front
-			// of the V1/V2 enrichment a page load is waiting on.
-			queue.HantBackfillQueueName: {MaxWorkers: 1},
-			// Inferred episode counts: MaxWorkers MUST stay 1, for the
-			// same reason as the description backfill.  Its cost is two
-			// Bangumi requests per row, metered by the token bucket on
-			// the single shared *bangumi.Client above, so extra workers
-			// would not drain the backlog faster — they would queue on
-			// the same bucket while stealing dispatch slots from
-			// on-demand enrichment.  The separate queue is for isolation
-			// and pausability, not parallelism.
-			queue.EpisodesBgmQueueName: {MaxWorkers: 1},
-			// Airing episode titles: MaxWorkers MUST stay 1.  One pass is
-			// one job that walks its whole candidate list inline, and every
-			// row costs a token from the dandanplay bucket that user-facing
-			// /match draws on.  A second concurrent pass would not go faster
-			// -- the bucket is the constraint, not the worker count -- it
-			// would only take twice as many tokens away from the request
-			// path.
-			queue.EpisodeTitlesQueueName: {MaxWorkers: 1},
-			// MaxWorkers 1 is load-bearing rather than polite here.
-			// BindBgmIdsFromIdMap refuses a subject some bound row already
-			// holds, but that check and its UPDATE are one statement: two
-			// concurrent passes could each pass it for the same subject and
-			// both bind, and anime_cache.bgm_id has no unique index to catch
-			// it.  A single slot is what makes the race unreachable, and it
-			// is why every writer of anime_cache.bgm_id shares this queue.
-			queue.BgmBindQueueName: {MaxWorkers: 1},
-			// Rating refresh: MaxWorkers 1, replacing an earlier 2 that
-			// was chosen so a four-minute Bangumi pass would not sit in
-			// front of a thirty-second AniList one.
-			//
-			// An intermediate version of this comment justified the 1 as
-			// what let ratingsUniqueStates leave `running` out of its
-			// state set.  That premise is dead: `running` is back in the
-			// set, because river's UniqueOpts.validate REQUIRES it and
-			// removing it stopped the sweep enqueueing at all.  The slot
-			// count neither grants nor needs that freedom.
-			//
-			// What it does buy is that two passes of the same kind cannot
-			// overlap even if uniqueness is ever relaxed, which is the
-			// direction TODOS.md points at for closing the post-deploy
-			// suppression window.  The cost is small at this cadence:
-			// with anilistRatingsBatch at 500 the AniList pass is ~21s
-			// and the Bangumi pass ~4 minutes, so serialising them spends
-			// about five minutes of one slot per hour.
-			queue.RatingsQueueName: {MaxWorkers: 1},
-		},
-		PeriodicJobs: []*river.PeriodicJob{
-			queue.PeriodicWarmSeasonJob(),
-			queue.PeriodicOrphanScanJob(),
-			queue.PeriodicDescriptionBackfillScanJob(),
-			queue.PeriodicDescriptionLlmBackfillScanJob(),
-			// Hourly, RunOnStart — river's OSS scheduler recomputes the
-			// next run as now+period on every Start, so a deploy would
-			// otherwise push the sweep a full hour out every time.
-			queue.PeriodicEpisodesBgmScanJob(),
-			queue.PeriodicEpisodeTitlesJob(),
-			queue.PeriodicBindIdMapJob(),
-			// 90 days, and deliberately NOT RunOnStart — see the note on
-			// PeriodicHantBackfillJob for why this one reads the opposite
-			// way round from the two sweeps above it, and for what that
-			// costs on a service that deploys more often than quarterly.
-			queue.PeriodicHantBackfillJob(),
-			// Hourly, RunOnStart, for the reason the two sweeps above
-			// give: river's OSS scheduler recomputes nextRunAt at every
-			// Start, so without it a service that deploys more often
-			// than the interval never sweeps.  The read stamp is what
-			// makes firing on boot free.
-			queue.PeriodicAnilistRatingsJob(),
-			queue.PeriodicBangumiRatingsJob(),
-		},
-		Logger: slog.Default(),
+		Workers:      workers,
+		Queues:       registry.QueueConfigs(),
+		PeriodicJobs: registry.PeriodicJobs(),
+		Logger:       slog.Default(),
 	})
 	if err != nil {
 		slog.Error("river queue boot failed", "err", err)
@@ -1285,4 +1156,86 @@ func healthHandler(pool *pgxpool.Pool) http.HandlerFunc {
 			OK: true, Service: "go-api", Stage: "P2.1", DB: "up",
 		})
 	}
+}
+
+// workerDeps is everything the river worker bundle is built from.
+//
+// A struct rather than eleven positional parameters because the members are
+// shared instances whose sharing is load-bearing: bangumiClient carries the
+// 800ms token bucket four sweeps draw from, dandanClient carries the one
+// user-facing /match also draws on, and a second instance of either would
+// silently double the real rate against the same upstream.  Naming them at
+// the call site is worth more here than brevity.
+type workerDeps struct {
+	bangumi queue.BangumiV12Client
+	anilist *anilist.Client
+	dandan  *dandanplay.Client
+	llm     queue.DescriptionTranslator
+	db      *dbgen.Queries
+	pool    *pgxpool.Pool
+	// The concrete late-bound enqueuer, not the narrow queue.Enqueuer: each
+	// Add*Workers call takes its own single-method interface, and only the
+	// concrete type satisfies all of them at once.
+	enqueuer  *queue.LateBoundEnqueuer
+	normalize queue.MainRowNormalizer
+}
+
+// buildWorkers assembles the production river worker bundle.
+//
+// Extracted from main() so cmd/server/workers_test.go can assert that every
+// kind in the queue registry has a worker here.  That check has to live
+// somewhere: the registry gives a kind a queue and a schedule, and river's
+// PERIODIC path never consults the workers bundle, so a scheduled kind with
+// no worker is inserted happily and only fails when a producer picks it up.
+func buildWorkers(d workerDeps) *river.Workers {
+	workers := queue.WorkersWithBangumiAndNormalizer(
+		d.bangumi,
+		d.anilist,
+		d.db,
+		d.enqueuer,
+		d.normalize,
+	)
+	// LLM translation sweep registers separately so the bundle builder's
+	// signature (and its test doubles) stay untouched.  With a nil
+	// translator this registers a disabled scan + a defensive no-op row
+	// worker — see AddDescriptionLlmWorkers.
+	queue.AddDescriptionLlmWorkers(workers, d.llm, d.db, d.enqueuer)
+	// zh-Hant sweep.  Registers separately for the same reason: it shares
+	// none of the bundle builder's dependencies and needs one nothing else
+	// does — the vendored dataset directory, which the image bakes at
+	// /usr/local/share/animego/hant and a checkout has at data/hant.
+	// Empty string here means "read HANT_DATA_DIR, default data/hant";
+	// docker-compose sets it for the container.
+	queue.AddHantBackfillWorker(workers, d.db, "")
+	// Inferred-episode-count sweep.  Registers separately for the same
+	// reason as the two above — it needs none of V12DB and V12DB needs
+	// none of it — and takes the SAME bangumiClient every other worker
+	// holds so its two-requests-per-row draw from the one token bucket
+	// rather than opening a second one beside it.
+	queue.AddEpisodesBgmWorkers(workers, d.bangumi, d.db, d.enqueuer)
+	// Airing-show episode-title top-up.  Takes the shared dandanplay client
+	// for the same reason the sweep above takes the shared bangumiClient, and
+	// the pool because its write is a four-statement transaction shared with
+	// cmd/bgmbackfill (internal/episodetitles).  Gated at work time by
+	// EPISODE_TITLES_SWEEP_ENABLED; registering it is not the same as running
+	// it.
+	queue.AddEpisodeTitlesWorker(workers, d.pool, d.db, d.dandan, d.bangumi)
+
+	// The id-map bind sweep.  Takes the pool because its unit of work is a
+	// transaction spanning a binding write and that binding's V2 dispatch --
+	// a bound row with no enrichment queued behind it would drop out of the
+	// sweep's own candidate set and never be looked at again.  Takes the
+	// enqueuer for the same reason; `enqueuer` is late-bound above and is
+	// wired to river before any job can run.  Gated at work time by
+	// BGM_BIND_IDMAP_SWEEP_ENABLED.
+	queue.AddBindIdMapWorker(workers, d.pool, d.db, d.enqueuer)
+
+	// The two rating-refresh sweeps.  Register separately for the reason
+	// every sweep above does -- they need the AniList client, which the
+	// bundle builder holds but does not hand to any worker of its own --
+	// and the Bangumi half takes the SAME bangumiClient so its one
+	// request per row draws from the shared token bucket rather than
+	// opening a second one beside it.
+	queue.AddRatingsWorkers(workers, d.anilist, d.bangumi, d.db)
+	return workers
 }

--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -63,26 +64,7 @@ import (
 )
 
 func main() {
-	// The default logger writes JSON to stdout AND forwards every ERROR to
-	// Sentry.  The forwarding half is not a nicety: river reports background
-	// failures by logging one ERROR line and carrying on — a periodic job
-	// whose UniqueOpts fail validation, an insert conflict, a transaction
-	// error — and until 2026-09-08 that line reached nothing but the
-	// container log.  A sweep stopped enqueueing for 23 minutes and the only
-	// evidence anywhere was one line nobody was reading.
-	//
-	// Wrapping here rather than after sentry.Init below is safe and
-	// deliberate: the handler resolves its hub per record, so lines logged
-	// before Init (and every line when SENTRY_DSN is empty) hit an
-	// uninitialised hub that drops them, while the stdout half is
-	// byte-identical either way.  See internal/obs.
-	logger := slog.New(obs.NewSentryErrorHandler(
-		slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-			Level: slog.LevelInfo,
-		}),
-		obs.Options{},
-	))
-	slog.SetDefault(logger)
+	slog.SetDefault(newRootLogger(os.Stdout))
 
 	// Sentry init — P10 observability lane.  Empty SENTRY_DSN is the
 	// intended no-op for dev/staging (sentry-go drops events silently
@@ -217,13 +199,7 @@ func main() {
 	// See registry.go for why the registry reads InsertOpts() rather than
 	// replacing it, and test/integration/queue_registry_test.go for the
 	// gate that boots this exact configuration against a real Postgres.
-	registry := queue.Default()
-	riverClient, err := queue.Boot(pool, queue.Config{
-		Workers:      workers,
-		Queues:       registry.QueueConfigs(),
-		PeriodicJobs: registry.PeriodicJobs(),
-		Logger:       slog.Default(),
-	})
+	riverClient, err := queue.Boot(pool, queueBootConfig(workers))
 	if err != nil {
 		slog.Error("river queue boot failed", "err", err)
 		os.Exit(1)
@@ -1251,4 +1227,51 @@ func buildWorkers(d workerDeps) *river.Workers {
 	// opening a second one beside it.
 	queue.AddRatingsWorkers(workers, d.anilist, d.bangumi, d.db)
 	return workers
+}
+
+// newRootLogger builds the process logger: JSON to out, plus every ERROR
+// forwarded to Sentry.
+//
+// The forwarding half is not a nicety.  river reports background failures by
+// logging one ERROR line and carrying on — a periodic job whose UniqueOpts
+// fail validation, an insert conflict, a transaction error — and until
+// 2026-09-08 that line reached nothing but the container log.  A sweep
+// stopped enqueueing for 23 minutes and the only evidence anywhere was one
+// line nobody was reading.
+//
+// Wrapping here rather than after sentry.Init is safe and deliberate: the
+// handler resolves its hub per record, so lines logged before Init (and every
+// line when SENTRY_DSN is empty) hit an uninitialised hub that drops them,
+// while the stdout half is byte-identical either way.
+//
+// Extracted from main() so main_wiring_test.go can assert the forwarder is
+// actually in the chain.  Losing it would be silent in exactly the way this
+// whole change exists to prevent: logs would look identical and Sentry would
+// simply stop hearing about background failures.
+func newRootLogger(out io.Writer) *slog.Logger {
+	return slog.New(obs.NewSentryErrorHandler(
+		slog.NewJSONHandler(out, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}),
+		obs.Options{},
+	))
+}
+
+// queueBootConfig is the river configuration the server boots with: the
+// registry's queues and schedules, plus the worker bundle.
+//
+// Extracted for the same reason as newRootLogger.  Dropping
+// Queues or PeriodicJobs here fails silently and severely: queue.Boot falls
+// back to {default: 1}, so eight dedicated queues get no producer and their
+// jobs sit `available` forever, and no sweep is ever scheduled.  Neither
+// produces an error, a log line, or a failed request — the same shape as the
+// incident that prompted the registry.
+func queueBootConfig(workers *river.Workers) queue.Config {
+	registry := queue.Default()
+	return queue.Config{
+		Workers:      workers,
+		Queues:       registry.QueueConfigs(),
+		PeriodicJobs: registry.PeriodicJobs(),
+		Logger:       slog.Default(),
+	}
 }

--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 	"github.com/lawrenceli0228/animego/go-api/internal/jwtx"
 	"github.com/lawrenceli0228/animego/go-api/internal/notifications"
+	"github.com/lawrenceli0228/animego/go-api/internal/obs"
 	"github.com/lawrenceli0228/animego/go-api/internal/queue"
 	"github.com/lawrenceli0228/animego/go-api/internal/safety"
 	"github.com/lawrenceli0228/animego/go-api/internal/social"
@@ -62,9 +63,25 @@ import (
 )
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
+	// The default logger writes JSON to stdout AND forwards every ERROR to
+	// Sentry.  The forwarding half is not a nicety: river reports background
+	// failures by logging one ERROR line and carrying on — a periodic job
+	// whose UniqueOpts fail validation, an insert conflict, a transaction
+	// error — and until 2026-09-08 that line reached nothing but the
+	// container log.  A sweep stopped enqueueing for 23 minutes and the only
+	// evidence anywhere was one line nobody was reading.
+	//
+	// Wrapping here rather than after sentry.Init below is safe and
+	// deliberate: the handler resolves its hub per record, so lines logged
+	// before Init (and every line when SENTRY_DSN is empty) hit an
+	// uninitialised hub that drops them, while the stdout half is
+	// byte-identical either way.  See internal/obs.
+	logger := slog.New(obs.NewSentryErrorHandler(
+		slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}),
+		obs.Options{},
+	))
 	slog.SetDefault(logger)
 
 	// Sentry init — P10 observability lane.  Empty SENTRY_DSN is the

--- a/go-api/cmd/server/main.go
+++ b/go-api/cmd/server/main.go
@@ -963,6 +963,19 @@ func main() {
 		r.Post("/enrichment/{anilistId}/reset", adminEnrichmentHandlers.ResetEnrichment)
 		r.Post("/enrichment/{anilistId}/flag", adminEnrichmentHandlers.FlagEnrichment)
 
+		// Queue control, generalised.  heal-cn/pause above is now one of
+		// these under an older name, kept because the admin frontend calls
+		// it; these reach the other seven dedicated queues, which were each
+		// given their own worker pool precisely so they could be stopped one
+		// at a time without a deploy.
+		//
+		// {name} is validated against the queue registry, which refuses
+		// river's default queue -- it carries V1, V2, warm_season and
+		// orphan_scan at once -- and river's "*" wildcard with it.
+		r.Get("/queues", adminEnrichmentHandlers.QueuesStatus)
+		r.Post("/queues/{name}/pause", adminEnrichmentHandlers.PauseQueue)
+		r.Post("/queues/{name}/resume", adminEnrichmentHandlers.ResumeQueue)
+
 		// zh-Hant drift monitor: the two counters that say how far the
 		// Traditional columns have fallen behind their sources, and the
 		// button that catches them up.

--- a/go-api/cmd/server/main_wiring_test.go
+++ b/go-api/cmd/server/main_wiring_test.go
@@ -1,0 +1,167 @@
+// main_wiring_test.go — the two pieces of boot wiring whose loss is silent.
+//
+// Everything else in main() fails loudly if it is wrong: a bad DSN exits, an
+// unmounted route 404s on first use, a missing handler is a compile error.
+// These two do not.  Drop the Sentry forwarder and the logs look identical
+// while Sentry stops hearing about background failures.  Drop Queues or
+// PeriodicJobs and queue.Boot falls back to {default: 1}, so eight queues get
+// no producer and no sweep is ever scheduled — no error, no log line, no
+// failed request.
+//
+// That is the same shape as the incident this whole change exists to prevent,
+// which is why these are worth an indirection to test.
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/queue"
+)
+
+// ---------------------------------------------------------------------------
+// newRootLogger
+// ---------------------------------------------------------------------------
+
+// TestNewRootLogger_ForwardsErrorsToSentry drives the logger the way river
+// does and asserts the record reaches a Sentry capturer.
+//
+// Through the real handler chain rather than by type assertion: what has to
+// hold is that an ERROR gets forwarded, not that a particular type is present.
+// A future handler inserted between the two would pass a type check and could
+// still swallow the record.
+func TestNewRootLogger_ForwardsErrorsToSentry(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newRootLogger(&buf)
+
+	transport := &recordingTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://key@example.invalid/1",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+	hub := sentry.NewHub(client, sentry.NewScope())
+
+	logger.ErrorContext(sentry.SetHubOnContext(context.Background(), hub),
+		"maintenance.PeriodicJobEnqueuer: Internal error generating periodic job",
+		"error", "UniqueOpts.ByState must contain all required states, missing: running")
+
+	events := transport.all()
+	require.Len(t, events, 1,
+		"the process logger must forward ERROR to Sentry; without it river's "+
+			"background failures reach the container log and nothing else")
+	assert.Contains(t, events[0].Message, "Internal error generating periodic job")
+
+	assert.Contains(t, buf.String(), "Internal error generating periodic job",
+		"and the container log must still get it")
+}
+
+// TestNewRootLogger_KeepsStdoutJSON pins that the forwarder did not change the
+// log format callers and dashboards parse.
+func TestNewRootLogger_KeepsStdoutJSON(t *testing.T) {
+	var buf bytes.Buffer
+	newRootLogger(&buf).Info("postgres pool ready", "max_conns", 10)
+
+	line := buf.String()
+	assert.True(t, strings.HasPrefix(line, "{"), "must stay JSON, got %q", line)
+	assert.Contains(t, line, `"msg":"postgres pool ready"`)
+	assert.Contains(t, line, `"max_conns":10`)
+}
+
+// TestNewRootLogger_DoesNotForwardBelowError pins that routine logging does
+// not spend Sentry quota.
+func TestNewRootLogger_DoesNotForwardBelowError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newRootLogger(&buf)
+
+	transport := &recordingTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://key@example.invalid/1",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+	ctx := sentry.SetHubOnContext(context.Background(), sentry.NewHub(client, sentry.NewScope()))
+
+	logger.InfoContext(ctx, "river queue ready")
+	logger.WarnContext(ctx, "sentry init failed")
+
+	assert.Empty(t, transport.all())
+}
+
+// recordingTransport keeps events instead of sending them.
+type recordingTransport struct{ events []*sentry.Event }
+
+func (t *recordingTransport) Configure(sentry.ClientOptions)        {}
+func (t *recordingTransport) Flush(_ time.Duration) bool            { return true }
+func (t *recordingTransport) FlushWithContext(context.Context) bool { return true }
+func (t *recordingTransport) Close()                                {}
+func (t *recordingTransport) SendEvent(event *sentry.Event)         { t.events = append(t.events, event) }
+func (t *recordingTransport) all() []*sentry.Event                  { return t.events }
+
+// ---------------------------------------------------------------------------
+// queueBootConfig
+// ---------------------------------------------------------------------------
+
+// TestQueueBootConfig_CarriesEveryRegistryQueue is the assertion that would
+// have failed on the night: without it, dropping Queues leaves seven
+// workloads with no producer and nothing anywhere says so.
+func TestQueueBootConfig_CarriesEveryRegistryQueue(t *testing.T) {
+	t.Parallel()
+
+	cfg := queueBootConfig(river.NewWorkers())
+
+	assert.Equal(t, queue.Default().QueueConfigs(), cfg.Queues,
+		"the boot config must be the registry's queue map, not a subset and not "+
+			"river's {default: 1} fallback")
+	require.NotEmpty(t, cfg.Queues)
+}
+
+// TestQueueBootConfig_SchedulesEveryPeriodicKind pins the other half.  An
+// empty PeriodicJobs slice is not an error to river; it just means no sweep
+// ever runs again.
+func TestQueueBootConfig_SchedulesEveryPeriodicKind(t *testing.T) {
+	t.Parallel()
+
+	cfg := queueBootConfig(river.NewWorkers())
+
+	var scheduled int
+	for _, e := range queue.Default().Entries() {
+		if e.Periodic != nil {
+			scheduled++
+		}
+	}
+	require.NotZero(t, scheduled)
+	assert.Len(t, cfg.PeriodicJobs, scheduled,
+		"every scheduled kind in the registry must reach river")
+}
+
+// TestQueueBootConfig_PassesTheWorkerBundle guards the third way this call can
+// go wrong: a nil Workers makes queue.Boot fall back to the V2-stub-only
+// bundle, so every real worker silently disappears.
+func TestQueueBootConfig_PassesTheWorkerBundle(t *testing.T) {
+	t.Parallel()
+
+	workers := buildWorkers(workerDeps{})
+	cfg := queueBootConfig(workers)
+
+	assert.Same(t, workers, cfg.Workers)
+}
+
+// TestQueueBootConfig_UsesTheDefaultLogger ties the two halves of this file
+// together: river reports its background failures through this logger, and
+// main sets slog's default to newRootLogger's output.  A nil Logger here
+// would leave queue.Boot to substitute slog.Default() anyway, so this is
+// about the intent being explicit rather than incidental.
+func TestQueueBootConfig_UsesTheDefaultLogger(t *testing.T) {
+	cfg := queueBootConfig(river.NewWorkers())
+	assert.Same(t, slog.Default(), cfg.Logger)
+}

--- a/go-api/cmd/server/workers_test.go
+++ b/go-api/cmd/server/workers_test.go
@@ -1,0 +1,93 @@
+// workers_test.go — the gate that every registered job kind has a worker.
+//
+// This check has to live somewhere, and river will not do it.  The registry
+// gives a kind a queue and a schedule; river's PERIODIC insert path
+// (insertParamsFromConfigArgsAndOptions) never consults the workers bundle,
+// so a scheduled kind with no worker is inserted happily and only fails later
+// when a producer tries to run it — as a job that errors and retries, which
+// looks like a flaky upstream rather than a wiring mistake.
+//
+// client.Insert does check, which is why the integration suite can pin that
+// behaviour; but nothing on the boot path exercises Insert for these kinds.
+// So the check is here, against the real bundle main() builds.
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/queue"
+)
+
+// TestBuildWorkers_CoversEveryRegisteredKind is the whole point of extracting
+// buildWorkers out of main().
+//
+// Every dependency is nil.  Registration only constructs the workers; nothing
+// here runs one, so no client is ever dialled.  That is what makes the check
+// cheap enough to be a unit test.
+func TestBuildWorkers_CoversEveryRegisteredKind(t *testing.T) {
+	t.Parallel()
+
+	workers := buildWorkers(workerDeps{})
+	require.NotNil(t, workers)
+
+	registered := registeredKinds(t, workers)
+	for _, kind := range queue.Default().Kinds() {
+		assert.Contains(t, registered, kind,
+			"kind %q is in the queue registry — so it gets a queue and, if scheduled, "+
+				"river will enqueue it — but buildWorkers registers no worker for it. "+
+				"The job would be created and then fail at dispatch.", kind)
+	}
+}
+
+// TestBuildWorkers_RegistersNothingUnknown catches the other direction: a
+// worker for a kind the registry does not know about gets no queue
+// configuration, so its jobs sit unfetched on a queue river never starts a
+// producer for.
+func TestBuildWorkers_RegistersNothingUnknown(t *testing.T) {
+	t.Parallel()
+
+	declared := make(map[string]bool)
+	for _, kind := range queue.Default().Kinds() {
+		declared[kind] = true
+	}
+
+	for _, kind := range registeredKinds(t, buildWorkers(workerDeps{})) {
+		assert.True(t, declared[kind],
+			"a worker is registered for kind %q but the registry does not declare it, "+
+				"so no queue is configured for its jobs", kind)
+	}
+}
+
+// registeredKinds reads the kinds out of a river.Workers bundle.
+//
+// river keeps the map unexported and offers no accessor, so this is
+// reflection — the same deliberate coupling the periodic-job tests take, and
+// for the same reason: river is version-pinned, and an upgrade that reshapes
+// Workers should stop and make somebody re-confirm this rather than let the
+// check quietly become a no-op.
+//
+// The require below is what stops that.  A rename would otherwise leave this
+// test iterating an empty list and passing.
+func registeredKinds(t *testing.T, w *river.Workers) []string {
+	t.Helper()
+
+	field := reflect.ValueOf(w).Elem().FieldByName("workersMap")
+	require.True(t, field.IsValid(),
+		"river.Workers no longer has a `workersMap` field — this check has become "+
+			"a no-op and needs rewriting against the new shape")
+	require.Equal(t, reflect.Map, field.Kind())
+	require.NotZero(t, field.Len(),
+		"the bundle registered no workers at all, which means this check would pass "+
+			"vacuously")
+
+	out := make([]string, 0, field.Len())
+	for _, key := range field.MapKeys() {
+		out = append(out, key.String())
+	}
+	return out
+}

--- a/go-api/internal/admin/enrichment.go
+++ b/go-api/internal/admin/enrichment.go
@@ -714,20 +714,42 @@ type pauseResponse struct {
 	Paused bool `json:"paused"`
 }
 
-// PauseHeal handles POST /api/admin/enrichment/heal-cn/pause.  Thin
-// wrapper around queue.PauseV3.  If QueueCtrl is nil (test/boot before
-// river is ready) the call still returns 200 paused:true — matches
-// Express's in-memory bool flip semantics.
+// errQueueCtrlUnavailable is what a nil QueueCtrl now produces.
+//
+// It used to produce 200 {"paused":true} and no pause at all.  The comment
+// justifying that called it "matches Express's in-memory bool flip
+// semantics", which was true and beside the point: Express's flag WAS the
+// mechanism, so flipping it did pause the work.  Here the flag is river's,
+// and a nil controller means the request reached a process that cannot
+// touch it.
+//
+// The cost of the old behaviour is paid exactly when it hurts most.  These
+// endpoints are the three-in-the-morning lever — "stop that sweep now, look
+// at the data, decide later" — and an operator who pressed it got a
+// confident success and a queue that kept running.  Generalising pause to
+// eight queues would have multiplied that by eight.
+var errQueueCtrlUnavailable = httpx.NewError(
+	http.StatusServiceUnavailable, httpx.CodeServerError,
+	"queue controller unavailable: the queue was NOT paused")
+
+// PauseHeal handles POST /api/admin/enrichment/heal-cn/pause.
+//
+// Kept as its own route because the admin frontend already calls it.  It is
+// now a thin alias for PauseQueue against BangumiV3QueueName.
 func (h *EnrichmentHandlers) PauseHeal(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), enrichmentQueryTimeout)
 	defer cancel()
 
-	if h.QueueCtrl != nil {
-		if err := queue.PauseV3(ctx, h.QueueCtrl); err != nil {
-			slog.WarnContext(ctx, "admin: PauseV3", "err", err)
-			httpx.Fail(w, httpx.WrapError(err, http.StatusInternalServerError, httpx.CodeServerError, "internal error"))
-			return
-		}
+	if h.QueueCtrl == nil {
+		slog.ErrorContext(ctx, "admin: pause requested with no queue controller",
+			"queue", queue.BangumiV3QueueName)
+		httpx.Fail(w, errQueueCtrlUnavailable)
+		return
+	}
+	if err := queue.PauseV3(ctx, h.QueueCtrl); err != nil {
+		slog.ErrorContext(ctx, "admin: PauseV3", "err", err)
+		httpx.Fail(w, httpx.WrapError(err, http.StatusInternalServerError, httpx.CodeServerError, "internal error"))
+		return
 	}
 
 	httpx.Data(w, http.StatusOK, pauseResponse{Paused: true})
@@ -738,15 +760,118 @@ func (h *EnrichmentHandlers) ResumeHeal(w http.ResponseWriter, r *http.Request) 
 	ctx, cancel := context.WithTimeout(r.Context(), enrichmentQueryTimeout)
 	defer cancel()
 
-	if h.QueueCtrl != nil {
-		if err := queue.ResumeV3(ctx, h.QueueCtrl); err != nil {
-			slog.WarnContext(ctx, "admin: ResumeV3", "err", err)
-			httpx.Fail(w, httpx.WrapError(err, http.StatusInternalServerError, httpx.CodeServerError, "internal error"))
-			return
-		}
+	if h.QueueCtrl == nil {
+		slog.ErrorContext(ctx, "admin: resume requested with no queue controller",
+			"queue", queue.BangumiV3QueueName)
+		httpx.Fail(w, errQueueCtrlUnavailable)
+		return
+	}
+	if err := queue.ResumeV3(ctx, h.QueueCtrl); err != nil {
+		slog.ErrorContext(ctx, "admin: ResumeV3", "err", err)
+		httpx.Fail(w, httpx.WrapError(err, http.StatusInternalServerError, httpx.CodeServerError, "internal error"))
+		return
 	}
 
 	httpx.Data(w, http.StatusOK, pauseResponse{Paused: false})
+}
+
+// ============================================================================
+// POST /api/admin/queues/{name}/pause | /resume, GET /api/admin/queues
+// ============================================================================
+
+// queueStatusResponse is the shape GET /api/admin/queues returns.
+type queueStatusResponse struct {
+	// Queues lists every queue this surface may act on, sorted.  Returned
+	// alongside the flags so an operator (or a UI) does not have to hardcode
+	// the list to know what it can ask for.
+	Queues []string `json:"queues"`
+
+	// Paused maps queue name to its pause flag.  A queue river has no row
+	// for is ABSENT rather than false — see queue.StatusAll.
+	Paused map[string]bool `json:"paused"`
+
+	// V3Paused is the legacy field the existing admin frontend reads.
+	V3Paused bool `json:"v3Paused"`
+}
+
+// PauseQueue handles POST /api/admin/queues/{name}/pause.
+//
+// The name is validated against the queue registry, which refuses
+// river.QueueDefault: that queue carries V1, V2, warm_season and orphan_scan
+// at once, so pausing it would freeze the enrichment a page load is waiting
+// on.  An unknown or refused name is a 400, not a 500 — the operator asked
+// for something that does not exist, which is a different thing from river
+// failing.
+func (h *EnrichmentHandlers) PauseQueue(w http.ResponseWriter, r *http.Request) {
+	h.setQueuePaused(w, r, true)
+}
+
+// ResumeQueue handles POST /api/admin/queues/{name}/resume.
+func (h *EnrichmentHandlers) ResumeQueue(w http.ResponseWriter, r *http.Request) {
+	h.setQueuePaused(w, r, false)
+}
+
+// setQueuePaused is the shared body of the two handlers above.
+func (h *EnrichmentHandlers) setQueuePaused(w http.ResponseWriter, r *http.Request, paused bool) {
+	ctx, cancel := context.WithTimeout(r.Context(), enrichmentQueryTimeout)
+	defer cancel()
+
+	name := chi.URLParam(r, "name")
+
+	if h.QueueCtrl == nil {
+		slog.ErrorContext(ctx, "admin: queue pause/resume with no queue controller",
+			"queue", name, "paused", paused)
+		httpx.Fail(w, errQueueCtrlUnavailable)
+		return
+	}
+
+	act := queue.ResumeQueue
+	if paused {
+		act = queue.PauseQueue
+	}
+
+	if err := act(ctx, h.QueueCtrl, name); err != nil {
+		if errors.Is(err, queue.ErrQueueNotPausable) {
+			slog.WarnContext(ctx, "admin: refused queue", "queue", name, "err", err)
+			httpx.Fail(w, httpx.NewError(http.StatusBadRequest, httpx.CodeBadRequest, err.Error()))
+			return
+		}
+		slog.ErrorContext(ctx, "admin: queue pause/resume failed",
+			"queue", name, "paused", paused, "err", err)
+		httpx.Fail(w, httpx.WrapError(err, http.StatusInternalServerError, httpx.CodeServerError, "internal error"))
+		return
+	}
+
+	httpx.Data(w, http.StatusOK, pauseResponse{Paused: paused})
+}
+
+// QueuesStatus handles GET /api/admin/queues.
+//
+// Being able to stop a queue without being able to see whether it stopped is
+// half a switch, and the missing half is the one somebody needs while an
+// incident is running.
+func (h *EnrichmentHandlers) QueuesStatus(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), enrichmentQueryTimeout)
+	defer cancel()
+
+	if h.QueueCtrl == nil {
+		slog.ErrorContext(ctx, "admin: queue status with no queue controller")
+		httpx.Fail(w, errQueueCtrlUnavailable)
+		return
+	}
+
+	stats, err := queue.StatusAll(ctx, h.QueueCtrl)
+	if err != nil {
+		slog.ErrorContext(ctx, "admin: queue status failed", "err", err)
+		httpx.Fail(w, httpx.WrapError(err, http.StatusInternalServerError, httpx.CodeServerError, "internal error"))
+		return
+	}
+
+	httpx.Data(w, http.StatusOK, queueStatusResponse{
+		Queues:   queue.PausableQueues(),
+		Paused:   stats.Paused,
+		V3Paused: stats.V3Paused,
+	})
 }
 
 // ============================================================================

--- a/go-api/internal/admin/enrichment_test.go
+++ b/go-api/internal/admin/enrichment_test.go
@@ -926,6 +926,48 @@ func TestResumeQueue_ResumesNamedQueue(t *testing.T) {
 // TestPauseQueue_NilCtrl_Fails is the generalised form of the bug this change
 // fixes: without it, widening pause to eight queues would have multiplied a
 // confident-but-false success by eight.
+// TestResumeQueue_RefusesDefault covers the resume half of the shared
+// validation.  Pause and resume go through one function, but a future split
+// would silently leave resume open, and resuming default is how a paused
+// subsystem gets un-paused by accident.
+func TestResumeQueue_RefusesDefault(t *testing.T) {
+	qc := &fakeQueueController{}
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, qc)
+
+	rec := httptest.NewRecorder()
+	h.ResumeQueue(rec, newQueueRequest(http.MethodPost, "/api/admin/queues/default/resume", "default"))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+	if got := qc.snapshotNames(); len(got) != 0 {
+		t.Errorf("a refused name reached river: %v", got)
+	}
+}
+
+func TestResumeQueue_NilCtrl_Fails(t *testing.T) {
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, nil)
+
+	rec := httptest.NewRecorder()
+	h.ResumeQueue(rec, newQueueRequest(http.MethodPost, "/api/admin/queues/x/resume", queue.RatingsQueueName))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rec.Code)
+	}
+}
+
+func TestResumeQueue_RiverErrorIs500(t *testing.T) {
+	qc := &fakeQueueController{resumeErr: errors.New("queue down")}
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, qc)
+
+	rec := httptest.NewRecorder()
+	h.ResumeQueue(rec, newQueueRequest(http.MethodPost, "/api/admin/queues/x/resume", queue.RatingsQueueName))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d, want 500", rec.Code)
+	}
+}
+
 func TestPauseQueue_NilCtrl_Fails(t *testing.T) {
 	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, nil)
 

--- a/go-api/internal/admin/enrichment_test.go
+++ b/go-api/internal/admin/enrichment_test.go
@@ -168,11 +168,23 @@ type fakeQueueController struct {
 	pauseErr  error
 	resumeErr error
 	getErr    error
+
+	// names records every queue name that reached the controller, in order.
+	// The generic pause handlers are validated BEFORE they call river, so
+	// "did this name get through?" is the assertion that matters for them.
+	names []string
+}
+
+func (f *fakeQueueController) snapshotNames() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append(([]string)(nil), f.names...)
 }
 
 func (f *fakeQueueController) QueuePause(ctx context.Context, name string, opts *river.QueuePauseOpts) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.names = append(f.names, name)
 	if f.pauseErr != nil {
 		return f.pauseErr
 	}
@@ -183,6 +195,7 @@ func (f *fakeQueueController) QueuePause(ctx context.Context, name string, opts 
 func (f *fakeQueueController) QueueResume(ctx context.Context, name string, opts *river.QueuePauseOpts) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.names = append(f.names, name)
 	if f.resumeErr != nil {
 		return f.resumeErr
 	}
@@ -590,13 +603,37 @@ func TestResumeHeal_CallsQueueCtrl(t *testing.T) {
 	}
 }
 
-func TestPauseHeal_NilCtrl_StillReturns200(t *testing.T) {
+// TestPauseHeal_NilCtrl_Fails replaces a test that asserted the opposite.
+//
+// The old behaviour returned 200 {"paused":true} with a nil controller and
+// paused nothing, justified as matching "Express's in-memory bool flip
+// semantics".  That was true and beside the point: in Express the flag WAS
+// the mechanism, so flipping it did stop the work.  Here the flag is
+// river's, and a nil controller means the request reached a process that
+// cannot touch it.
+//
+// These endpoints are the three-in-the-morning lever.  An operator who
+// pressed it got a confident success and a queue that kept running.
+func TestPauseHeal_NilCtrl_Fails(t *testing.T) {
 	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/admin/enrichment/heal-cn/pause", nil)
 	rec := httptest.NewRecorder()
 	h.PauseHeal(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status=%d, want 200", rec.Code)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "NOT paused") {
+		t.Errorf("body must say the queue was not paused, got %s", rec.Body.String())
+	}
+}
+
+func TestResumeHeal_NilCtrl_Fails(t *testing.T) {
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/enrichment/heal-cn/resume", nil)
+	rec := httptest.NewRecorder()
+	h.ResumeHeal(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rec.Code)
 	}
 }
 
@@ -794,5 +831,183 @@ func TestReEnrichIDs_DoesNotEnqueueWhenTheReadFails(t *testing.T) {
 	}
 	if len(enq.v2Calls) != 0 {
 		t.Fatalf("a failed read must not enqueue anything, got %+v", enq.v2Calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The generalised queue control endpoints
+// ---------------------------------------------------------------------------
+
+// newQueueRequest builds a request with chi's {name} route parameter set, the
+// way the router would.
+func newQueueRequest(method, target, name string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("name", name)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// TestPauseQueue_RefusesDefault is the safety constraint at the HTTP edge.
+// The default queue carries V1, V2, warm_season and orphan_scan at once, so
+// pausing it freezes the enrichment a page load is waiting on.
+func TestPauseQueue_RefusesDefault(t *testing.T) {
+	qc := &fakeQueueController{}
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, qc)
+
+	rec := httptest.NewRecorder()
+	h.PauseQueue(rec, newQueueRequest(http.MethodPost, "/api/admin/queues/default/pause", "default"))
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d, want 400", rec.Code)
+	}
+	if got := qc.snapshotNames(); len(got) != 0 {
+		t.Errorf("a refused name reached river: %v", got)
+	}
+}
+
+// TestPauseQueue_RefusesUnknownName is a 400 and not a 500 on purpose: the
+// operator asked for something that does not exist, which is a different
+// thing from river failing, and only one of the two is worth paging about.
+func TestPauseQueue_RefusesUnknownName(t *testing.T) {
+	for _, name := range []string{"", "*", "no_such_queue"} {
+		qc := &fakeQueueController{}
+		h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, qc)
+
+		rec := httptest.NewRecorder()
+		h.PauseQueue(rec, newQueueRequest(http.MethodPost, "/api/admin/queues/x/pause", name))
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("name=%q status=%d, want 400", name, rec.Code)
+		}
+		if got := qc.snapshotNames(); len(got) != 0 {
+			t.Errorf("name=%q reached river: %v", name, got)
+		}
+	}
+}
+
+// TestPauseQueue_PausesEveryDedicatedQueue is the feature: the seven queues
+// beyond V3 that were each given their own worker pool so they could be
+// stopped one at a time are now reachable without a deploy.
+func TestPauseQueue_PausesEveryDedicatedQueue(t *testing.T) {
+	for _, name := range queue.PausableQueues() {
+		qc := &fakeQueueController{}
+		h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, qc)
+
+		rec := httptest.NewRecorder()
+		h.PauseQueue(rec, newQueueRequest(http.MethodPost, "/api/admin/queues/x/pause", name))
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("name=%q status=%d, want 200", name, rec.Code)
+		}
+		if got := qc.snapshotNames(); len(got) != 1 || got[0] != name {
+			t.Errorf("name=%q reached river as %v", name, got)
+		}
+		if !qc.paused {
+			t.Errorf("name=%q returned 200 without pausing", name)
+		}
+	}
+}
+
+func TestResumeQueue_ResumesNamedQueue(t *testing.T) {
+	qc := &fakeQueueController{paused: true}
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, qc)
+
+	rec := httptest.NewRecorder()
+	h.ResumeQueue(rec, newQueueRequest(http.MethodPost, "/api/admin/queues/x/resume", queue.RatingsQueueName))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", rec.Code)
+	}
+	if qc.paused {
+		t.Error("resume returned 200 but the queue is still paused")
+	}
+}
+
+// TestPauseQueue_NilCtrl_Fails is the generalised form of the bug this change
+// fixes: without it, widening pause to eight queues would have multiplied a
+// confident-but-false success by eight.
+func TestPauseQueue_NilCtrl_Fails(t *testing.T) {
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, nil)
+
+	rec := httptest.NewRecorder()
+	h.PauseQueue(rec, newQueueRequest(http.MethodPost, "/api/admin/queues/x/pause", queue.RatingsQueueName))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "NOT paused") {
+		t.Errorf("body must say the queue was not paused, got %s", rec.Body.String())
+	}
+}
+
+func TestPauseQueue_RiverErrorIs500(t *testing.T) {
+	qc := &fakeQueueController{pauseErr: errors.New("queue down")}
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, qc)
+
+	rec := httptest.NewRecorder()
+	h.PauseQueue(rec, newQueueRequest(http.MethodPost, "/api/admin/queues/x/pause", queue.RatingsQueueName))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d, want 500", rec.Code)
+	}
+}
+
+// TestQueuesStatus_ReportsEveryQueue covers the read half.  Being able to stop
+// a queue without being able to see whether it stopped is half a switch.
+func TestQueuesStatus_ReportsEveryQueue(t *testing.T) {
+	qc := &fakeQueueController{paused: true}
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, qc)
+
+	rec := httptest.NewRecorder()
+	h.QueuesStatus(rec, httptest.NewRequest(http.MethodGet, "/api/admin/queues", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", rec.Code)
+	}
+
+	var body struct {
+		Data queueStatusResponse `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, rec.Body.String())
+	}
+
+	want := queue.PausableQueues()
+	if len(body.Data.Queues) != len(want) {
+		t.Fatalf("queues=%v, want %v", body.Data.Queues, want)
+	}
+	for _, name := range want {
+		if paused, ok := body.Data.Paused[name]; !ok || !paused {
+			t.Errorf("queue %q: paused=%v ok=%v, want true", name, paused, ok)
+		}
+	}
+	if _, ok := body.Data.Paused["default"]; ok {
+		t.Error("default is not pausable and must not carry a flag")
+	}
+	if !body.Data.V3Paused {
+		t.Error("the legacy v3Paused field must stay in step with the map")
+	}
+}
+
+func TestQueuesStatus_NilCtrl_Fails(t *testing.T) {
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, nil)
+
+	rec := httptest.NewRecorder()
+	h.QueuesStatus(rec, httptest.NewRequest(http.MethodGet, "/api/admin/queues", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rec.Code)
+	}
+}
+
+func TestQueuesStatus_RiverErrorIs500(t *testing.T) {
+	qc := &fakeQueueController{getErr: errors.New("connection refused")}
+	h := newEnrichmentHandlersWithFakes(&fakeEnrichmentDB{}, &spyEnqueuer{}, qc)
+
+	rec := httptest.NewRecorder()
+	h.QueuesStatus(rec, httptest.NewRequest(http.MethodGet, "/api/admin/queues", nil))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d, want 500", rec.Code)
 	}
 }

--- a/go-api/internal/obs/sentryslog.go
+++ b/go-api/internal/obs/sentryslog.go
@@ -1,0 +1,343 @@
+// Package obs holds the small observability adapters that sit between the
+// standard library and the vendors we report to.
+//
+// Its first inhabitant exists because of a specific outage.  On 2026-09-08 a
+// change removed rivertype.JobStateRunning from one of four *UniqueStates
+// slices.  river's UniqueOpts.validate requires that state, so
+// PeriodicJobEnqueuer failed for that kind — and reported it like this
+// (internal/maintenance/periodic_job_enqueuer.go:572):
+//
+//	s.Logger.ErrorContext(ctx, s.Name+": Internal error generating periodic job", "error", err.Error())
+//
+// One ERROR line, and nothing else.  The service started, served traffic, and
+// simply never enqueued that sweep again.  river's Logger is a *slog.Logger,
+// and ours was a bare JSONHandler writing to stdout, so the line went to the
+// container log and no further.
+//
+// SentryErrorHandler closes that gap for every river background failure at
+// once — the enqueuer swallows insert conflicts, transaction errors and
+// constructor errors the same way, and no static gate can see any of them.
+package obs
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// Capturer is the one Sentry method this package needs.  Declared at the
+// use-site so tests can inject a recorder without an SDK transport, and so
+// the dependency direction stays one-way.  *sentry.Hub satisfies it.
+type Capturer interface {
+	CaptureEvent(event *sentry.Event) *sentry.EventID
+}
+
+// Compile-time guard: the SDK type we actually pass must satisfy Capturer.
+// Catches a signature change in the sentry-go upgrade path.
+var _ Capturer = (*sentry.Hub)(nil)
+
+const (
+	// DefaultRateWindow / DefaultRateBurst cap what one process can send.
+	//
+	// Sentry quota is finite and an ERROR is not necessarily rare: a wedged
+	// upstream can produce one per job attempt.  The cap is per window rather
+	// than per unique message because the failure this exists for repeats the
+	// SAME message once per enqueuer tick, and one alert is enough to act on.
+	//
+	// 20/minute is well above any healthy rate here (the whole service logged
+	// single-digit ERRORs a day before this) and well below a quota problem.
+	DefaultRateWindow = time.Minute
+	DefaultRateBurst  = 20
+
+	// droppedAttrKey names the extra that tells a reader the event they are
+	// looking at is standing in for others.  Without it a rate limiter turns a
+	// storm into a trickle and says nothing — which is the same silence this
+	// package was written to remove, one level up.
+	droppedAttrKey = "slog_events_dropped"
+
+	// slogContextKey names the Sentry context that carries the record's
+	// attributes.
+	slogContextKey = "slog"
+)
+
+// Options tunes SentryErrorHandler.  The zero value is the production
+// configuration: forward slog.LevelError and above, through the hub attached
+// to the record's context (or the current hub), at DefaultRateBurst per
+// DefaultRateWindow.
+type Options struct {
+	// Level is the threshold at or above which a record is forwarded.
+	// Zero means slog.LevelError.
+	Level slog.Level
+
+	// Capturer, when non-nil, receives every forwarded event.  Nil means
+	// resolve the hub per record: sentry.GetHubFromContext(ctx) if the
+	// context carries one, else sentry.CurrentHub().
+	//
+	// Resolving per record rather than capturing a hub at construction is
+	// what lets the HTTP middleware's request-scoped hub (with its user and
+	// request tags) receive errors logged inside a handler.
+	Capturer Capturer
+
+	// RateWindow / RateBurst cap forwarding.  Zero means the defaults above.
+	// A negative RateBurst disables the limiter entirely.
+	RateWindow time.Duration
+	RateBurst  int
+}
+
+// SentryErrorHandler passes every record through to a wrapped handler and
+// additionally forwards the ones at or above Options.Level to Sentry.
+//
+// Pass-through is unconditional and happens FIRST: the container log stays
+// exactly what it was, so this cannot make an incident harder to read even if
+// the Sentry half is misconfigured, rate-limited, or the SDK was never
+// initialised (an uninitialised hub drops events and returns nil).
+type SentryErrorHandler struct {
+	inner    slog.Handler
+	level    slog.Level
+	capturer Capturer
+	limiter  *limiter
+
+	// attrs are the WithAttrs-accumulated attributes, already qualified by
+	// whatever groups were open when they were added.  slog requires that
+	// WithAttrs/WithGroup return a NEW handler and leave the receiver alone,
+	// so these slices are copied on write and never appended to in place.
+	attrs  []slog.Attr
+	groups []string
+}
+
+// Compile-time guard: this must remain a slog.Handler.
+var _ slog.Handler = (*SentryErrorHandler)(nil)
+
+// NewSentryErrorHandler wraps inner.  A nil inner is a programming error and
+// panics at construction — the alternative is a logger that silently drops
+// every line, which is the failure mode this whole package exists to remove.
+func NewSentryErrorHandler(inner slog.Handler, opts Options) *SentryErrorHandler {
+	if inner == nil {
+		panic("obs.NewSentryErrorHandler: inner handler is required")
+	}
+
+	level := opts.Level
+	if level == 0 {
+		level = slog.LevelError
+	}
+
+	var lim *limiter
+	switch {
+	case opts.RateBurst < 0:
+		lim = nil
+	default:
+		burst := opts.RateBurst
+		if burst == 0 {
+			burst = DefaultRateBurst
+		}
+		window := opts.RateWindow
+		if window <= 0 {
+			window = DefaultRateWindow
+		}
+		lim = &limiter{window: window, burst: burst}
+	}
+
+	return &SentryErrorHandler{
+		inner:    inner,
+		level:    level,
+		capturer: opts.Capturer,
+		limiter:  lim,
+	}
+}
+
+// Enabled defers entirely to the wrapped handler.
+//
+// Deliberately NOT `inner.Enabled(...) || level >= h.level`: a record the
+// inner handler drops is one nobody can correlate against the container log,
+// and widening the level here would make Sentry the only place a class of
+// line exists.  If an ERROR needs forwarding, the base handler has to be
+// configured to keep it.
+func (h *SentryErrorHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+// Handle writes the record through the wrapped handler and, for records at or
+// above the threshold, sends a Sentry event carrying the message and every
+// attribute in scope.
+//
+// The inner handler's error is returned unchanged; a Sentry failure is never
+// allowed to turn into a logging failure.
+func (h *SentryErrorHandler) Handle(ctx context.Context, rec slog.Record) error {
+	err := h.inner.Handle(ctx, rec)
+	if rec.Level < h.level {
+		return err
+	}
+	h.forward(ctx, rec)
+	return err
+}
+
+// WithAttrs returns a copy carrying attrs, qualified by the open groups.
+func (h *SentryErrorHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	out := h.clone()
+	out.inner = h.inner.WithAttrs(attrs)
+	for _, a := range attrs {
+		out.attrs = append(out.attrs, slog.Attr{Key: qualify(h.groups, a.Key), Value: a.Value})
+	}
+	return out
+}
+
+// WithGroup returns a copy with name pushed onto the group prefix.
+func (h *SentryErrorHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	out := h.clone()
+	out.inner = h.inner.WithGroup(name)
+	out.groups = append(out.groups, name)
+	return out
+}
+
+// clone copies the handler with its slices detached, so the returned handler
+// can append without writing through to the receiver's backing arrays.
+func (h *SentryErrorHandler) clone() *SentryErrorHandler {
+	return &SentryErrorHandler{
+		inner:    h.inner,
+		level:    h.level,
+		capturer: h.capturer,
+		limiter:  h.limiter,
+		attrs:    append(([]slog.Attr)(nil), h.attrs...),
+		groups:   append(([]string)(nil), h.groups...),
+	}
+}
+
+// forward builds and sends the Sentry event for one record.
+func (h *SentryErrorHandler) forward(ctx context.Context, rec slog.Record) {
+	capturer := h.capturer
+	if capturer == nil {
+		capturer = hubFor(ctx)
+	}
+	if capturer == nil {
+		return
+	}
+
+	dropped := 0
+	if h.limiter != nil {
+		var allowed bool
+		allowed, dropped = h.limiter.allow(rec.Time)
+		if !allowed {
+			return
+		}
+	}
+
+	event := sentry.NewEvent()
+	event.Level = sentryLevel(rec.Level)
+	event.Message = rec.Message
+	event.Logger = "slog"
+	if !rec.Time.IsZero() {
+		event.Timestamp = rec.Time
+	}
+
+	// Attributes ride in a named context rather than the old top-level
+	// Extra map, which sentry-go dropped from Event before v0.46.  Grouping
+	// them under one key also keeps them together in the UI instead of
+	// scattered among the SDK's own contexts.
+	fields := make(sentry.Context, rec.NumAttrs()+len(h.attrs)+1)
+	for _, a := range h.attrs {
+		fields[a.Key] = a.Value.Resolve().Any()
+	}
+	rec.Attrs(func(a slog.Attr) bool {
+		fields[qualify(h.groups, a.Key)] = a.Value.Resolve().Any()
+		return true
+	})
+	if dropped > 0 {
+		fields[droppedAttrKey] = dropped
+	}
+	if len(fields) > 0 {
+		event.Contexts[slogContextKey] = fields
+	}
+
+	capturer.CaptureEvent(event)
+}
+
+// hubFor picks the request-scoped hub when the context carries one and falls
+// back to the process hub.  Returns nil only if the SDK handed back nil, which
+// it does not do today — the guard is here so a future SDK change degrades to
+// "no forwarding" rather than a nil dereference inside a log call.
+func hubFor(ctx context.Context) Capturer {
+	if hub := sentry.GetHubFromContext(ctx); hub != nil {
+		return hub
+	}
+	if hub := sentry.CurrentHub(); hub != nil {
+		return hub
+	}
+	return nil
+}
+
+// sentryLevel maps slog levels onto Sentry's.  Anything at or above Error is
+// reported as an error; the intermediate levels are mapped for the benefit of
+// callers that lower Options.Level.
+func sentryLevel(l slog.Level) sentry.Level {
+	switch {
+	case l >= slog.LevelError:
+		return sentry.LevelError
+	case l >= slog.LevelWarn:
+		return sentry.LevelWarning
+	case l >= slog.LevelInfo:
+		return sentry.LevelInfo
+	default:
+		return sentry.LevelDebug
+	}
+}
+
+// qualify joins an attribute key to the open group prefix the way slog's own
+// handlers do, so an extra reads the same as the corresponding JSON path.
+func qualify(groups []string, key string) string {
+	if len(groups) == 0 {
+		return key
+	}
+	out := make([]byte, 0, len(key)+8*len(groups))
+	for _, g := range groups {
+		out = append(out, g...)
+		out = append(out, '.')
+	}
+	return string(append(out, key...))
+}
+
+// limiter is a fixed-window counter.  Fixed window rather than a token bucket
+// because the quantity being protected is a per-interval quota, and because
+// the count of what it suppressed has to survive to the next allowed event —
+// a bucket that only says yes or no would lose it.
+type limiter struct {
+	mu     sync.Mutex
+	window time.Duration
+	burst  int
+
+	windowStart time.Time
+	sent        int
+	dropped     int
+}
+
+// allow reports whether an event may be sent at now, and — when it may — how
+// many were dropped since the previous allowed one.  Callers attach that count
+// to the event so a suppressed storm is visible rather than merely quiet.
+//
+// A zero now (slog leaves Record.Time zero only for hand-built records) is
+// treated as "same window", which fails toward sending.
+func (l *limiter) allow(now time.Time) (bool, int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !now.IsZero() && now.Sub(l.windowStart) >= l.window {
+		l.windowStart = now
+		l.sent = 0
+	}
+	if l.sent >= l.burst {
+		l.dropped++
+		return false, 0
+	}
+	l.sent++
+	dropped := l.dropped
+	l.dropped = 0
+	return true, dropped
+}

--- a/go-api/internal/obs/sentryslog_test.go
+++ b/go-api/internal/obs/sentryslog_test.go
@@ -1,0 +1,437 @@
+// sentryslog_test.go — unit coverage for the slog → Sentry bridge.
+//
+// The load-bearing case is TestSentryErrorHandler_ForwardsRiverEnqueuerError:
+// it drives the handler with the exact call river makes when a periodic job's
+// UniqueOpts fail validation, because that line going nowhere is the whole
+// reason this package exists.
+package obs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recorder is a Capturer that keeps every event it is handed.
+type recorder struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (r *recorder) CaptureEvent(event *sentry.Event) *sentry.EventID {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+	id := sentry.EventID("test")
+	return &id
+}
+
+func (r *recorder) all() []*sentry.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append(([]*sentry.Event)(nil), r.events...)
+}
+
+// newTestLogger returns a logger whose records go to both a JSON buffer (the
+// stand-in for the container log) and rec.
+func newTestLogger(t *testing.T, rec *recorder, opts Options) (*slog.Logger, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	opts.Capturer = rec
+	base := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	return slog.New(NewSentryErrorHandler(base, opts)), &buf
+}
+
+// slogFields pulls the attribute context off an event, or nil when absent.
+func slogFields(t *testing.T, e *sentry.Event) sentry.Context {
+	t.Helper()
+	return e.Contexts[slogContextKey]
+}
+
+// ---------------------------------------------------------------------------
+// The incident
+// ---------------------------------------------------------------------------
+
+// TestSentryErrorHandler_ForwardsRiverEnqueuerError reproduces the log call
+// from river's PeriodicJobEnqueuer (periodic_job_enqueuer.go:572) that
+// reported the 2026-09-08 stall and was seen by nobody.
+func TestSentryErrorHandler_ForwardsRiverEnqueuerError(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	logger, buf := newTestLogger(t, rec, Options{})
+
+	logger.ErrorContext(context.Background(),
+		"maintenance.PeriodicJobEnqueuer: Internal error generating periodic job",
+		"error", "UniqueOpts.ByState must contain all required states, missing: running")
+
+	events := rec.all()
+	require.Len(t, events, 1, "the one ERROR river emits must reach Sentry")
+	assert.Equal(t, sentry.LevelError, events[0].Level)
+	assert.Contains(t, events[0].Message, "Internal error generating periodic job")
+	assert.Equal(t, "slog", events[0].Logger)
+	assert.Equal(t,
+		"UniqueOpts.ByState must contain all required states, missing: running",
+		slogFields(t, events[0])["error"],
+		"the attribute naming the missing state is the whole diagnostic")
+
+	// The container log must be untouched by the forwarding.
+	assert.Contains(t, buf.String(), "Internal error generating periodic job")
+}
+
+// ---------------------------------------------------------------------------
+// Level threshold
+// ---------------------------------------------------------------------------
+
+func TestSentryErrorHandler_IgnoresBelowThreshold(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	logger, buf := newTestLogger(t, rec, Options{})
+
+	logger.Info("postgres pool ready", "max_conns", 10)
+	logger.Warn("sentry init failed", "err", "bad dsn")
+
+	assert.Empty(t, rec.all(), "INFO and WARN must not spend Sentry quota")
+	assert.Contains(t, buf.String(), "postgres pool ready",
+		"pass-through must be unconditional")
+	assert.Contains(t, buf.String(), "sentry init failed")
+}
+
+func TestSentryErrorHandler_HonoursCustomLevel(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	logger, _ := newTestLogger(t, rec, Options{Level: slog.LevelWarn})
+
+	logger.Warn("river queue stop", "err", "context deadline exceeded")
+
+	events := rec.all()
+	require.Len(t, events, 1)
+	assert.Equal(t, sentry.LevelWarning, events[0].Level,
+		"a forwarded WARN must not be reported as an error")
+}
+
+// ---------------------------------------------------------------------------
+// Pass-through fidelity
+// ---------------------------------------------------------------------------
+
+// TestSentryErrorHandler_PassThroughIsByteIdentical pins the property that
+// makes this handler safe to wrap the production logger with: the JSON line
+// written to stdout is exactly what the bare handler would have written.
+func TestSentryErrorHandler_PassThroughIsByteIdentical(t *testing.T) {
+	t.Parallel()
+
+	var wrapped, bare bytes.Buffer
+	opts := &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+		// Strip the timestamp so the two runs are comparable.
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	}
+	wrappedLogger := slog.New(NewSentryErrorHandler(
+		slog.NewJSONHandler(&wrapped, opts), Options{Capturer: &recorder{}}))
+	bareLogger := slog.New(slog.NewJSONHandler(&bare, opts))
+
+	for _, l := range []*slog.Logger{wrappedLogger, bareLogger} {
+		l.With("service", "go-api").WithGroup("queue").
+			Error("river queue boot failed", "err", "queue not found", "attempt", 2)
+	}
+
+	assert.Equal(t, bare.String(), wrapped.String(),
+		"wrapping must not change a single byte of the container log")
+}
+
+// ---------------------------------------------------------------------------
+// Attributes, With, and groups
+// ---------------------------------------------------------------------------
+
+func TestSentryErrorHandler_CarriesWithAttrsAndGroups(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	logger, _ := newTestLogger(t, rec, Options{})
+
+	logger.With("service", "go-api").
+		WithGroup("queue").
+		With("name", "ratings").
+		Error("sweep failed", "err", "boom")
+
+	events := rec.all()
+	require.Len(t, events, 1)
+	fields := slogFields(t, events[0])
+	assert.Equal(t, "go-api", fields["service"], "ungrouped With attr")
+	assert.Equal(t, "ratings", fields["queue.name"], "With attr inside a group")
+	assert.Equal(t, "boom", fields["queue.err"], "record attr inside a group")
+}
+
+// TestSentryErrorHandler_WithDoesNotMutateParent guards the slog.Handler
+// contract that WithAttrs/WithGroup return a new handler: a shared backing
+// array would leak one request's fields onto another's events.
+func TestSentryErrorHandler_WithDoesNotMutateParent(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	var buf bytes.Buffer
+	root := NewSentryErrorHandler(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}),
+		Options{Capturer: rec})
+
+	// Three attrs, added one at a time, is the shape that matters: append's
+	// growth leaves len=3 cap=4, so a handler that does NOT copy its slice
+	// hands both children the same backing array with one free slot — and the
+	// second child's attr overwrites the first's in place.  A parent with one
+	// attr cannot catch it: len==cap forces a reallocation and the bug hides.
+	parent := slog.New(root).With("shared", 1).With("shared2", 2).With("shared3", 3)
+	childA := parent.With("only_a", "a")
+	childB := parent.With("only_b", "b")
+
+	childA.Error("a")
+	childB.Error("b")
+	parent.Error("p")
+
+	events := rec.all()
+	require.Len(t, events, 3)
+
+	assert.Equal(t, "a", slogFields(t, events[0])["only_a"])
+	assert.NotContains(t, slogFields(t, events[0]), "only_b")
+
+	assert.Equal(t, "b", slogFields(t, events[1])["only_b"])
+	assert.NotContains(t, slogFields(t, events[1]), "only_a",
+		"sibling loggers must not see each other's attributes")
+
+	assert.NotContains(t, slogFields(t, events[2]), "only_a",
+		"the parent must not inherit a child's attributes")
+	assert.NotContains(t, slogFields(t, events[2]), "only_b")
+	assert.EqualValues(t, 1, slogFields(t, events[2])["shared"])
+	assert.EqualValues(t, 3, slogFields(t, events[2])["shared3"])
+}
+
+// TestSentryErrorHandler_ResolvesLazyValues asserts LogValuer attributes are
+// resolved before they are handed to Sentry — an unresolved slog.Value
+// serialises as an opaque struct in the payload.
+func TestSentryErrorHandler_ResolvesLazyValues(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	logger, _ := newTestLogger(t, rec, Options{})
+
+	// Both paths: an attr attached via With (stored on the handler) and one
+	// passed on the call (read off the record).  They resolve in different
+	// loops, so covering only one lets the other rot.
+	logger.With("owner", lazyUser{ID: 7}).Error("token refused", "user", lazyUser{ID: 42})
+
+	events := rec.all()
+	require.Len(t, events, 1)
+	assert.Equal(t, "user-42", slogFields(t, events[0])["user"], "record attr")
+	assert.Equal(t, "user-7", slogFields(t, events[0])["owner"], "With attr")
+
+	// And the value must survive JSON encoding, which is what the SDK does
+	// to it on the way out.
+	raw, err := json.Marshal(events[0].Contexts)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), "user-42")
+}
+
+type lazyUser struct{ ID int }
+
+func (u lazyUser) LogValue() slog.Value {
+	return slog.StringValue("user-" + strings.TrimSpace(itoa(u.ID)))
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+
+// TestSentryErrorHandler_RateLimitsAndReportsDrops covers the failure mode the
+// plan flagged for this task: a hot error loop burning the Sentry quota.  The
+// suppression must not itself be silent.
+func TestSentryErrorHandler_RateLimitsAndReportsDrops(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	var buf bytes.Buffer
+	h := NewSentryErrorHandler(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}),
+		Options{Capturer: rec, RateBurst: 2, RateWindow: time.Minute})
+
+	base := time.Date(2026, 9, 8, 22, 0, 0, 0, time.UTC)
+	emit := func(at time.Time, msg string) {
+		r := slog.NewRecord(at, slog.LevelError, msg, 0)
+		require.NoError(t, h.Handle(context.Background(), r))
+	}
+
+	emit(base, "one")
+	emit(base.Add(time.Second), "two")
+	emit(base.Add(2*time.Second), "three")
+	emit(base.Add(3*time.Second), "four")
+
+	require.Len(t, rec.all(), 2, "burst of 2 must cap the window at 2 events")
+	assert.Equal(t, 4, strings.Count(buf.String(), "level"),
+		"every record must still reach the container log")
+
+	// Next window: the first event through carries the suppressed count.
+	emit(base.Add(2*time.Minute), "five")
+	events := rec.all()
+	require.Len(t, events, 3)
+	assert.EqualValues(t, 2, slogFields(t, events[2])[droppedAttrKey],
+		"a suppressed storm must say how much it suppressed")
+
+	// And the counter resets, so the next event does not re-report them.
+	emit(base.Add(2*time.Minute).Add(time.Second), "six")
+	events = rec.all()
+	require.Len(t, events, 4)
+	assert.NotContains(t, slogFields(t, events[3]), droppedAttrKey)
+}
+
+func TestSentryErrorHandler_RateLimitCanBeDisabled(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	logger, _ := newTestLogger(t, rec, Options{RateBurst: -1})
+
+	for i := 0; i < DefaultRateBurst+5; i++ {
+		logger.Error("boom")
+	}
+	assert.Len(t, rec.all(), DefaultRateBurst+5,
+		"a negative burst must disable the limiter outright")
+}
+
+// TestSentryErrorHandler_DefaultBurstApplies pins that the zero Options value
+// is the production configuration rather than an unlimited one.
+func TestSentryErrorHandler_DefaultBurstApplies(t *testing.T) {
+	t.Parallel()
+
+	rec := &recorder{}
+	logger, _ := newTestLogger(t, rec, Options{})
+
+	for i := 0; i < DefaultRateBurst+5; i++ {
+		logger.Error("boom")
+	}
+	assert.Len(t, rec.all(), DefaultRateBurst,
+		"the zero value must carry the default cap")
+}
+
+// ---------------------------------------------------------------------------
+// Degradation
+// ---------------------------------------------------------------------------
+
+// TestSentryErrorHandler_NoHubDoesNotPanic covers the deployment where
+// SENTRY_DSN is unset: the process hub has no client and CaptureEvent is a
+// no-op.  Logging must be unaffected.
+func TestSentryErrorHandler_NoHubDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewSentryErrorHandler(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}),
+		Options{})) // no Capturer: resolves the real (uninitialised) hub
+
+	assert.NotPanics(t, func() {
+		logger.Error("config load failed", "err", "missing DATABASE_URL")
+	})
+	assert.Contains(t, buf.String(), "config load failed")
+}
+
+// TestSentryErrorHandler_PrefersHubFromContext pins that an error logged
+// inside an HTTP handler is captured on the request-scoped hub, so it keeps
+// the request tags the Sentry middleware attached.
+func TestSentryErrorHandler_PrefersHubFromContext(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewSentryErrorHandler(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}),
+		Options{}))
+
+	transport := &captureTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:       "https://key@example.invalid/1",
+		Transport: transport,
+	})
+	require.NoError(t, err)
+	hub := sentry.NewHub(client, sentry.NewScope())
+	hub.Scope().SetTag("route", "/api/admin/queues")
+
+	logger.ErrorContext(sentry.SetHubOnContext(context.Background(), hub),
+		"admin: queue.Status failed", "err", "queue not found")
+
+	events := transport.all()
+	require.Len(t, events, 1, "the context hub must receive the event")
+	assert.Equal(t, "/api/admin/queues", events[0].Tags["route"],
+		"the request-scoped hub's tags are the reason to prefer it")
+}
+
+// captureTransport records events instead of sending them.
+type captureTransport struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (t *captureTransport) Configure(sentry.ClientOptions) {}
+func (t *captureTransport) Flush(time.Duration) bool       { return true }
+func (t *captureTransport) FlushWithContext(context.Context) bool {
+	return true
+}
+func (t *captureTransport) Close() {}
+func (t *captureTransport) SendEvent(event *sentry.Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, event)
+}
+
+func (t *captureTransport) all() []*sentry.Event {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append(([]*sentry.Event)(nil), t.events...)
+}
+
+// TestNewSentryErrorHandler_RejectsNilInner pins the loud failure: a nil inner
+// handler would produce a logger that drops every line.
+func TestNewSentryErrorHandler_RejectsNilInner(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() { NewSentryErrorHandler(nil, Options{}) })
+}
+
+// TestSentryErrorHandler_EnabledFollowsInner pins that the wrapper does not
+// widen the level filter: a record the base handler drops must not exist in
+// Sentry alone, where nobody could correlate it against the container log.
+func TestSentryErrorHandler_EnabledFollowsInner(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	h := NewSentryErrorHandler(
+		slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError + 1}),
+		Options{Capturer: &recorder{}})
+
+	assert.False(t, h.Enabled(context.Background(), slog.LevelError),
+		"the wrapper must not re-enable a level the base handler filters out")
+}

--- a/go-api/internal/queue/bangumi_episodes.go
+++ b/go-api/internal/queue/bangumi_episodes.go
@@ -741,36 +741,6 @@ func episodesBgmCount(titles []epTitle) int32 {
 // Wiring
 // ---------------------------------------------------------------------------
 
-// PeriodicEpisodesBgmScanJob returns the river PeriodicJob that fires the sweep
-// every hour.  Pass it to queue.Config.PeriodicJobs.
-//
-// InsertOpts is nil in the tuple: EpisodesBgmScanArgs.InsertOpts() already pins
-// the job to EpisodesBgmQueueName, and that is all it needs.
-//
-// Do NOT add UniqueOpts here without setting ByState explicitly.  River's
-// default unique states include `completed`, and completed jobs stay in
-// river_job for 24h, so a naive UniqueOpts would block the hourly cadence for a
-// full day after every successful scan.  A stacked scan is tolerable by
-// comparison: it is one indexed SELECT whose rows are then deduplicated by
-// UniqueOpts{ByArgs} on the per-row jobs.
-//
-// RunOnStart is TRUE.  River's OSS scheduler does not persist periodic
-// schedules — it recomputes the next run as now+period on every Start — so with
-// RunOnStart=false a deploy would push the next sweep a full hour out, and a
-// day with several deploys could produce no sweep at all.  That is the failure
-// mode PeriodicDescriptionBackfillScanJob's comment records; the cost of
-// avoiding it is one extra batch per boot, which UniqueOpts{ByArgs} on
-// EpisodesBgmArgs collapses against anything still queued.
-func PeriodicEpisodesBgmScanJob() *river.PeriodicJob {
-	return river.NewPeriodicJob(
-		river.PeriodicInterval(episodesBgmScanInterval),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return EpisodesBgmScanArgs{}, nil
-		},
-		&river.PeriodicJobOpts{RunOnStart: true},
-	)
-}
-
 // EpisodesBgmDB is the union of the two DB surfaces the pair of workers needs.
 // dbgen.Queries satisfies it.
 type EpisodesBgmDB interface {

--- a/go-api/internal/queue/bangumi_episodes_test.go
+++ b/go-api/internal/queue/bangumi_episodes_test.go
@@ -31,7 +31,6 @@ package queue
 import (
 	"context"
 	"errors"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -1062,37 +1061,6 @@ func TestEpisodesBgmScanIntervalIsHourly(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Periodic job
 // ---------------------------------------------------------------------------
-
-// Prevents: RunOnStart quietly reverting to river's default.
-//
-// River's OSS scheduler does not persist periodic schedules — it recomputes the
-// next run as now+period on every Start — so with RunOnStart=false every deploy
-// pushes the sweep a full hour out, and a day with several deploys can produce
-// no sweep at all.
-//
-// Read via reflection because river keeps PeriodicJob's fields unexported and
-// exposes no accessor.  That couples this test to river's internals on purpose:
-// river is version-pinned, so an upgrade that reshapes PeriodicJob should stop
-// and make somebody re-confirm this rather than silently carry an unverified
-// assumption forward.
-func TestPeriodicEpisodesBgmScanJobRunsOnStart(t *testing.T) {
-	t.Parallel()
-
-	job := PeriodicEpisodesBgmScanJob()
-	require.NotNil(t, job)
-
-	optsField := reflect.ValueOf(job).Elem().FieldByName("opts")
-	require.True(t, optsField.IsValid(),
-		"river.PeriodicJob no longer has an `opts` field — re-verify the sweep still runs at boot")
-	require.False(t, optsField.IsNil(),
-		"nil opts means RunOnStart=false, which lets a redeploying service never sweep")
-
-	runOnStart := optsField.Elem().FieldByName("RunOnStart")
-	require.True(t, runOnStart.IsValid(),
-		"river.PeriodicJobOpts no longer has RunOnStart — re-verify what the sweep does at boot")
-	assert.True(t, runOnStart.Bool(),
-		"river recomputes the next run on every Start, so RunOnStart=false can mean the sweep never fires")
-}
 
 // Both halves have to be registered together.  A scan with no per-row worker
 // enqueues jobs nothing can run; a per-row worker with no scan is never fed.

--- a/go-api/internal/queue/bgm_bind_idmap.go
+++ b/go-api/internal/queue/bgm_bind_idmap.go
@@ -209,24 +209,6 @@ func bindIdMapSweepEnabled() bool {
 	return err == nil && on
 }
 
-// PeriodicBindIdMapJob returns the river PeriodicJob for the sweep.
-//
-// RunOnStart is true because river's open-source pilot does not persist
-// periodic schedules — nextRunAt is recomputed at every Start — so a service
-// that deploys more often than the interval would otherwise never sweep.
-// Firing on boot is safe here for the same reason the sweep needs no attempt
-// bookkeeping: a pass that has nothing left to bind is one query returning
-// zero rows.
-func PeriodicBindIdMapJob() *river.PeriodicJob {
-	return river.NewPeriodicJob(
-		river.PeriodicInterval(bindIdMapInterval),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return BindIdMapArgs{}, nil
-		},
-		&river.PeriodicJobOpts{RunOnStart: true},
-	)
-}
-
 // AddBindIdMapWorker registers the sweep on an existing bundle.
 func AddBindIdMapWorker(w *river.Workers, pool *pgxpool.Pool, q *dbgen.Queries, enq bindIdMapV2Enqueuer) {
 	river.AddWorker(w, NewBindIdMapWorker(pool, q, enq))

--- a/go-api/internal/queue/control.go
+++ b/go-api/internal/queue/control.go
@@ -8,28 +8,32 @@
 // PausedAt timestamp in river_queue so the state survives a process
 // restart, which the Express in-memory flag never did.
 //
-// QUEUE NAMING:  the BangumiV3QueueName constant declares the queue
-// that V3 enrichment jobs should ride on ("bangumi_v3").  At the time
-// of this writing all four worker kinds (V1, V2, V3, warm_season)
-// route to river.QueueDefault — see worker.go's default Queues map.
-// The next wiring phase (P2.3.2 admin handler) will add InsertOpts to
-// BangumiV3Args + register a "bangumi_v3" queue config so this pause
-// surface actually pauses V3 jobs in isolation.  Until then, calling
-// PauseV3 against the default boot config returns river's
-// "queue not found" error (river.ErrNotFound) — the right failure
-// mode (loud, observable) rather than silently pausing "default"
-// (which would freeze V1+V2+warm_season too).
+// QUEUE NAMING:  each *QueueName constant below declares the river queue
+// one workload rides.  That wiring is live — the Args types carry the
+// queue in their InsertOpts and registry_default.go configures a worker
+// pool for each — so pausing one of these pauses that workload and
+// nothing else.
 //
-// Callers that want to pause all queues at once (the "*" wildcard
-// supported by river.QueuePause) can do so via the underlying client
-// directly — this package intentionally keeps the surface targeted
-// to V3 so the admin endpoint can't accidentally freeze the whole
-// queue subsystem.
+// SCOPE: this surface used to be V3-only, with this note explaining why:
+//
+//	this package intentionally keeps the surface targeted to V3 so the
+//	admin endpoint can't accidentally freeze the whole queue subsystem
+//
+// The constraint stands; only its implementation has moved.  PauseQueue
+// takes any name, validates it against the registry, and refuses
+// river.QueueDefault — which is the queue that constraint was really
+// about, because default carries V1, V2, warm_season and orphan_scan at
+// once.  river's "*" wildcard is refused by the same check.
+//
+// Widening the surface is what makes the other eight queues reachable at
+// three in the morning without a deploy, which is the whole reason they
+// were given dedicated queues in the first place.
 
 package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -38,11 +42,10 @@ import (
 	"github.com/riverqueue/river/rivertype"
 )
 
-// BangumiV3QueueName is the river queue name V3 enrichment jobs route
-// to.  See the package doc for the wiring-phase TODO; today V3 still
-// rides on river.QueueDefault — this constant declares the target
-// queue so the admin pause/resume API has a stable contract that the
-// wiring phase can flip on without touching call sites.
+// BangumiV3QueueName is the river queue V3 enrichment jobs route to.
+// BangumiV3Args.InsertOpts pins them to it and the registry configures its
+// worker pool, so pausing it isolates heal-CN from V1/V2 and seasonal
+// warming.
 const BangumiV3QueueName = "bangumi_v3"
 
 // DescriptionBackfillQueueName isolates the Chinese-description sweep from
@@ -128,7 +131,20 @@ type Stats struct {
 	// V3Paused is true when the BangumiV3 queue (BangumiV3QueueName)
 	// has a non-nil PausedAt timestamp in river_queue.  Survives
 	// process restart because river persists pause state.
+	//
+	// Kept as its own field, spelled the way Express spelled it, because
+	// the admin frontend already reads it.  It is the same value as
+	// Paused[BangumiV3QueueName] when both are populated.
 	V3Paused bool `json:"v3Paused"`
+
+	// Paused reports the flag for every pausable queue, keyed by name.
+	//
+	// A queue river has no row for is ABSENT rather than false.  river
+	// creates river_queue rows when a producer starts, so a missing entry
+	// means "this process has not started that queue yet" — which is a
+	// different thing from "running", and collapsing the two would put a
+	// confident `false` next to a queue nobody is draining.
+	Paused map[string]bool `json:"paused,omitempty"`
 }
 
 // QueueController is the small subset of *river.Client[pgx.Tx]
@@ -152,6 +168,107 @@ type QueueController interface {
 // upgrade path (e.g. QueuePauseOpts → QueuePauseParams renames).
 var _ QueueController = (*river.Client[pgx.Tx])(nil)
 
+// ErrQueueNotPausable is returned for a queue name the admin surface must
+// not act on: one the registry does not declare, and river.QueueDefault.
+//
+// A sentinel rather than a formatted string because the HTTP layer has to
+// tell it apart from a river failure — this one is a 400 (the operator asked
+// for something that does not exist) and everything else is a 500.
+var ErrQueueNotPausable = errors.New("queue is not pausable")
+
+// checkPausable validates a queue name against the registry.
+//
+// Two things are refused and only one of them is a typo.  An unknown name is
+// the operator's mistake.  river.QueueDefault is OURS to refuse: it carries
+// V1, V2, warm_season and orphan_scan, so pausing it freezes the enrichment a
+// page load is waiting on, and river's "*" wildcard would freeze everything.
+// Neither is something an admin endpoint should be able to reach.
+func checkPausable(name string) error {
+	if Default().Pausable(name) {
+		return nil
+	}
+	if name == river.QueueDefault {
+		return fmt.Errorf("%w: %q carries V1, V2, warm_season and orphan_scan at once", ErrQueueNotPausable, name)
+	}
+	return fmt.Errorf("%w: %q is not a declared queue", ErrQueueNotPausable, name)
+}
+
+// PausableQueues returns the queue names PauseQueue will accept.
+func PausableQueues() []string { return Default().PausableNames() }
+
+// PauseQueue pauses one named queue.
+//
+// Idempotent: river treats a second pause as a refresh of PausedAt, and the
+// state is persisted in river_queue so it survives a restart — which the
+// Express in-memory flag never did.
+func PauseQueue(ctx context.Context, qc QueueController, name string) error {
+	if err := checkPausable(name); err != nil {
+		return err
+	}
+	slog.InfoContext(ctx, "queue: pause", "queue", name)
+	if err := qc.QueuePause(ctx, name, nil); err != nil {
+		return fmt.Errorf("queue.PauseQueue (%s): %w", name, err)
+	}
+	return nil
+}
+
+// ResumeQueue resumes one named queue.  Idempotent: river clears PausedAt
+// unconditionally.
+func ResumeQueue(ctx context.Context, qc QueueController, name string) error {
+	if err := checkPausable(name); err != nil {
+		return err
+	}
+	slog.InfoContext(ctx, "queue: resume", "queue", name)
+	if err := qc.QueueResume(ctx, name, nil); err != nil {
+		return fmt.Errorf("queue.ResumeQueue (%s): %w", name, err)
+	}
+	return nil
+}
+
+// QueuePaused reports whether one named queue is paused.
+//
+// Being able to stop a queue without being able to see whether it stopped is
+// half a switch, and the half that is missing is the one an operator needs at
+// three in the morning.
+func QueuePaused(ctx context.Context, qc QueueController, name string) (bool, error) {
+	if err := checkPausable(name); err != nil {
+		return false, err
+	}
+	q, err := qc.QueueGet(ctx, name)
+	if err != nil {
+		return false, fmt.Errorf("queue.QueuePaused (%s): %w", name, err)
+	}
+	return q.PausedAt != nil, nil
+}
+
+// StatusAll reports the pause flag for every pausable queue.
+//
+// A queue river has no row for is omitted rather than reported false: river
+// creates river_queue rows when a producer starts, so its absence means "not
+// started here", which is not the same claim as "running".  Any other error
+// is returned, because a status surface that hides failures is the shape this
+// whole change exists to remove.
+func StatusAll(ctx context.Context, qc QueueController) (Stats, error) {
+	names := PausableQueues()
+	out := Stats{Paused: make(map[string]bool, len(names))}
+
+	for _, name := range names {
+		q, err := qc.QueueGet(ctx, name)
+		if errors.Is(err, river.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return Stats{}, fmt.Errorf("queue.StatusAll (%s): %w", name, err)
+		}
+		paused := q.PausedAt != nil
+		out.Paused[name] = paused
+		if name == BangumiV3QueueName {
+			out.V3Paused = paused
+		}
+	}
+	return out, nil
+}
+
 // PauseV3 pauses the V3 enrichment queue via river.QueuePause.
 // No-op when the queue is already paused (river treats QueuePause as
 // idempotent — a second pause just refreshes PausedAt).
@@ -160,11 +277,7 @@ var _ QueueController = (*river.Client[pgx.Tx])(nil)
 // the queue does not exist (river.ErrNotFound) — see package doc for
 // the wiring-phase caveat.
 func PauseV3(ctx context.Context, qc QueueController) error {
-	slog.InfoContext(ctx, "queue: pauseV3", "queue", BangumiV3QueueName)
-	if err := qc.QueuePause(ctx, BangumiV3QueueName, nil); err != nil {
-		return fmt.Errorf("queue.PauseV3 (%s): %w", BangumiV3QueueName, err)
-	}
-	return nil
+	return PauseQueue(ctx, qc, BangumiV3QueueName)
 }
 
 // ResumeV3 resumes the V3 enrichment queue via river.QueueResume.
@@ -174,11 +287,7 @@ func PauseV3(ctx context.Context, qc QueueController) error {
 // Returns the underlying river error wrapped with the queue name
 // when the queue does not exist (river.ErrNotFound).
 func ResumeV3(ctx context.Context, qc QueueController) error {
-	slog.InfoContext(ctx, "queue: resumeV3", "queue", BangumiV3QueueName)
-	if err := qc.QueueResume(ctx, BangumiV3QueueName, nil); err != nil {
-		return fmt.Errorf("queue.ResumeV3 (%s): %w", BangumiV3QueueName, err)
-	}
-	return nil
+	return ResumeQueue(ctx, qc, BangumiV3QueueName)
 }
 
 // Status returns the current pause flag for the V3 queue.  Reads via
@@ -192,12 +301,11 @@ func ResumeV3(ctx context.Context, qc QueueController) error {
 // at all in the river config, so propagating that error is
 // intentional.
 func Status(ctx context.Context, qc QueueController) (Stats, error) {
-	slog.InfoContext(ctx, "queue: status", "queue", BangumiV3QueueName)
-	q, err := qc.QueueGet(ctx, BangumiV3QueueName)
+	paused, err := QueuePaused(ctx, qc, BangumiV3QueueName)
 	if err != nil {
-		return Stats{}, fmt.Errorf("queue.Status (%s): %w", BangumiV3QueueName, err)
+		return Stats{}, err
 	}
-	return Stats{V3Paused: q.PausedAt != nil}, nil
+	return Stats{V3Paused: paused}, nil
 }
 
 // RatingsQueueName isolates the two rating-refresh sweeps.

--- a/go-api/internal/queue/control.go
+++ b/go-api/internal/queue/control.go
@@ -215,7 +215,12 @@ func Status(ctx context.Context, qc QueueController) (Stats, error) {
 //
 // Both kinds share one queue rather than taking one each.  They are the
 // same feature and are turned off for the same reasons, so a single
-// pause is the control an operator actually wants; the queue is
-// configured with two worker slots so that pausing is the only thing
-// that makes them wait for each other.
+// pause is the control an operator actually wants.
+//
+// The queue is configured with ONE worker slot, so the two sweeps do
+// wait for each other: about five minutes of every hour, which is the
+// price of making two passes of the same kind unable to overlap.  An
+// earlier version of this sentence said two slots and was wrong on
+// HEAD -- see the MaxWorkers block in cmd/server/main.go, which is the
+// authority.
 const RatingsQueueName = "ratings"

--- a/go-api/internal/queue/control_test.go
+++ b/go-api/internal/queue/control_test.go
@@ -86,6 +86,20 @@ func (f *fakeQueueController) snapshotResumeCalls() []string {
 	return out
 }
 
+// snapshotAllCalls reports every call that reached the controller, whichever
+// method it went through.  The validation tests below assert on this rather
+// than on one method's list: a refused name must not reach river AT ALL, and
+// checking only pauseCalls would miss a refusal that leaked into QueueGet.
+func (f *fakeQueueController) snapshotAllCalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.pauseCalls)+len(f.resumeCalls)+len(f.getCalls))
+	out = append(out, f.pauseCalls...)
+	out = append(out, f.resumeCalls...)
+	out = append(out, f.getCalls...)
+	return out
+}
+
 func (f *fakeQueueController) snapshotGetCalls() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -135,7 +149,11 @@ func TestPauseV3_WrapsError(t *testing.T) {
 	err := PauseV3(context.Background(), f)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, sentinel), "underlying error must remain unwrappable")
-	assert.Contains(t, err.Error(), "queue.PauseV3", "wrap must include the helper name")
+	// The wrap names PauseQueue, not PauseV3: PauseV3 is now a thin alias
+	// for the general form, and the general form is where the wrapping
+	// lives.  What the message has to carry is the queue, which is the part
+	// an operator acts on.
+	assert.Contains(t, err.Error(), "queue.PauseQueue", "wrap must name the operation")
 	assert.Contains(t, err.Error(), BangumiV3QueueName, "wrap must include the queue name")
 }
 
@@ -165,7 +183,7 @@ func TestResumeV3_WrapsError(t *testing.T) {
 	err := ResumeV3(context.Background(), f)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, sentinel))
-	assert.Contains(t, err.Error(), "queue.ResumeV3")
+	assert.Contains(t, err.Error(), "queue.ResumeQueue", "wrap must name the operation")
 	assert.Contains(t, err.Error(), BangumiV3QueueName)
 }
 
@@ -225,7 +243,7 @@ func TestStatus_WrapsError(t *testing.T) {
 	got, err := Status(context.Background(), f)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, sentinel))
-	assert.Contains(t, err.Error(), "queue.Status")
+	assert.Contains(t, err.Error(), "queue.QueuePaused", "wrap must name the operation")
 	assert.Contains(t, err.Error(), BangumiV3QueueName)
 	assert.Equal(t, Stats{}, got, "error path must return zero Stats")
 }
@@ -282,3 +300,197 @@ func TestPauseResumeStatus_RoundTrip(t *testing.T) {
 // Compile-time assertion for the real *river.Client[pgx.Tx] living
 // in control.go covers the interface satisfaction.  No runtime test
 // here — the package-level guard catches drift at build time.
+
+// ---------------------------------------------------------------------------
+// The generalised pause surface
+// ---------------------------------------------------------------------------
+
+// TestPauseQueue_RefusesDefault is the constraint control.go's package doc has
+// carried since the surface was V3-only: the admin endpoint must not be able
+// to freeze the whole queue subsystem.
+//
+// default is not one workload, it is four — V1, V2, warm_season and
+// orphan_scan — so pausing it stops the enrichment a page load is waiting on.
+// Widening pause to the other eight queues is only safe while this holds.
+func TestPauseQueue_RefusesDefault(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeQueueController{}
+	err := PauseQueue(context.Background(), f, river.QueueDefault)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrQueueNotPausable)
+	assert.Contains(t, err.Error(), "V1, V2, warm_season and orphan_scan",
+		"the refusal must say what pausing default would have stopped")
+	assert.Empty(t, f.snapshotAllCalls(), "a refused pause must not reach river")
+}
+
+// TestPauseQueue_RefusesWildcard covers river's all-queues form, which would
+// freeze everything default would and then some.
+func TestPauseQueue_RefusesWildcard(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeQueueController{}
+	err := PauseQueue(context.Background(), f, "*")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrQueueNotPausable)
+	assert.Empty(t, f.snapshotAllCalls())
+}
+
+// TestPauseQueue_RefusesUnknownName covers the operator's typo.  Passing it
+// through would hand river a name it has never heard of, and river's
+// QueuePause is happy to record a pause for a queue that does not exist —
+// so the operator would get a success for a queue that keeps running.
+func TestPauseQueue_RefusesUnknownName(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"", "ratings ", "rating", "bangumi_v4"} {
+		f := &fakeQueueController{}
+		err := PauseQueue(context.Background(), f, name)
+
+		require.Error(t, err, "name %q", name)
+		assert.ErrorIs(t, err, ErrQueueNotPausable)
+		assert.Empty(t, f.snapshotAllCalls(), "name %q must not reach river", name)
+	}
+}
+
+// TestPauseQueue_AcceptsEveryDedicatedQueue asserts the whole point: the eight
+// queues that were given their own pool precisely so they could be stopped
+// independently are all reachable.
+func TestPauseQueue_AcceptsEveryDedicatedQueue(t *testing.T) {
+	t.Parallel()
+
+	names := PausableQueues()
+	require.Len(t, names, 8)
+
+	for _, name := range names {
+		f := &fakeQueueController{}
+		require.NoError(t, PauseQueue(context.Background(), f, name), "pause %q", name)
+		assert.Equal(t, []string{name}, f.snapshotAllCalls())
+
+		f2 := &fakeQueueController{}
+		require.NoError(t, ResumeQueue(context.Background(), f2, name), "resume %q", name)
+		assert.Equal(t, []string{name}, f2.snapshotAllCalls())
+	}
+}
+
+func TestResumeQueue_RefusesDefault(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeQueueController{}
+	err := ResumeQueue(context.Background(), f, river.QueueDefault)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrQueueNotPausable)
+	assert.Empty(t, f.snapshotAllCalls())
+}
+
+func TestQueuePaused_RefusesDefault(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeQueueController{}
+	_, err := QueuePaused(context.Background(), f, river.QueueDefault)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrQueueNotPausable)
+	assert.Empty(t, f.snapshotAllCalls())
+}
+
+// TestQueuePaused_ReadsPausedAt is the other half of the switch: being able to
+// stop a queue without being able to see whether it stopped is half a control.
+func TestQueuePaused_ReadsPausedAt(t *testing.T) {
+	t.Parallel()
+
+	at := time.Now()
+	for _, tc := range []struct {
+		name     string
+		pausedAt *time.Time
+		want     bool
+	}{
+		{"paused", &at, true},
+		{"running", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := &fakeQueueController{
+				getFn: func(_ context.Context, name string) (*rivertype.Queue, error) {
+					return &rivertype.Queue{Name: name, PausedAt: tc.pausedAt}, nil
+				},
+			}
+			got, err := QueuePaused(context.Background(), f, RatingsQueueName)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestStatusAll_ReportsEveryPausableQueue pins the generalised read.
+func TestStatusAll_ReportsEveryPausableQueue(t *testing.T) {
+	t.Parallel()
+
+	at := time.Now()
+	f := &fakeQueueController{
+		getFn: func(_ context.Context, name string) (*rivertype.Queue, error) {
+			q := &rivertype.Queue{Name: name}
+			if name == BangumiV3QueueName || name == RatingsQueueName {
+				q.PausedAt = &at
+			}
+			return q, nil
+		},
+	}
+
+	got, err := StatusAll(context.Background(), f)
+	require.NoError(t, err)
+
+	assert.Len(t, got.Paused, 8, "every pausable queue must be reported")
+	assert.True(t, got.Paused[BangumiV3QueueName])
+	assert.True(t, got.Paused[RatingsQueueName])
+	assert.False(t, got.Paused[HantBackfillQueueName])
+	assert.NotContains(t, got.Paused, river.QueueDefault,
+		"default is not pausable, so it has no flag to report")
+	assert.True(t, got.V3Paused,
+		"the legacy field must stay in step with the map the frontend has not moved to yet")
+}
+
+// TestStatusAll_OmitsQueuesRiverHasNoRowFor is the distinction that keeps the
+// status honest.  river creates a river_queue row when a producer starts, so a
+// missing one means "not started here" — reporting it as false would put a
+// confident "running" next to a queue nobody is draining.
+func TestStatusAll_OmitsQueuesRiverHasNoRowFor(t *testing.T) {
+	t.Parallel()
+
+	f := &fakeQueueController{
+		getFn: func(_ context.Context, name string) (*rivertype.Queue, error) {
+			if name == HantBackfillQueueName {
+				return nil, river.ErrNotFound
+			}
+			return &rivertype.Queue{Name: name}, nil
+		},
+	}
+
+	got, err := StatusAll(context.Background(), f)
+	require.NoError(t, err, "a queue river has no row for is not an error")
+	assert.NotContains(t, got.Paused, HantBackfillQueueName,
+		"absent, not false — the two are different claims")
+	assert.Len(t, got.Paused, 7)
+}
+
+// TestStatusAll_PropagatesRealErrors — a status surface that hides failures is
+// the shape this whole change exists to remove.
+func TestStatusAll_PropagatesRealErrors(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("river: connection refused")
+	f := &fakeQueueController{
+		getFn: func(_ context.Context, _ string) (*rivertype.Queue, error) {
+			return nil, sentinel
+		},
+	}
+
+	got, err := StatusAll(context.Background(), f)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, Stats{}, got, "error path must return zero Stats")
+}

--- a/go-api/internal/queue/description_backfill.go
+++ b/go-api/internal/queue/description_backfill.go
@@ -357,46 +357,6 @@ func (w *DescriptionBackfillWorker) Work(ctx context.Context, job *river.Job[Des
 	return nil
 }
 
-// PeriodicDescriptionBackfillScanJob returns the river PeriodicJob that fires
-// the sweep every hour.  Pass it to queue.Config.PeriodicJobs alongside
-// PeriodicOrphanScanJob and PeriodicWarmSeasonJob.
-//
-// InsertOpts is nil in the tuple: DescriptionBackfillScanArgs.InsertOpts()
-// already pins the job to DescriptionBackfillQueueName, and that is all this
-// job needs.  Note that river's periodic enqueuer does NOT check for an
-// existing pending or running instance before inserting — it inserts every
-// time the schedule elapses, full stop — so if the backfill queue ever wedges,
-// scan jobs will stack up behind it.  That is tolerated rather than fixed: a
-// stacked scan is one indexed SELECT whose rows are then deduplicated by
-// UniqueOpts{ByArgs} on the per-row jobs, and it matches what
-// PeriodicOrphanScanJob and PeriodicWarmSeasonJob already do.
-//
-// Do NOT "fix" it by adding UniqueOpts here without setting ByState
-// explicitly: river's default unique states include `completed`, and completed
-// jobs stay in river_job for 24h, so a naive UniqueOpts would block the hourly
-// cadence for a full day after every successful scan.
-//
-// RunOnStart is TRUE, which is where this departs from PeriodicOrphanScanJob.
-// That job can leave it false because main.go calls ScanAndEnqueueOrphans
-// directly at boot, so every restart still produces one immediate scan; this
-// job has no such companion call.  River schedules a periodic job's first run a
-// full interval after Start, so with RunOnStart=false every deploy would push
-// the next sweep an hour out — and on a day with several deploys the backfill
-// could make no progress at all, which is exactly the failure mode that left
-// ~1,052 orphan rows stranded before the orphan periodic job existed.  Firing
-// on start also means a release can be verified immediately instead of an hour
-// later.  The cost is one extra batch per boot, and UniqueOpts{ByArgs} on
-// DescriptionBackfillArgs collapses it against anything still queued.
-func PeriodicDescriptionBackfillScanJob() *river.PeriodicJob {
-	return river.NewPeriodicJob(
-		river.PeriodicInterval(descriptionBackfillScanInterval),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return DescriptionBackfillScanArgs{}, nil
-		},
-		&river.PeriodicJobOpts{RunOnStart: true},
-	)
-}
-
 // Compile-time guards: both workers must satisfy river.Worker for their args.
 var (
 	_ river.Worker[DescriptionBackfillScanArgs] = (*DescriptionBackfillScanWorker)(nil)

--- a/go-api/internal/queue/description_backfill_test.go
+++ b/go-api/internal/queue/description_backfill_test.go
@@ -35,7 +35,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -1098,58 +1097,6 @@ func TestDescriptionBackfillQueueName_IsIsolated(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Periodic job
 // ---------------------------------------------------------------------------
-
-// TestPeriodicDescriptionBackfillScanJob_NonNil — a nil return would drop the
-// schedule with no runtime error at all, leaving the entire backfill dead
-// while everything looks wired.
-func TestPeriodicDescriptionBackfillScanJob_NonNil(t *testing.T) {
-	t.Parallel()
-
-	require.NotNil(t, PeriodicDescriptionBackfillScanJob(),
-		"PeriodicDescriptionBackfillScanJob must return a non-nil job")
-}
-
-// TestPeriodicDescriptionBackfillScanJob_RunsOnStart pins RunOnStart=true,
-// which is a deliberate divergence from PeriodicOrphanScanJob and the only
-// thing standing between this sweep and never running at all.
-//
-// River schedules a periodic job's first run one full interval AFTER Start.
-// The orphan job can afford RunOnStart=false because main.go also calls
-// ScanAndEnqueueOrphans directly at boot; this sweep has no such companion
-// call, so with RunOnStart=false every deploy would push the next pass an
-// hour out and a day with hourly deploys would produce zero passes — the
-// exact silent-stall shape that stranded ~1,052 orphan rows before the
-// orphan periodic job existed.
-//
-// The cost of RunOnStart=true is one extra pass per boot, and it is close to
-// free: the per-row jobs dedupe by args against anything still queued or
-// recently completed (see
-// TestDescriptionBackfillArgs_UniqueStateIncludesCompleted), so a burst of
-// deploys does not multiply upstream requests.
-//
-// Read via reflection because river keeps PeriodicJob's fields unexported and
-// exposes no accessor.  That couples this test to river's internals on
-// purpose: river is version-pinned, so an upgrade that reshapes PeriodicJob
-// should stop and make somebody re-confirm this flag rather than silently
-// carry an unverified assumption forward.
-func TestPeriodicDescriptionBackfillScanJob_RunsOnStart(t *testing.T) {
-	t.Parallel()
-
-	job := PeriodicDescriptionBackfillScanJob()
-	require.NotNil(t, job)
-
-	optsField := reflect.ValueOf(job).Elem().FieldByName("opts")
-	require.True(t, optsField.IsValid(),
-		"river.PeriodicJob no longer has an `opts` field — re-verify RunOnStart is still set on the sweep")
-	require.False(t, optsField.IsNil(),
-		"PeriodicDescriptionBackfillScanJob passed nil opts, so RunOnStart defaulted to false — the sweep would skip its first hour after every deploy")
-
-	runOnStart := optsField.Elem().FieldByName("RunOnStart")
-	require.True(t, runOnStart.IsValid(),
-		"river.PeriodicJobOpts no longer has RunOnStart — re-verify the sweep still fires at boot")
-	assert.True(t, runOnStart.Bool(),
-		"RunOnStart must stay true or a service that deploys more often than hourly never sweeps at all")
-}
 
 // ---------------------------------------------------------------------------
 // Compile-time guards

--- a/go-api/internal/queue/description_llm_backfill.go
+++ b/go-api/internal/queue/description_llm_backfill.go
@@ -396,22 +396,6 @@ func (w *DescriptionLlmWorker) markAttempted(ctx context.Context, anilistID int3
 	}
 }
 
-// PeriodicDescriptionLlmBackfillScanJob returns the hourly trigger.
-// RunOnStart=true for the same reason as the Bangumi sweep: this scan has no
-// boot-time companion call, and river schedules a periodic job's first run a
-// full interval after Start — without it, frequent deploys could starve the
-// sweep entirely.  Registered unconditionally; the disabled posture lives in
-// the scan worker, keeping the wiring identical whether or not a key is set.
-func PeriodicDescriptionLlmBackfillScanJob() *river.PeriodicJob {
-	return river.NewPeriodicJob(
-		river.PeriodicInterval(descriptionLlmScanInterval),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return DescriptionLlmBackfillScanArgs{}, nil
-		},
-		&river.PeriodicJobOpts{RunOnStart: true},
-	)
-}
-
 // AddDescriptionLlmWorkers registers both workers on an existing bundle.
 // Separate from WorkersWithBangumi so that function's signature (and its
 // existing call sites and test doubles) stay untouched; main.go calls this

--- a/go-api/internal/queue/episode_titles_releasing.go
+++ b/go-api/internal/queue/episode_titles_releasing.go
@@ -450,26 +450,6 @@ func episodeTitlesSweepEnabled() bool {
 	return err == nil && on
 }
 
-// PeriodicEpisodeTitlesJob returns the river PeriodicJob for the sweep.
-//
-// RunOnStart is true, and the attempt stamp is what makes that safe.  river's
-// open-source pilot does not persist periodic schedules — nextRunAt is
-// recomputed at every Start — so a service that deploys more often than the
-// interval would otherwise never sweep at all (the failure
-// PeriodicHantBackfillJob records for its quarterly timer).  Firing on boot
-// removes that dependency, and a redeploy ten minutes later costs nothing:
-// every row the previous pass touched carries a stamp inside the 26h window
-// and is no longer a candidate.
-func PeriodicEpisodeTitlesJob() *river.PeriodicJob {
-	return river.NewPeriodicJob(
-		river.PeriodicInterval(episodeTitlesInterval),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return EpisodeTitlesArgs{}, nil
-		},
-		&river.PeriodicJobOpts{RunOnStart: true},
-	)
-}
-
 // AddEpisodeTitlesWorker registers the sweep on an existing bundle.
 //
 // Separate from the bundle builder for the same reason AddHantBackfillWorker

--- a/go-api/internal/queue/hant_backfill.go
+++ b/go-api/internal/queue/hant_backfill.go
@@ -201,48 +201,6 @@ func (w *HantBackfillWorker) Work(ctx context.Context, _ *river.Job[HantBackfill
 	return nil
 }
 
-// PeriodicHantBackfillJob returns the river PeriodicJob that fires the
-// sweep every 90 days.  Pass it to queue.Config.PeriodicJobs alongside
-// PeriodicDescriptionBackfillScanJob and friends.
-//
-// InsertOpts is nil in the tuple: HantBackfillArgs.InsertOpts() already
-// pins the queue and the uniqueness, and that is all this job needs.
-//
-// RunOnStart is FALSE, which is where this departs from
-// PeriodicDescriptionBackfillScanJob — and the departure is the point.
-// That job fires hourly, so RunOnStart=false meant a service deploying
-// several times a day never swept at all.  This one fires quarterly, so
-// the same flag reads the other way round: RunOnStart=true would not be
-// "quarterly, plus a nudge at boot", it would be "every deploy", and a
-// 90-day interval that in practice never elapses is not an interval.
-// The cost is not hypothetical either — a pass reads every row in
-// anime_cache including description_cn and runs s2twp over ~16k
-// synopses, in front of the request path on the coldest container.
-//
-// Nor is this job left without a trigger the way the description sweep
-// was.  POST /api/admin/hant/backfill enqueues it on demand, and
-// GET /api/admin/hant/stats reports titleBehind / descBehind so a human
-// can see when it is worth pressing.  That is the same argument
-// PeriodicOrphanScanJob makes for RunOnStart=false: it can afford a
-// delayed first fire because main.go calls ScanAndEnqueueOrphans at boot.
-//
-// KNOWN LIMIT, recorded so nobody reads the interval as a promise: river's
-// open-source pilot does not persist periodic schedules
-// (riverpilot.StandardPilot.PeriodicJobGetAll returns nil), so nextRunAt
-// is recomputed as now+90d at every Start.  On a service that deploys more
-// often than quarterly the timer never elapses, and the admin button is
-// the real trigger.  The periodic fire is the backstop for a process that
-// does stay up — not the day-to-day path.
-func PeriodicHantBackfillJob() *river.PeriodicJob {
-	return river.NewPeriodicJob(
-		river.PeriodicInterval(hantBackfillInterval),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return HantBackfillArgs{}, nil
-		},
-		nil, // PeriodicJobOpts — defaults are fine; RunOnStart=false, see above
-	)
-}
-
 // AddHantBackfillWorker registers the sweep on an existing bundle.
 //
 // Separate from WorkersWithBangumi (the same shape as

--- a/go-api/internal/queue/hant_backfill_test.go
+++ b/go-api/internal/queue/hant_backfill_test.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"slices"
 	"testing"
@@ -206,48 +205,6 @@ func TestHantBackfillUniqueStatesMatchTheEndpointsRunningSet(t *testing.T) {
 // ---------------------------------------------------------------------------
 // Periodic job
 // ---------------------------------------------------------------------------
-
-// A nil return would drop the schedule with no runtime error at all,
-// leaving the sweep dead while everything looks wired.
-func TestPeriodicHantBackfillJobNonNil(t *testing.T) {
-	t.Parallel()
-
-	require.NotNil(t, PeriodicHantBackfillJob())
-}
-
-// Prevents: RunOnStart being added "for symmetry" with the two
-// description sweeps.
-//
-// Those fire hourly, so RunOnStart=false meant a service deploying several
-// times a day never swept at all.  This one fires quarterly, so the same
-// flag reads the other way round: RunOnStart=true would not be "quarterly
-// plus a nudge at boot", it would be "every deploy" — a whole-table read
-// plus s2twp over ~16k synopses in front of the request path on the
-// coldest container, several times a week.
-//
-// Read via reflection because river keeps PeriodicJob's fields unexported
-// and exposes no accessor.  That couples this test to river's internals on
-// purpose: river is version-pinned, so an upgrade that reshapes
-// PeriodicJob should stop and make somebody re-confirm this rather than
-// silently carry an unverified assumption forward.
-func TestPeriodicHantBackfillJobDoesNotRunOnStart(t *testing.T) {
-	t.Parallel()
-
-	job := PeriodicHantBackfillJob()
-	require.NotNil(t, job)
-
-	optsField := reflect.ValueOf(job).Elem().FieldByName("opts")
-	require.True(t, optsField.IsValid(),
-		"river.PeriodicJob no longer has an `opts` field — re-verify RunOnStart is still unset on the sweep")
-	if optsField.IsNil() {
-		return // nil opts is RunOnStart=false, which is what this pins
-	}
-	runOnStart := optsField.Elem().FieldByName("RunOnStart")
-	require.True(t, runOnStart.IsValid(),
-		"river.PeriodicJobOpts no longer has RunOnStart — re-verify what the sweep does at boot")
-	assert.False(t, runOnStart.Bool(),
-		"RunOnStart=true turns a 90-day sweep into an every-deploy sweep; the admin button is the on-demand trigger")
-}
 
 // The interval is the one number that decides how much drift accumulates
 // before the sweep catches it on its own.  Pinned so a units mistake

--- a/go-api/internal/queue/orphan_scan_job.go
+++ b/go-api/internal/queue/orphan_scan_job.go
@@ -89,24 +89,3 @@ func (w *OrphanScanWorker) Work(ctx context.Context, _ *river.Job[OrphanScanArgs
 	slog.InfoContext(ctx, "orphan_scan done", "enqueued", total)
 	return nil
 }
-
-// PeriodicOrphanScanJob returns a river PeriodicJob that fires every
-// 1 hour to re-enqueue V1 jobs for any bangumi_version=0 rows.  Pass
-// the result to queue.Config.PeriodicJobs alongside PeriodicWarmSeasonJob.
-//
-// InsertOpts is nil (same as PeriodicWarmSeasonJob) — river's periodic
-// scheduler inserts only when no pending/running instance of the same
-// kind exists, which is sufficient deduplication for a 1-hour sweep.
-//
-// The boot-time ScanAndEnqueueOrphans call in main.go is NOT replaced
-// by this; the two are additive.
-func PeriodicOrphanScanJob() *river.PeriodicJob {
-	return river.NewPeriodicJob(
-		river.PeriodicInterval(orphanScanPeriodicInterval),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return OrphanScanArgs{}, nil
-		},
-		nil, // PeriodicJobOpts — defaults are fine; RunOnStart=false
-		// because main.go handles the boot scan via ScanAndEnqueueOrphans.
-	)
-}

--- a/go-api/internal/queue/orphan_scan_job_test.go
+++ b/go-api/internal/queue/orphan_scan_job_test.go
@@ -39,35 +39,6 @@ func TestOrphanScanArgs_Kind(t *testing.T) {
 // PeriodicOrphanScanJob
 // ---------------------------------------------------------------------------
 
-// TestPeriodicOrphanScanJob_NonNil asserts the constructor returns a
-// non-nil *river.PeriodicJob — a nil return would silently drop the
-// periodic schedule with no runtime error.
-func TestPeriodicOrphanScanJob_NonNil(t *testing.T) {
-	t.Parallel()
-
-	job := PeriodicOrphanScanJob()
-	require.NotNil(t, job, "PeriodicOrphanScanJob must return a non-nil job")
-}
-
-// TestPeriodicOrphanScanJob_ConstructorYieldsOrphanScanArgs asserts that
-// the constructor closure embedded in the periodic job yields an
-// OrphanScanArgs (Kind = "orphan_scan") and nil InsertOpts, matching
-// PeriodicWarmSeasonJob's approach.
-func TestPeriodicOrphanScanJob_ConstructorYieldsOrphanScanArgs(t *testing.T) {
-	t.Parallel()
-
-	// Reconstruct the same constructor logic inline so we can call it
-	// directly without accessing unexported river internals.
-	constructFn := func() (river.JobArgs, *river.InsertOpts) {
-		return OrphanScanArgs{}, nil
-	}
-
-	args, opts := constructFn()
-	assert.Equal(t, "orphan_scan", args.Kind(),
-		"constructor must yield OrphanScanArgs with Kind=orphan_scan")
-	assert.Nil(t, opts, "InsertOpts must be nil (no uniqueness override needed)")
-}
-
 // TestPeriodicOrphanScanJob_Interval asserts the scheduled cadence is
 // 1 hour.  Mirrors the warm-season test pattern of verifying the
 // exported constant matches intent.

--- a/go-api/internal/queue/ratings_refresh.go
+++ b/go-api/internal/queue/ratings_refresh.go
@@ -479,34 +479,6 @@ func int32Ptr(v int) *int32 {
 // Registration
 // ---------------------------------------------------------------------------
 
-// PeriodicAnilistRatingsJob returns the river PeriodicJob for the AniList sweep.
-//
-// RunOnStart is true, and the read stamp is what makes that safe.
-// river's open-source pilot does not persist periodic schedules —
-// nextRunAt is recomputed at every Start — so a service that deploys
-// more often than the interval would never sweep at all, which is the
-// failure PeriodicHantBackfillJob records for its quarterly timer.
-// Firing on boot removes that dependency, and a redeploy ten minutes
-// later costs nothing: every row the previous pass read carries a stamp
-// and is no longer a candidate.
-func PeriodicAnilistRatingsJob() *river.PeriodicJob {
-	return river.NewPeriodicJob(
-		river.PeriodicInterval(ratingsInterval),
-		func() (river.JobArgs, *river.InsertOpts) { return AnilistRatingsArgs{}, nil },
-		&river.PeriodicJobOpts{RunOnStart: true},
-	)
-}
-
-// PeriodicBangumiRatingsJob returns the river PeriodicJob for the Bangumi
-// sweep.  See PeriodicAnilistRatingsJob for why RunOnStart is safe.
-func PeriodicBangumiRatingsJob() *river.PeriodicJob {
-	return river.NewPeriodicJob(
-		river.PeriodicInterval(ratingsInterval),
-		func() (river.JobArgs, *river.InsertOpts) { return BangumiRatingsArgs{}, nil },
-		&river.PeriodicJobOpts{RunOnStart: true},
-	)
-}
-
 // AddRatingsWorkers registers both sweeps on an existing bundle.
 //
 // Separate from the bundle builder for the reason AddEpisodeTitlesWorker

--- a/go-api/internal/queue/registry.go
+++ b/go-api/internal/queue/registry.go
@@ -1,0 +1,392 @@
+// registry.go — the single declaration of every background job this service
+// runs: which queue it rides, how many slots that queue gets and why, and
+// whether river fires it on a schedule.
+//
+// # WHY THIS EXISTS
+//
+// The same facts used to live in three places that had no way of disagreeing
+// out loud.  A queue name was declared in control.go, its worker count in a
+// 90-line map literal in cmd/server/main.go, and its schedule in a
+// Periodic<Name>Job constructor next to the worker — ten of those, differing
+// only in an interval constant and a RunOnStart bool.  Adding a sweep meant
+// touching all three and there was nothing that noticed when you touched two.
+//
+// The cost of that is not repetition, it is silence.  On 2026-09-08 a change
+// to one of four byte-identical *UniqueStates slices made
+// PeriodicJobEnqueuer fail for one kind.  river reports that as a single
+// ERROR line and keeps running, so the service started, served traffic, and
+// stopped enqueueing the sweep — for 23 minutes, with no other symptom.
+//
+// # WHAT THIS DOES AND DOES NOT OWN
+//
+// It owns the wiring: queue names, worker counts, schedules.  It does NOT own
+// InsertOpts.  river calls InsertOpts() on the Args type itself, and one of
+// those calls happens inside bgm_bind_idmap.go's bind-and-enqueue
+// transaction; turning a static method into a registry map lookup would put a
+// panic surface on that path for nothing.
+//
+// So the direction is: the registry READS InsertOpts() and checks it against
+// what the entry declares (see validate).  A queue named here that the Args
+// type does not actually route to fails at process start, in the same
+// compile-time-guard spirit as the `var _ river.JobArgs = ...` lines in
+// args.go — but it never becomes the source of the routing itself.
+package queue
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/riverqueue/river"
+)
+
+// ---------------------------------------------------------------------------
+// Concurrency
+// ---------------------------------------------------------------------------
+
+// Concurrency is a queue's worker count together with the reason it has that
+// value, and whether the value may be changed without re-deriving the reason.
+//
+// A bare int cannot carry the distinction that matters here.  Four of these
+// numbers are 1 because a second worker would break something — a shared
+// upstream token bucket that extra workers only queue up on, or a
+// check-then-update race that a single slot is what makes unreachable.  One
+// of them is 4 because DeepSeek round-trips genuinely parallelise.  Read as
+// ints they are indistinguishable, and the standing invitation to "just try
+// 2" applies equally to both.
+type Concurrency struct {
+	max    int
+	fixed  bool
+	reason string
+}
+
+// FixedConcurrency declares a worker count that is load-bearing: something
+// other than throughput depends on it, and the reason says what.
+//
+// Caveat worth stating where somebody will read it: MaxWorkers is a
+// PER-PROCESS guarantee.  It serialises workers inside this river client and
+// nothing else.  cmd/bgmbackfill and cmd/hantbackfill are separate processes
+// that write some of the same tables, so a reason phrased as an absolute
+// ("only one writer can exist") would be false for those kinds.  Phrase the
+// reason as what the slot actually buys.
+func FixedConcurrency(max int, reason string) Concurrency {
+	return Concurrency{max: max, fixed: true, reason: reason}
+}
+
+// TunableConcurrency declares a worker count that is a throughput knob: the
+// value is a starting point and raising it costs only the resource named in
+// the reason.
+func TunableConcurrency(max int, reason string) Concurrency {
+	return Concurrency{max: max, fixed: false, reason: reason}
+}
+
+// Max returns the worker count.
+func (c Concurrency) Max() int { return c.max }
+
+// Fixed reports whether the count is load-bearing rather than a knob.
+func (c Concurrency) Fixed() bool { return c.fixed }
+
+// Reason returns the prose recorded with the count.
+func (c Concurrency) Reason() string { return c.reason }
+
+// ---------------------------------------------------------------------------
+// Entries
+// ---------------------------------------------------------------------------
+
+// PeriodicSpec is the schedule half of an entry: what river's
+// PeriodicJobEnqueuer does with this kind.
+type PeriodicSpec struct {
+	// Interval is how often river re-fires the job.
+	Interval time.Duration
+
+	// RunOnStart fires the job once at client Start, in addition to the
+	// interval.
+	//
+	// True for every hourly sweep here, and that is not a preference.
+	// river's OSS scheduler recomputes nextRunAt as now+Interval at every
+	// Start, so a service that deploys more often than its interval would
+	// otherwise never run the job at all.  False belongs to the two jobs
+	// main.go enqueues by hand at boot (warm_season, orphan_scan) and to the
+	// quarterly zh-Hant sweep, where a per-deploy whole-table pass is the
+	// expensive mistake rather than the safe one.
+	RunOnStart bool
+
+	// Args builds the payload for one firing.  Nil means "the entry's own
+	// zero-value Args", which is the common case — most sweeps read their
+	// work list from the database and carry no payload at all.
+	//
+	// Non-nil exists for warm_season, whose payload is the CURRENT season:
+	// computing it at firing time rather than at boot is what stops a
+	// long-lived process from warming last quarter forever.
+	Args func() river.JobArgs
+}
+
+// Entry is one job kind: what it is, where it runs, and when.
+type Entry struct {
+	// Args is a zero-value prototype of the job's payload type.  The
+	// registry reads Kind() and InsertOpts() off it; it is never inserted.
+	Args river.JobArgs
+
+	// Queue is the river queue this kind is expected to ride.  Declared
+	// rather than derived so that validate can cross-check it against what
+	// Args.InsertOpts() actually returns — a mismatch between the two is
+	// precisely the drift this file exists to make loud.
+	Queue string
+
+	// Periodic is the schedule, or nil for a kind that is only ever
+	// enqueued by other code (per-row workers, and the chained enrichment
+	// phases).
+	Periodic *PeriodicSpec
+}
+
+// Kind returns the river kind string, read from the prototype.
+func (e Entry) Kind() string { return e.Args.Kind() }
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+// Registry is the whole set of queue and job declarations.  Build one with
+// NewRegistry (which validates) and read river configuration off it.
+//
+// Treat instances as immutable: WithConcurrency returns a copy rather than
+// editing in place, so a handler holding a registry cannot have it changed
+// underneath.
+type Registry struct {
+	queues  map[string]Concurrency
+	entries []Entry
+}
+
+// NewRegistry validates the declarations and returns a Registry, or an error
+// naming the first problem.
+//
+// Production uses Default(), which panics on that error at package init.  The
+// constructor returns it instead so tests can assert on the message.
+func NewRegistry(queues map[string]Concurrency, entries []Entry) (*Registry, error) {
+	r := &Registry{
+		queues:  make(map[string]Concurrency, len(queues)),
+		entries: append(([]Entry)(nil), entries...),
+	}
+	for name, c := range queues {
+		r.queues[name] = c
+	}
+	if err := r.validate(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+// validate enforces the invariants that keep the registry honest.
+//
+// Every one of these is a mistake somebody can make in a hurry while adding
+// the ninth sweep, and every one of them would otherwise show up as a job
+// that quietly never runs.
+func (r *Registry) validate() error {
+	if len(r.queues) == 0 {
+		return fmt.Errorf("queue registry: no queues declared")
+	}
+
+	for name, c := range r.queues {
+		if name == "" {
+			return fmt.Errorf("queue registry: queue name must not be empty")
+		}
+		if c.max < 1 {
+			return fmt.Errorf("queue registry: queue %q has MaxWorkers %d, must be at least 1", name, c.max)
+		}
+		if c.reason == "" {
+			return fmt.Errorf("queue registry: queue %q declares no reason for MaxWorkers %d", name, c.max)
+		}
+	}
+
+	seen := make(map[string]struct{}, len(r.entries))
+	used := make(map[string]struct{}, len(r.queues))
+
+	for _, e := range r.entries {
+		if e.Args == nil {
+			return fmt.Errorf("queue registry: entry for queue %q has no Args prototype", e.Queue)
+		}
+		kind := e.Kind()
+		if kind == "" {
+			return fmt.Errorf("queue registry: entry on queue %q has an empty Kind()", e.Queue)
+		}
+		if _, dup := seen[kind]; dup {
+			return fmt.Errorf("queue registry: kind %q declared twice", kind)
+		}
+		seen[kind] = struct{}{}
+
+		if _, ok := r.queues[e.Queue]; !ok {
+			return fmt.Errorf("queue registry: kind %q rides undeclared queue %q", kind, e.Queue)
+		}
+		used[e.Queue] = struct{}{}
+
+		// The cross-check that makes this file a mirror rather than a
+		// second opinion.  river routes by InsertOpts(), so if the two
+		// disagree the registry's queue map is configuring a queue the job
+		// never lands on.
+		if actual := insertQueue(e.Args); actual != e.Queue {
+			return fmt.Errorf(
+				"queue registry: kind %q declares queue %q but its InsertOpts() routes to %q",
+				kind, e.Queue, actual)
+		}
+
+		if e.Periodic != nil && e.Periodic.Interval <= 0 {
+			return fmt.Errorf("queue registry: kind %q has a periodic schedule with interval %v", kind, e.Periodic.Interval)
+		}
+	}
+
+	// A queue with no kind on it is a worker pool river will start and keep
+	// idle forever — the shape left behind by a sweep that was removed, or
+	// by a rename that landed on one side only.
+	for name := range r.queues {
+		if _, ok := used[name]; !ok {
+			return fmt.Errorf("queue registry: queue %q is declared but no kind rides it", name)
+		}
+	}
+
+	return nil
+}
+
+// insertQueue reports the queue an Args type actually routes to, applying
+// river's own default for a type that declares no InsertOpts or leaves Queue
+// empty.
+func insertQueue(args river.JobArgs) string {
+	withOpts, ok := args.(river.JobArgsWithInsertOpts)
+	if !ok {
+		return river.QueueDefault
+	}
+	if q := withOpts.InsertOpts().Queue; q != "" {
+		return q
+	}
+	return river.QueueDefault
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+// QueueConfigs returns the map for river.Config.Queues.
+func (r *Registry) QueueConfigs() map[string]river.QueueConfig {
+	out := make(map[string]river.QueueConfig, len(r.queues))
+	for name, c := range r.queues {
+		out[name] = river.QueueConfig{MaxWorkers: c.max}
+	}
+	return out
+}
+
+// PeriodicJobs returns the slice for river.Config.PeriodicJobs, in declaration
+// order.
+func (r *Registry) PeriodicJobs() []*river.PeriodicJob {
+	var out []*river.PeriodicJob
+	for _, e := range r.entries {
+		if e.Periodic == nil {
+			continue
+		}
+		var opts *river.PeriodicJobOpts
+		if e.Periodic.RunOnStart {
+			opts = &river.PeriodicJobOpts{RunOnStart: true}
+		}
+
+		// The closure captures the range variable, which Go scopes per
+		// iteration (1.22+) — so this is one constructor per entry and not
+		// ten pointing at the last one.  Hoisting `e` out of the loop would
+		// reinstate exactly that bug, which is what the sibling test pins.
+		out = append(out, river.NewPeriodicJob(
+			river.PeriodicInterval(e.Periodic.Interval),
+			func() (river.JobArgs, *river.InsertOpts) {
+				if e.Periodic.Args != nil {
+					return e.Periodic.Args(), nil
+				}
+				// nil InsertOpts on purpose: the Args type's own
+				// InsertOpts() already pins the queue and the uniqueness,
+				// and returning a second set here would be the drift this
+				// file exists to prevent.
+				return e.Args, nil
+			},
+			opts,
+		))
+	}
+	return out
+}
+
+// Names returns every declared queue name, sorted.
+func (r *Registry) Names() []string {
+	out := make([]string, 0, len(r.queues))
+	for name := range r.queues {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// PausableNames returns the queue names the admin pause surface may target:
+// every declared queue EXCEPT river.QueueDefault, sorted.
+//
+// default is excluded deliberately and permanently.  It is not one workload,
+// it is four — V1, V2, warm_season and orphan_scan — so pausing it is the
+// "accidentally freeze the whole queue subsystem" outcome the older, V3-only
+// surface was narrowed to prevent.  Widening the surface to every queue is
+// only safe because this one stays out of it.
+func (r *Registry) PausableNames() []string {
+	out := make([]string, 0, len(r.queues))
+	for name := range r.queues {
+		if name == river.QueueDefault {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Pausable reports whether name is a queue the admin surface may pause.
+func (r *Registry) Pausable(name string) bool {
+	if name == river.QueueDefault {
+		return false
+	}
+	_, ok := r.queues[name]
+	return ok
+}
+
+// Kinds returns every declared job kind, in declaration order.
+func (r *Registry) Kinds() []string {
+	out := make([]string, 0, len(r.entries))
+	for _, e := range r.entries {
+		out = append(out, e.Kind())
+	}
+	return out
+}
+
+// Entries returns a copy of the declarations.
+func (r *Registry) Entries() []Entry {
+	return append(([]Entry)(nil), r.entries...)
+}
+
+// Concurrency returns the declared concurrency for a queue.
+func (r *Registry) Concurrency(name string) (Concurrency, bool) {
+	c, ok := r.queues[name]
+	return c, ok
+}
+
+// WithConcurrency returns a copy of the registry with one queue's worker count
+// changed.  Refuses a queue that was declared with FixedConcurrency, naming
+// the reason — the point of the type is that the number cannot be changed
+// without reading why it is what it is.
+func (r *Registry) WithConcurrency(name string, max int) (*Registry, error) {
+	c, ok := r.queues[name]
+	if !ok {
+		return nil, fmt.Errorf("queue registry: unknown queue %q", name)
+	}
+	if c.fixed {
+		return nil, fmt.Errorf("queue registry: queue %q has fixed concurrency %d: %s", name, c.max, c.reason)
+	}
+	if max < 1 {
+		return nil, fmt.Errorf("queue registry: queue %q MaxWorkers %d, must be at least 1", name, max)
+	}
+
+	queues := make(map[string]Concurrency, len(r.queues))
+	for k, v := range r.queues {
+		queues[k] = v
+	}
+	queues[name] = TunableConcurrency(max, c.reason)
+	return &Registry{queues: queues, entries: append(([]Entry)(nil), r.entries...)}, nil
+}

--- a/go-api/internal/queue/registry_default.go
+++ b/go-api/internal/queue/registry_default.go
@@ -1,0 +1,242 @@
+// registry_default.go — the production declarations.
+//
+// This is the file to edit when adding a background job.  Everything river
+// needs to run it is here: the queue it rides, the worker count for that
+// queue and why it is that number, and the schedule.  cmd/server/main.go
+// reads this and does not restate any of it.
+//
+// The prose that used to sit in main.go's Queues literal is preserved, mostly
+// verbatim, because it is the only record of why several of these numbers are
+// 1.  Two claims in it were false on HEAD and were corrected in the commit
+// before this one rather than moved.
+package queue
+
+import (
+	"time"
+
+	"github.com/riverqueue/river"
+)
+
+// defaultRegistry is the production declaration set.  Built at package init
+// so a malformed registry stops the process at start rather than at the first
+// insert — and stops the test binary too, which is where it will actually be
+// caught.
+var defaultRegistry = mustRegistry(NewRegistry(productionQueues, productionEntries))
+
+// Default returns the production registry.
+func Default() *Registry { return defaultRegistry }
+
+// mustRegistry panics on a construction error.  Reserved for the package-level
+// var above: a registry that does not validate is a programming error with no
+// runtime recovery, and river would go on to run some subset of the intended
+// jobs while reporting nothing.
+func mustRegistry(r *Registry, err error) *Registry {
+	if err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// productionQueues declares every river queue and its worker count.
+//
+// Note what MaxWorkers is and is not.  It bounds workers inside THIS process.
+// cmd/bgmbackfill and cmd/hantbackfill are separate processes that write some
+// of the same tables, so none of these reasons can be read as "only one
+// writer exists" — they are all phrased as what the slot buys inside the
+// server.
+var productionQueues = map[string]Concurrency{
+	// The default queue carries four workloads at once: V1, V2,
+	// warm_season and orphan_scan.  That is why it is the one queue the
+	// admin pause surface refuses to touch (see Registry.PausableNames).
+	//
+	// One slot because V1 and V2 both spend the shared Bangumi token
+	// bucket, so a second worker would not go faster — it would take turns
+	// on the same 800ms allowance while doubling the dispatch churn.
+	river.QueueDefault: FixedConcurrency(1,
+		"V1/V2 spend the shared 800ms Bangumi bucket; extra slots queue on it rather than beat it"),
+
+	// V3 gets its own queue so the admin heal-CN pause isolates that
+	// workload.  Pausing default would freeze enrichment and seasonal
+	// warming with it.
+	BangumiV3QueueName: FixedConcurrency(1,
+		"heal-CN draws the same shared Bangumi bucket as V1/V2"),
+
+	// Chinese-description backfill.  A long-running sweep over ~17k rows
+	// whose only cost is Bangumi API time, metered by a token bucket on the
+	// single shared *bangumi.Client.  Extra workers would therefore not
+	// drain the backlog any faster; they would queue on the same bucket
+	// while stealing dispatch slots from on-demand enrichment.  The
+	// separate queue is for isolation and pausability, not parallelism.
+	DescriptionBackfillQueueName: FixedConcurrency(1,
+		"the backlog is bucket-bound, not worker-bound; extra slots only steal dispatch from live enrichment"),
+
+	// LLM translation.  The one queue here that genuinely parallelises: its
+	// budget is DeepSeek round-trips (seconds each, no shared token
+	// bucket), and 4-way keeps a 600-row batch under ~15 minutes without
+	// hammering the API.  Tunable because raising it costs only DeepSeek
+	// concurrency — nothing else depends on the number.
+	DescriptionLlmQueueName: TunableConcurrency(4,
+		"DeepSeek round-trips are the budget and they parallelise; raising this costs API concurrency and nothing else"),
+
+	// zh-Hant sweep.  One job is the whole table, so a second worker has
+	// nothing to do except run a duplicate pass — and HantBackfillArgs is
+	// unique across every non-terminal state precisely to stop that.  The
+	// separate queue is so a pass that reads all ~17.5k rows and issues two
+	// dozen 500-row UPDATEs cannot sit in front of the V1/V2 enrichment a
+	// page load is waiting on.
+	HantBackfillQueueName: FixedConcurrency(1,
+		"one job is the whole table; a second slot could only run a duplicate pass"),
+
+	// Inferred episode counts.  Two Bangumi requests per row, metered by
+	// the same shared token bucket, so the same argument as the description
+	// backfill applies unchanged.
+	EpisodesBgmQueueName: FixedConcurrency(1,
+		"two bucket-metered requests per row; extra slots steal dispatch from live enrichment without going faster"),
+
+	// Airing episode titles.  One pass is one job that walks its whole
+	// candidate list inline, and every row costs a token from the
+	// dandanplay bucket that user-facing /match draws on.  A second
+	// concurrent pass would not go faster -- the bucket is the constraint,
+	// not the worker count -- it would only take twice as many tokens away
+	// from the request path.
+	EpisodeTitlesQueueName: FixedConcurrency(1,
+		"the dandanplay bucket is shared with user-facing /match; a second pass only takes tokens from it"),
+
+	// Binding.  MaxWorkers 1 is load-bearing rather than polite here.
+	// BindBgmIdsFromIdMap refuses a subject some bound row already holds,
+	// but that check and its UPDATE are one statement: two concurrent
+	// passes could each pass it for the same subject and both bind, and
+	// anime_cache.bgm_id has no unique index to catch it.  A single slot is
+	// what makes the race unreachable BETWEEN JOBS IN THIS PROCESS, and it
+	// is why every writer of anime_cache.bgm_id shares this queue.
+	//
+	// It is not a guarantee against a second process.  cmd/bgmbackfill's
+	// id_map_binds.go deliberately ships without an --apply flag, and that
+	// deliberate absence — not this slot count — is what keeps the
+	// invariant true today.
+	BgmBindQueueName: FixedConcurrency(1,
+		"serialises in-process bgm_id writers; anime_cache.bgm_id has no unique index to catch a lost race"),
+
+	// Rating refresh, both kinds on one queue.  They are the same feature
+	// and are turned off for the same reasons, so a single pause is the
+	// control an operator wants.
+	//
+	// One slot, which replaced an earlier 2 chosen so a four-minute Bangumi
+	// pass would not sit in front of a thirty-second AniList one.  The cost
+	// is small at this cadence: with anilistRatingsBatch at 500 the AniList
+	// pass is ~21s and the Bangumi pass ~4 minutes, so serialising them
+	// spends about five minutes of one slot per hour.
+	RatingsQueueName: FixedConcurrency(1,
+		"two passes of the same kind cannot overlap, which is what keeps a relaxed-uniqueness future safe"),
+}
+
+// productionEntries declares every job kind.
+//
+// Order is the order river receives the periodic jobs in, and it matches the
+// order the old main.go literal used so a diff of the two reads cleanly.
+var productionEntries = []Entry{
+	// --- default queue: the enrichment pipeline and the two boot scans ---
+
+	// V1/V2/V3 are chained by their workers, never scheduled.
+	{Args: BangumiV1Args{}, Queue: river.QueueDefault},
+	{Args: BangumiV2Args{}, Queue: river.QueueDefault},
+	{Args: BangumiV3Args{}, Queue: BangumiV3QueueName},
+
+	// warm_season: RunOnStart is false because main.go enqueues the
+	// current AND next season by hand at boot, which this single-payload
+	// schedule cannot express.  The payload is built at firing time so a
+	// long-lived process rolls onto the new season instead of warming last
+	// quarter forever.
+	{
+		Args:  WarmSeasonArgs{},
+		Queue: river.QueueDefault,
+		Periodic: &PeriodicSpec{
+			Interval: warmSeasonPeriodicInterval,
+			Args: func() river.JobArgs {
+				cur, year := CurrentSeason(time.Now())
+				return WarmSeasonArgs{Season: cur, Year: year}
+			},
+		},
+	},
+
+	// orphan_scan: RunOnStart false for the same reason — main.go runs the
+	// boot scan itself via ScanAndEnqueueOrphans.
+	{
+		Args:     OrphanScanArgs{},
+		Queue:    river.QueueDefault,
+		Periodic: &PeriodicSpec{Interval: orphanScanPeriodicInterval},
+	},
+
+	// --- description backfill: a scan that fans out to per-row jobs ---
+
+	{
+		Args:     DescriptionBackfillScanArgs{},
+		Queue:    DescriptionBackfillQueueName,
+		Periodic: &PeriodicSpec{Interval: descriptionBackfillScanInterval, RunOnStart: true},
+	},
+	{Args: DescriptionBackfillArgs{}, Queue: DescriptionBackfillQueueName},
+
+	// --- LLM translation: same shape, different budget ---
+
+	{
+		Args:     DescriptionLlmBackfillScanArgs{},
+		Queue:    DescriptionLlmQueueName,
+		Periodic: &PeriodicSpec{Interval: descriptionLlmScanInterval, RunOnStart: true},
+	},
+	{Args: DescriptionLlmBackfillArgs{}, Queue: DescriptionLlmQueueName},
+
+	// --- inferred episode counts ---
+
+	{
+		Args:     EpisodesBgmScanArgs{},
+		Queue:    EpisodesBgmQueueName,
+		Periodic: &PeriodicSpec{Interval: episodesBgmScanInterval, RunOnStart: true},
+	},
+	{Args: EpisodesBgmArgs{}, Queue: EpisodesBgmQueueName},
+
+	// --- airing episode titles ---
+
+	{
+		Args:     EpisodeTitlesArgs{},
+		Queue:    EpisodeTitlesQueueName,
+		Periodic: &PeriodicSpec{Interval: episodeTitlesInterval, RunOnStart: true},
+	},
+
+	// --- bgm_id binding ---
+
+	{
+		Args:     BindIdMapArgs{},
+		Queue:    BgmBindQueueName,
+		Periodic: &PeriodicSpec{Interval: bindIdMapInterval, RunOnStart: true},
+	},
+
+	// --- zh-Hant sweep ---
+
+	// Quarterly, and deliberately NOT RunOnStart: one pass is the whole
+	// table, so firing it on every deploy would be the expensive mistake.
+	// The cost of that choice is real — a service that deploys more often
+	// than once a quarter may never reach the interval — and it is accepted
+	// because the admin button exists to run it on demand.
+	{
+		Args:     HantBackfillArgs{},
+		Queue:    HantBackfillQueueName,
+		Periodic: &PeriodicSpec{Interval: hantBackfillInterval},
+	},
+
+	// --- rating refresh ---
+
+	// Hourly and RunOnStart, for the reason the sweeps above give: river's
+	// OSS scheduler recomputes nextRunAt at every Start, so without it a
+	// service that deploys more often than the interval never sweeps.  The
+	// read stamp is what makes firing on boot free.
+	{
+		Args:     AnilistRatingsArgs{},
+		Queue:    RatingsQueueName,
+		Periodic: &PeriodicSpec{Interval: ratingsInterval, RunOnStart: true},
+	},
+	{
+		Args:     BangumiRatingsArgs{},
+		Queue:    RatingsQueueName,
+		Periodic: &PeriodicSpec{Interval: ratingsInterval, RunOnStart: true},
+	},
+}

--- a/go-api/internal/queue/registry_default.go
+++ b/go-api/internal/queue/registry_default.go
@@ -107,15 +107,28 @@ var productionQueues = map[string]Concurrency{
 	// but that check and its UPDATE are one statement: two concurrent
 	// passes could each pass it for the same subject and both bind, and
 	// anime_cache.bgm_id has no unique index to catch it.  A single slot is
-	// what makes the race unreachable BETWEEN JOBS IN THIS PROCESS, and it
+	// what makes that race unreachable BETWEEN JOBS IN THIS PROCESS, and it
 	// is why every writer of anime_cache.bgm_id shares this queue.
 	//
-	// It is not a guarantee against a second process.  cmd/bgmbackfill's
-	// id_map_binds.go deliberately ships without an --apply flag, and that
-	// deliberate absence — not this slot count — is what keeps the
-	// invariant true today.
+	// Be precise about what it buys, because the obvious reading is wrong
+	// in two directions.
+	//
+	// It is not a guarantee against a second process: cmd/bgmbackfill and
+	// cmd/hantbackfill write some of the same tables without going through
+	// river at all.  id_map_binds.go deliberately ships without an --apply
+	// flag, and that absence — not this slot count — is what keeps the
+	// binding path single-writer today.
+	//
+	// And it is not the reason "one subject, one row" holds, because that
+	// does not hold: measured 2026-09-03, 541 subjects are already held by
+	// two or more rows (1,161 rows in total), some of them legitimately —
+	// Bangumi sometimes covers with one subject what AniList splits into
+	// two seasons.  What the slot buys is that this sweep cannot make that
+	// number larger.  TODOS.md carries what it would take to make the
+	// database enforce the invariant instead; the blocker there is
+	// adjudicating those 1,161 rows, not writing the migration.
 	BgmBindQueueName: FixedConcurrency(1,
-		"serialises in-process bgm_id writers; anime_cache.bgm_id has no unique index to catch a lost race"),
+		"keeps this sweep from adding to the 541 subjects already multi-held; in-process only"),
 
 	// Rating refresh, both kinds on one queue.  They are the same feature
 	// and are turned off for the same reasons, so a single pause is the

--- a/go-api/internal/queue/registry_test.go
+++ b/go-api/internal/queue/registry_test.go
@@ -1,0 +1,694 @@
+// registry_test.go — unit coverage for the declarations and the invariants
+// that keep them honest.
+//
+// Split in two.  The first half exercises the Registry machinery against
+// small hand-built declaration sets, because that is the only way to see the
+// error messages somebody adding the ninth sweep will actually hit.  The
+// second half asserts facts about the PRODUCTION registry, which is the set
+// that ships.
+//
+// What is deliberately NOT here: any assertion that a UniqueOpts state set
+// contains the four states river requires.  Those constants are private to
+// river (insert_opts.go requiredV3states) and hand-copying them would produce
+// a gate that reports green while river reports an error — the exact failure
+// shape this whole change exists to remove, with a reassuring test on top.
+// The real check is the integration test, which runs river's own validate.
+package queue
+
+import (
+	"reflect"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// fakeArgs is a job type the tests can point anywhere.
+type fakeArgs struct {
+	kind  string
+	queue string
+}
+
+func (a fakeArgs) Kind() string { return a.kind }
+func (a fakeArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{Queue: a.queue}
+}
+
+// noOptsArgs declares no InsertOpts at all, so river routes it to default.
+type noOptsArgs struct{}
+
+func (noOptsArgs) Kind() string { return "no_opts" }
+
+func okQueues() map[string]Concurrency {
+	return map[string]Concurrency{
+		"alpha": FixedConcurrency(1, "shared bucket"),
+	}
+}
+
+func okEntries() []Entry {
+	return []Entry{{Args: fakeArgs{kind: "a", queue: "alpha"}, Queue: "alpha"}}
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+func TestNewRegistry_AcceptsAWellFormedSet(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(okQueues(), okEntries())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha"}, r.Names())
+}
+
+// TestNewRegistry_RejectsKindOnUndeclaredQueue is the "added the ninth sweep
+// and forgot the queue" case.  Before the registry this produced a river
+// client that accepted the insert and never dispatched it.
+func TestNewRegistry_RejectsKindOnUndeclaredQueue(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRegistry(okQueues(), []Entry{
+		{Args: fakeArgs{kind: "b", queue: "beta"}, Queue: "beta"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `kind "b" rides undeclared queue "beta"`)
+}
+
+// TestNewRegistry_RejectsDeclaredQueueNoKindRides catches the other half of a
+// half-finished rename: a worker pool river starts and keeps idle forever.
+func TestNewRegistry_RejectsDeclaredQueueNoKindRides(t *testing.T) {
+	t.Parallel()
+
+	queues := okQueues()
+	queues["orphaned"] = FixedConcurrency(1, "nothing rides this")
+
+	_, err := NewRegistry(queues, okEntries())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `queue "orphaned" is declared but no kind rides it`)
+}
+
+// TestNewRegistry_RejectsQueueDisagreeingWithInsertOpts is the invariant that
+// makes this file a mirror of InsertOpts rather than a second opinion about
+// it.  river routes by InsertOpts; a registry that says otherwise is
+// configuring a queue the job never lands on.
+func TestNewRegistry_RejectsQueueDisagreeingWithInsertOpts(t *testing.T) {
+	t.Parallel()
+
+	queues := okQueues()
+	queues["beta"] = FixedConcurrency(1, "declared")
+
+	_, err := NewRegistry(queues, []Entry{
+		{Args: fakeArgs{kind: "a", queue: "alpha"}, Queue: "alpha"},
+		// Declares beta, routes to alpha.
+		{Args: fakeArgs{kind: "b", queue: "alpha"}, Queue: "beta"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		`kind "b" declares queue "beta" but its InsertOpts() routes to "alpha"`)
+}
+
+// TestNewRegistry_TreatsMissingInsertOptsAsDefault pins river's own fallback:
+// an Args type with no InsertOpts rides the default queue.  Three production
+// kinds rely on this.
+func TestNewRegistry_TreatsMissingInsertOptsAsDefault(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(
+		map[string]Concurrency{river.QueueDefault: FixedConcurrency(1, "shared bucket")},
+		[]Entry{{Args: noOptsArgs{}, Queue: river.QueueDefault}},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{river.QueueDefault}, r.Names())
+}
+
+// TestNewRegistry_TreatsEmptyQueueInInsertOptsAsDefault covers the other
+// spelling: a type that implements InsertOpts but leaves Queue blank.
+func TestNewRegistry_TreatsEmptyQueueInInsertOptsAsDefault(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRegistry(
+		map[string]Concurrency{river.QueueDefault: FixedConcurrency(1, "shared bucket")},
+		[]Entry{{Args: fakeArgs{kind: "blank", queue: ""}, Queue: river.QueueDefault}},
+	)
+	require.NoError(t, err)
+}
+
+func TestNewRegistry_RejectsDuplicateKind(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRegistry(okQueues(), []Entry{
+		{Args: fakeArgs{kind: "a", queue: "alpha"}, Queue: "alpha"},
+		{Args: fakeArgs{kind: "a", queue: "alpha"}, Queue: "alpha"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `kind "a" declared twice`)
+}
+
+func TestNewRegistry_RejectsZeroMaxWorkers(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRegistry(
+		map[string]Concurrency{"alpha": FixedConcurrency(0, "oops")},
+		okEntries(),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be at least 1")
+}
+
+// TestNewRegistry_RejectsUnexplainedConcurrency is the point of the type.  A
+// number with no reason is the thing that got copied eight times.
+func TestNewRegistry_RejectsUnexplainedConcurrency(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRegistry(
+		map[string]Concurrency{"alpha": FixedConcurrency(1, "")},
+		okEntries(),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declares no reason")
+}
+
+func TestNewRegistry_RejectsNonPositivePeriodicInterval(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRegistry(okQueues(), []Entry{{
+		Args:     fakeArgs{kind: "a", queue: "alpha"},
+		Queue:    "alpha",
+		Periodic: &PeriodicSpec{Interval: 0, RunOnStart: true},
+	}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "periodic schedule with interval")
+}
+
+func TestNewRegistry_RejectsNilArgs(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRegistry(okQueues(), []Entry{{Queue: "alpha"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no Args prototype")
+}
+
+// TestNewRegistry_CopiesInputs pins that a caller mutating the maps and slices
+// it passed in cannot reach inside a validated registry afterwards.
+func TestNewRegistry_CopiesInputs(t *testing.T) {
+	t.Parallel()
+
+	queues := okQueues()
+	entries := okEntries()
+	r, err := NewRegistry(queues, entries)
+	require.NoError(t, err)
+
+	queues["beta"] = FixedConcurrency(9, "snuck in")
+	entries[0].Queue = "beta"
+
+	assert.Equal(t, []string{"alpha"}, r.Names(), "queue map must be copied")
+	assert.Equal(t, "alpha", r.Entries()[0].Queue, "entry slice must be copied")
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency: fixed vs tunable
+// ---------------------------------------------------------------------------
+
+func TestQueueConfigs_CarriesDeclaredMaxWorkers(t *testing.T) {
+	t.Parallel()
+
+	queues := map[string]Concurrency{
+		"alpha": FixedConcurrency(1, "shared bucket"),
+		"beta":  TunableConcurrency(4, "round-trips parallelise"),
+	}
+	r, err := NewRegistry(queues, []Entry{
+		{Args: fakeArgs{kind: "a", queue: "alpha"}, Queue: "alpha"},
+		{Args: fakeArgs{kind: "b", queue: "beta"}, Queue: "beta"},
+	})
+	require.NoError(t, err)
+
+	cfgs := r.QueueConfigs()
+	assert.Equal(t, 1, cfgs["alpha"].MaxWorkers)
+	assert.Equal(t, 4, cfgs["beta"].MaxWorkers)
+}
+
+// TestWithConcurrency_RefusesFixedAndNamesTheReason is what makes Fixed more
+// than a label: the number cannot be changed without reading why it is what
+// it is.
+func TestWithConcurrency_RefusesFixedAndNamesTheReason(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(okQueues(), okEntries())
+	require.NoError(t, err)
+
+	_, err = r.WithConcurrency("alpha", 4)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fixed concurrency 1")
+	assert.Contains(t, err.Error(), "shared bucket",
+		"the refusal must carry the reason, not just the refusal")
+}
+
+func TestWithConcurrency_AllowsTunable(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(
+		map[string]Concurrency{"beta": TunableConcurrency(4, "round-trips parallelise")},
+		[]Entry{{Args: fakeArgs{kind: "b", queue: "beta"}, Queue: "beta"}},
+	)
+	require.NoError(t, err)
+
+	tuned, err := r.WithConcurrency("beta", 8)
+	require.NoError(t, err)
+	assert.Equal(t, 8, tuned.QueueConfigs()["beta"].MaxWorkers)
+	assert.Equal(t, 4, r.QueueConfigs()["beta"].MaxWorkers,
+		"WithConcurrency must return a copy, not edit the receiver")
+}
+
+func TestWithConcurrency_RejectsUnknownQueue(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(okQueues(), okEntries())
+	require.NoError(t, err)
+
+	_, err = r.WithConcurrency("nope", 2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown queue "nope"`)
+}
+
+func TestWithConcurrency_RejectsZero(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(
+		map[string]Concurrency{"beta": TunableConcurrency(4, "round-trips parallelise")},
+		[]Entry{{Args: fakeArgs{kind: "b", queue: "beta"}, Queue: "beta"}},
+	)
+	require.NoError(t, err)
+
+	_, err = r.WithConcurrency("beta", 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be at least 1")
+}
+
+// ---------------------------------------------------------------------------
+// Pause whitelist
+// ---------------------------------------------------------------------------
+
+// TestPausableNames_ExcludesDefault pins the safety constraint the old
+// V3-only surface was narrowed to enforce.  default carries V1, V2,
+// warm_season and orphan_scan; pausing it freezes the enrichment a page load
+// is waiting on.
+func TestPausableNames_ExcludesDefault(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(
+		map[string]Concurrency{
+			river.QueueDefault: FixedConcurrency(1, "four workloads share it"),
+			"alpha":            FixedConcurrency(1, "shared bucket"),
+		},
+		[]Entry{
+			{Args: noOptsArgs{}, Queue: river.QueueDefault},
+			{Args: fakeArgs{kind: "a", queue: "alpha"}, Queue: "alpha"},
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"alpha"}, r.PausableNames())
+	assert.False(t, r.Pausable(river.QueueDefault),
+		"default must never be pausable through the admin surface")
+	assert.True(t, r.Pausable("alpha"))
+	assert.Contains(t, r.Names(), river.QueueDefault,
+		"Names() still reports default; only the pause whitelist excludes it")
+}
+
+func TestPausable_RejectsUnknownName(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(okQueues(), okEntries())
+	require.NoError(t, err)
+
+	assert.False(t, r.Pausable("does_not_exist"))
+	assert.False(t, r.Pausable(""))
+	assert.False(t, r.Pausable("*"),
+		"river's all-queues wildcard must not reach the admin surface")
+}
+
+// ---------------------------------------------------------------------------
+// Periodic jobs
+// ---------------------------------------------------------------------------
+
+func TestPeriodicJobs_SkipsUnscheduledKinds(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(okQueues(), []Entry{
+		{Args: fakeArgs{kind: "a", queue: "alpha"}, Queue: "alpha"},
+		{Args: fakeArgs{kind: "b", queue: "alpha"}, Queue: "alpha",
+			Periodic: &PeriodicSpec{Interval: time.Hour}},
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, r.PeriodicJobs(), 1)
+}
+
+// TestPeriodicJobs_ConstructorsAreBoundPerEntry catches the classic loop-
+// variable capture: every constructor returning the last entry's Args would
+// leave nine kinds unscheduled and one scheduled ten times.
+func TestPeriodicJobs_ConstructorsAreBoundPerEntry(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(okQueues(), []Entry{
+		{Args: fakeArgs{kind: "a", queue: "alpha"}, Queue: "alpha",
+			Periodic: &PeriodicSpec{Interval: time.Hour}},
+		{Args: fakeArgs{kind: "b", queue: "alpha"}, Queue: "alpha",
+			Periodic: &PeriodicSpec{Interval: time.Hour}},
+	})
+	require.NoError(t, err)
+
+	jobs := r.PeriodicJobs()
+	require.Len(t, jobs, 2)
+	assert.Equal(t, []string{"a", "b"}, []string{
+		periodicKind(t, jobs[0]), periodicKind(t, jobs[1]),
+	})
+}
+
+// TestPeriodicJobs_UsesTheSpecArgsConstructorWhenGiven covers warm_season,
+// whose payload is the CURRENT season and must be computed at firing time.
+func TestPeriodicJobs_UsesTheSpecArgsConstructorWhenGiven(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	r, err := NewRegistry(okQueues(), []Entry{{
+		Args:  fakeArgs{kind: "a", queue: "alpha"},
+		Queue: "alpha",
+		Periodic: &PeriodicSpec{Interval: time.Hour, Args: func() river.JobArgs {
+			calls++
+			return fakeArgs{kind: "computed", queue: "alpha"}
+		}},
+	}})
+	require.NoError(t, err)
+
+	jobs := r.PeriodicJobs()
+	require.Len(t, jobs, 1)
+
+	assert.Equal(t, "computed", periodicKind(t, jobs[0]))
+	assert.Equal(t, "computed", periodicKind(t, jobs[0]))
+	assert.Equal(t, 2, calls,
+		"the constructor must run per firing, not once at registry build")
+}
+
+// TestPeriodicJobs_ReturnsNilInsertOpts pins the boundary decision: the
+// schedule does not restate routing or uniqueness, because the Args type's
+// own InsertOpts() already carries both and a second copy is the drift.
+func TestPeriodicJobs_ReturnsNilInsertOpts(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(okQueues(), []Entry{{
+		Args:     fakeArgs{kind: "a", queue: "alpha"},
+		Queue:    "alpha",
+		Periodic: &PeriodicSpec{Interval: time.Hour},
+	}})
+	require.NoError(t, err)
+
+	_, opts := periodicConstructor(t, r.PeriodicJobs()[0])()
+	assert.Nil(t, opts)
+}
+
+// ---------------------------------------------------------------------------
+// The production registry
+// ---------------------------------------------------------------------------
+
+// TestDefaultRegistry_Validates is the guard on the guard.  Every assertion
+// below it, and every boot of the server, depends on Default() having been
+// constructible — and it is built in a package-level var, so a mistake in the
+// declarations takes the process down at start.  This test is where that is
+// meant to be caught instead.
+func TestDefaultRegistry_Validates(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry(productionQueues, productionEntries)
+	require.NoError(t, err, "the production declarations must validate")
+	require.NotNil(t, r)
+	assert.Same(t, defaultRegistry, Default())
+}
+
+// TestDefaultRegistry_QueueNames pins the exact set.  A new queue is a
+// deliberate act; arriving here by accident (a typo'd constant creating a
+// ninth queue with one job on it) is not.
+func TestDefaultRegistry_QueueNames(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{
+		BangumiV3QueueName,
+		BgmBindQueueName,
+		river.QueueDefault,
+		DescriptionBackfillQueueName,
+		DescriptionLlmQueueName,
+		EpisodeTitlesQueueName,
+		EpisodesBgmQueueName,
+		HantBackfillQueueName,
+		RatingsQueueName,
+	}, Default().Names())
+}
+
+// TestDefaultRegistry_EveryKindIsDeclared pins the full kind list against the
+// Args types that exist.  A kind added to args.go and not to the registry gets
+// no queue configuration and no schedule — which is the shape of "the sweep
+// silently never runs".
+func TestDefaultRegistry_EveryKindIsDeclared(t *testing.T) {
+	t.Parallel()
+
+	declared := map[string]bool{}
+	for _, k := range Default().Kinds() {
+		declared[k] = true
+	}
+
+	// Every river.JobArgs implementation in this package.  Adding one here is
+	// the deliberate half of adding a job; the compiler enforces the type and
+	// this enforces the registration.
+	for _, args := range []river.JobArgs{
+		BangumiV1Args{},
+		BangumiV2Args{},
+		BangumiV3Args{},
+		WarmSeasonArgs{},
+		OrphanScanArgs{},
+		DescriptionBackfillScanArgs{},
+		DescriptionBackfillArgs{},
+		DescriptionLlmBackfillScanArgs{},
+		DescriptionLlmBackfillArgs{},
+		EpisodesBgmScanArgs{},
+		EpisodesBgmArgs{},
+		EpisodeTitlesArgs{},
+		BindIdMapArgs{},
+		HantBackfillArgs{},
+		AnilistRatingsArgs{},
+		BangumiRatingsArgs{},
+	} {
+		assert.True(t, declared[args.Kind()],
+			"kind %q implements river.JobArgs but is not in the registry: it would get "+
+				"no queue configuration and no schedule", args.Kind())
+	}
+	assert.Len(t, Default().Kinds(), 16,
+		"a kind was added to or removed from the registry without updating this list")
+}
+
+// TestDefaultRegistry_RunOnStartSplit pins which sweeps fire at boot.
+//
+// Getting this wrong is silent in both directions.  A missing RunOnStart on an
+// hourly sweep means a service that deploys more often than hourly never
+// sweeps at all, because river's OSS scheduler recomputes nextRunAt at every
+// Start.  A spurious one on the quarterly zh-Hant sweep means a whole-table
+// pass per deploy.
+func TestDefaultRegistry_RunOnStartSplit(t *testing.T) {
+	t.Parallel()
+
+	runOnStart := map[string]bool{}
+	for _, e := range Default().Entries() {
+		if e.Periodic == nil {
+			continue
+		}
+		runOnStart[e.Kind()] = e.Periodic.RunOnStart
+	}
+
+	assert.Equal(t, map[string]bool{
+		// Boot-fired: hourly or six-hourly sweeps that a redeploying
+		// service would otherwise never reach.
+		"description_backfill_scan":     true,
+		"description_llm_backfill_scan": true,
+		"episodes_bgm_scan":             true,
+		"episode_titles_releasing":      true,
+		"bgm_bind_idmap":                true,
+		"anilist_ratings":               true,
+		"bangumi_ratings":               true,
+
+		// Not boot-fired: main.go enqueues these two by hand at boot with
+		// payloads the single-payload schedule cannot express...
+		"warm_season": false,
+		"orphan_scan": false,
+		// ...and this one is a quarterly whole-table pass that must not
+		// run once per deploy.
+		"hant_backfill": false,
+	}, runOnStart)
+}
+
+// TestDefaultRegistry_PeriodicJobsMatchDeclarations asserts the built river
+// objects agree with the declarations, through river's own (unexported)
+// fields rather than through the struct we just read.
+func TestDefaultRegistry_PeriodicJobsMatchDeclarations(t *testing.T) {
+	t.Parallel()
+
+	jobs := Default().PeriodicJobs()
+	require.Len(t, jobs, 10, "ten scheduled kinds")
+
+	var want []Entry
+	for _, e := range Default().Entries() {
+		if e.Periodic != nil {
+			want = append(want, e)
+		}
+	}
+	require.Len(t, want, len(jobs))
+
+	for i, job := range jobs {
+		entry := want[i]
+		assert.Equal(t, entry.Kind(), periodicKind(t, job),
+			"PeriodicJobs must preserve declaration order")
+
+		optsField := reflect.ValueOf(job).Elem().FieldByName("opts")
+		require.True(t, optsField.IsValid(),
+			"river.PeriodicJob no longer has an `opts` field — re-verify RunOnStart is still set")
+
+		if !entry.Periodic.RunOnStart {
+			assert.True(t, optsField.IsNil(),
+				"kind %q declares RunOnStart=false but river was handed opts", entry.Kind())
+			continue
+		}
+
+		require.False(t, optsField.IsNil(),
+			"kind %q declares RunOnStart=true but river was handed nil opts, which defaults it to false",
+			entry.Kind())
+		runOnStart := optsField.Elem().FieldByName("RunOnStart")
+		require.True(t, runOnStart.IsValid(),
+			"river.PeriodicJobOpts no longer has RunOnStart — re-verify what these sweeps do at boot")
+		assert.True(t, runOnStart.Bool(), "kind %q must fire at boot", entry.Kind())
+	}
+}
+
+// TestDefaultRegistry_WarmSeasonPayloadIsBuiltAtFiringTime pins the one
+// schedule with a computed payload.  A constant payload would pin a
+// long-lived process to whichever season it booted in.
+func TestDefaultRegistry_WarmSeasonPayloadIsBuiltAtFiringTime(t *testing.T) {
+	t.Parallel()
+
+	var warm *river.PeriodicJob
+	for _, job := range Default().PeriodicJobs() {
+		if periodicKind(t, job) == "warm_season" {
+			warm = job
+			break
+		}
+	}
+	require.NotNil(t, warm)
+
+	args, _ := periodicConstructor(t, warm)()
+	payload, ok := args.(WarmSeasonArgs)
+	require.True(t, ok)
+
+	wantSeason, wantYear := CurrentSeason(time.Now())
+	assert.Equal(t, wantSeason, payload.Season)
+	assert.Equal(t, wantYear, payload.Year)
+}
+
+// TestDefaultRegistry_ConcurrencyIsExplained asserts every worker count in
+// production carries prose.  These numbers were copied eight times across a
+// 90-line map literal, and four of them are 1 for reasons that are not
+// throughput.
+func TestDefaultRegistry_ConcurrencyIsExplained(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range Default().Names() {
+		c, ok := Default().Concurrency(name)
+		require.True(t, ok)
+		assert.NotEmpty(t, c.Reason(), "queue %q must record why MaxWorkers is %d", name, c.Max())
+		assert.GreaterOrEqual(t, c.Max(), 1)
+	}
+}
+
+// TestDefaultRegistry_OnlyTheLlmQueueIsTunable pins the split.  Every other
+// count is load-bearing: a shared upstream token bucket that extra workers
+// only queue on, or a check-then-update race a single slot makes unreachable.
+func TestDefaultRegistry_OnlyTheLlmQueueIsTunable(t *testing.T) {
+	t.Parallel()
+
+	var tunable []string
+	for _, name := range Default().Names() {
+		c, _ := Default().Concurrency(name)
+		if !c.Fixed() {
+			tunable = append(tunable, name)
+		}
+	}
+	assert.Equal(t, []string{DescriptionLlmQueueName}, tunable)
+}
+
+// TestDefaultRegistry_MaxWorkersUnchanged pins the shipped numbers, so a
+// change to one is a deliberate diff on a line that says what it costs.
+func TestDefaultRegistry_MaxWorkersUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cfgs := Default().QueueConfigs()
+	assert.Equal(t, map[string]river.QueueConfig{
+		river.QueueDefault:           {MaxWorkers: 1},
+		BangumiV3QueueName:           {MaxWorkers: 1},
+		DescriptionBackfillQueueName: {MaxWorkers: 1},
+		DescriptionLlmQueueName:      {MaxWorkers: 4},
+		HantBackfillQueueName:        {MaxWorkers: 1},
+		EpisodesBgmQueueName:         {MaxWorkers: 1},
+		EpisodeTitlesQueueName:       {MaxWorkers: 1},
+		BgmBindQueueName:             {MaxWorkers: 1},
+		RatingsQueueName:             {MaxWorkers: 1},
+	}, cfgs)
+}
+
+// TestDefaultRegistry_DefaultQueueIsNotPausable is the production instance of
+// the constraint control.go's package doc records: "so the admin endpoint
+// can't accidentally freeze the whole queue subsystem".  Widening the pause
+// surface from V3-only to every queue is safe only while this holds.
+func TestDefaultRegistry_DefaultQueueIsNotPausable(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, Default().Pausable(river.QueueDefault))
+	assert.NotContains(t, Default().PausableNames(), river.QueueDefault)
+	assert.Len(t, Default().PausableNames(), 8,
+		"eight dedicated queues are pausable; default is the ninth and stays out")
+}
+
+// ---------------------------------------------------------------------------
+// Reflection helpers
+// ---------------------------------------------------------------------------
+//
+// river keeps PeriodicJob's fields unexported and exposes no accessor, so
+// reading them means reflection.  That couples these tests to river's
+// internals on purpose: river is version-pinned, and an upgrade that reshapes
+// PeriodicJob should stop and make somebody re-confirm these facts rather
+// than silently carry an unverified assumption forward.
+
+// periodicConstructor returns the job's constructor func.
+func periodicConstructor(t *testing.T, job *river.PeriodicJob) river.PeriodicJobConstructor {
+	t.Helper()
+
+	field := reflect.ValueOf(job).Elem().FieldByName("constructorFunc")
+	require.True(t, field.IsValid(),
+		"river.PeriodicJob no longer has a `constructorFunc` field — re-verify these assertions")
+
+	fn, ok := reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).
+		Elem().Interface().(river.PeriodicJobConstructor)
+	require.True(t, ok, "constructorFunc is no longer a river.PeriodicJobConstructor")
+	return fn
+}
+
+// periodicKind runs the constructor and reports the kind it produced.
+func periodicKind(t *testing.T, job *river.PeriodicJob) string {
+	t.Helper()
+
+	args, _ := periodicConstructor(t, job)()
+	require.NotNil(t, args, "a periodic constructor must not return nil args")
+	return args.Kind()
+}

--- a/go-api/internal/queue/registry_test.go
+++ b/go-api/internal/queue/registry_test.go
@@ -151,6 +151,56 @@ func TestNewRegistry_RejectsDuplicateKind(t *testing.T) {
 	assert.Contains(t, err.Error(), `kind "a" declared twice`)
 }
 
+func TestNewRegistry_RejectsEmptyQueueSet(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRegistry(map[string]Concurrency{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no queues declared")
+}
+
+func TestNewRegistry_RejectsEmptyQueueName(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRegistry(
+		map[string]Concurrency{"": FixedConcurrency(1, "unnamed")},
+		[]Entry{{Args: fakeArgs{kind: "a", queue: ""}, Queue: ""}},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "queue name must not be empty")
+}
+
+// TestNewRegistry_RejectsEmptyKind covers an Args type whose Kind() returns
+// "".  river would accept it and the registry's duplicate check would then
+// collapse every such kind into one.
+func TestNewRegistry_RejectsEmptyKind(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRegistry(okQueues(), []Entry{
+		{Args: fakeArgs{kind: "", queue: "alpha"}, Queue: "alpha"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty Kind()")
+}
+
+// TestMustRegistry_PanicsOnInvalidDeclarations pins the boot behaviour of the
+// package-level var: a registry that does not validate takes the process down
+// at start rather than letting river run some subset of the intended jobs
+// while reporting nothing.
+func TestMustRegistry_PanicsOnInvalidDeclarations(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		mustRegistry(NewRegistry(okQueues(), []Entry{
+			{Args: fakeArgs{kind: "b", queue: "beta"}, Queue: "beta"},
+		}))
+	})
+
+	assert.NotPanics(t, func() {
+		mustRegistry(NewRegistry(okQueues(), okEntries()))
+	})
+}
+
 func TestNewRegistry_RejectsZeroMaxWorkers(t *testing.T) {
 	t.Parallel()
 

--- a/go-api/internal/queue/registry_test.go
+++ b/go-api/internal/queue/registry_test.go
@@ -531,6 +531,36 @@ func TestDefaultRegistry_RunOnStartSplit(t *testing.T) {
 	}, runOnStart)
 }
 
+// TestDefaultRegistry_Intervals pins every scheduled cadence.
+//
+// These were previously implicit: each Periodic<Name>Job constructor read a
+// package const and only two of the ten had a test that looked at the value.
+// The cadence is half of what RunOnStart means — an hourly sweep that becomes
+// daily is the same silence by a slower route.
+func TestDefaultRegistry_Intervals(t *testing.T) {
+	t.Parallel()
+
+	intervals := map[string]time.Duration{}
+	for _, e := range Default().Entries() {
+		if e.Periodic != nil {
+			intervals[e.Kind()] = e.Periodic.Interval
+		}
+	}
+
+	assert.Equal(t, map[string]time.Duration{
+		"warm_season":                   24 * time.Hour,
+		"orphan_scan":                   time.Hour,
+		"description_backfill_scan":     time.Hour,
+		"description_llm_backfill_scan": time.Hour,
+		"episodes_bgm_scan":             time.Hour,
+		"episode_titles_releasing":      6 * time.Hour,
+		"bgm_bind_idmap":                6 * time.Hour,
+		"hant_backfill":                 90 * 24 * time.Hour,
+		"anilist_ratings":               time.Hour,
+		"bangumi_ratings":               time.Hour,
+	}, intervals)
+}
+
 // TestDefaultRegistry_PeriodicJobsMatchDeclarations asserts the built river
 // objects agree with the declarations, through river's own (unexported)
 // fields rather than through the struct we just read.

--- a/go-api/internal/queue/warm_season.go
+++ b/go-api/internal/queue/warm_season.go
@@ -407,26 +407,3 @@ func NextSeason(season string, year int) (string, int) {
 	}
 	return season, year
 }
-
-// PeriodicWarmSeasonJob returns a river PeriodicJob that fires every
-// 24h to re-enqueue WarmSeasonArgs for the current season.  Each fire
-// re-computes the pair at constructor time, so year rollovers
-// (FALL 2025 → WINTER 2026) handle themselves without restart.
-//
-// Pass the result to queue.Config.PeriodicJobs.  Boot-time initial
-// runs are NOT covered by this — call Enqueuer.EnqueueWarmSeasonNow
-// at boot for the initial current + next season pair.
-//
-// Schedule: 24h fixed interval (river.PeriodicInterval).  No cron
-// alignment needed — warm cache freshness has hours of slack.
-func PeriodicWarmSeasonJob() *river.PeriodicJob {
-	return river.NewPeriodicJob(
-		river.PeriodicInterval(warmSeasonPeriodicInterval),
-		func() (river.JobArgs, *river.InsertOpts) {
-			cur, year := CurrentSeason(time.Now())
-			return WarmSeasonArgs{Season: cur, Year: year}, nil
-		},
-		nil, // PeriodicJobOpts — defaults are fine; RunOnStart=false
-		// because main.go handles the boot pair via EnqueueWarmSeasonNow.
-	)
-}

--- a/go-api/internal/queue/warm_season_test.go
+++ b/go-api/internal/queue/warm_season_test.go
@@ -674,18 +674,6 @@ func TestNewWarmSeasonWorker_NilEnqueuer_DefaultsToNoop(t *testing.T) {
 	require.NoError(t, w.Work(context.Background(), makeWorkJob("FALL", 2026)))
 }
 
-// TestPeriodicWarmSeasonJob_NotNil is a smoke check that the factory
-// returns a usable *river.PeriodicJob.  The schedule/constructor
-// internals are river's responsibility (not the worker's contract);
-// we only own returning a non-nil value with a sensible Kind on its
-// emitted Args.
-func TestPeriodicWarmSeasonJob_NotNil(t *testing.T) {
-	t.Parallel()
-
-	pj := PeriodicWarmSeasonJob()
-	require.NotNil(t, pj, "factory must return a non-nil PeriodicJob")
-}
-
 // ---------------------------------------------------------------------------
 // The inferred-episode-count seed
 // ---------------------------------------------------------------------------

--- a/go-api/test/integration/queue_registry_test.go
+++ b/go-api/test/integration/queue_registry_test.go
@@ -1,0 +1,584 @@
+//go:build integration
+
+// queue_registry_test.go — the gate on the background-job configuration.
+//
+// # WHY THIS IS AN INTEGRATION TEST AND NOT A STARTUP CHECK
+//
+// The obvious fix for the 2026-09-08 stall is a boot-time assertion that
+// every UniqueOpts.ByState contains the four states river requires.  That was
+// the plan, and it is wrong twice.
+//
+// It would misfire.  DescriptionBackfillArgs and DescriptionLlmBackfillArgs
+// use UniqueOpts{ByArgs: true} with a nil ByState on purpose, and river's
+// validate() returns early on nil — a hand-written gate would reject two
+// kinds river is perfectly happy with.
+//
+// And it would rot into the exact failure it was written to prevent.  Those
+// four states are river's PRIVATE constant (insert_opts.go requiredV3states);
+// rivertype exports neither it nor anything equal to it.  A hand-copied
+// version reports green while river reports an error the moment river adds a
+// fifth — an ERROR line, no other symptom, and now a reassuring test on top
+// of it.
+//
+// So the gate runs river's own validate(), against a real Postgres, by
+// booting the production configuration and asserting the rows actually land.
+package integration
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/obs"
+	"github.com/lawrenceli0228/animego/go-api/internal/queue"
+	"github.com/lawrenceli0228/animego/go-api/internal/testutil"
+)
+
+// registryWaitTimeout bounds the poll for an expected river_job row.  Generous
+// because RunOnStart inserts happen inside the enqueuer's first tick, not
+// synchronously inside Start.
+const registryWaitTimeout = 20 * time.Second
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+// inertWorkers registers a do-nothing worker for every kind in the registry.
+//
+// The production bundle is deliberately NOT used here.  Those workers make
+// Bangumi, AniList, dandanplay and DeepSeek calls, and this test's job is to
+// prove the CONFIGURATION is valid — that the jobs are created — not to run
+// them.  TestQueueRegistry_ProductionWorkersCoverEveryKind covers the other
+// half: that a real worker exists for each kind.
+func inertWorkers() *river.Workers {
+	w := river.NewWorkers()
+	river.AddWorker(w, &inert[queue.BangumiV1Args]{})
+	river.AddWorker(w, &inert[queue.BangumiV2Args]{})
+	river.AddWorker(w, &inert[queue.BangumiV3Args]{})
+	river.AddWorker(w, &inert[queue.WarmSeasonArgs]{})
+	river.AddWorker(w, &inert[queue.OrphanScanArgs]{})
+	river.AddWorker(w, &inert[queue.DescriptionBackfillScanArgs]{})
+	river.AddWorker(w, &inert[queue.DescriptionBackfillArgs]{})
+	river.AddWorker(w, &inert[queue.DescriptionLlmBackfillScanArgs]{})
+	river.AddWorker(w, &inert[queue.DescriptionLlmBackfillArgs]{})
+	river.AddWorker(w, &inert[queue.EpisodesBgmScanArgs]{})
+	river.AddWorker(w, &inert[queue.EpisodesBgmArgs]{})
+	river.AddWorker(w, &inert[queue.EpisodeTitlesArgs]{})
+	river.AddWorker(w, &inert[queue.BindIdMapArgs]{})
+	river.AddWorker(w, &inert[queue.HantBackfillArgs]{})
+	river.AddWorker(w, &inert[queue.AnilistRatingsArgs]{})
+	river.AddWorker(w, &inert[queue.BangumiRatingsArgs]{})
+	return w
+}
+
+// inert satisfies river.Worker for any Args type and does nothing.
+type inert[T river.JobArgs] struct {
+	river.WorkerDefaults[T]
+}
+
+func (w *inert[T]) Work(context.Context, *river.Job[T]) error { return nil }
+
+// capturedErrors records the ERROR-level slog lines a client emitted, through
+// the same forwarding handler production uses.  river reports background
+// failures ONLY through its Logger, so this is the only place a test can see
+// them.
+type capturedErrors struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (c *capturedErrors) CaptureEvent(event *sentry.Event) *sentry.EventID {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, event)
+	id := sentry.EventID("test")
+	return &id
+}
+
+func (c *capturedErrors) messages() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.events))
+	for _, e := range c.events {
+		out = append(out, e.Message)
+	}
+	return out
+}
+
+// newCapturingLogger returns a logger shaped exactly like production's: JSON
+// to a discard sink, wrapped by the Sentry forwarder.
+func newCapturingLogger(t *testing.T) (*slog.Logger, *capturedErrors) {
+	t.Helper()
+
+	cap := &capturedErrors{}
+	base := slog.NewJSONHandler(testWriter{t}, &slog.HandlerOptions{Level: slog.LevelInfo})
+	return slog.New(obs.NewSentryErrorHandler(base, obs.Options{
+		Capturer: cap,
+		// No cap: a test must see every error, not the first twenty.
+		RateBurst: -1,
+	})), cap
+}
+
+// testWriter routes river's log output into the test's own log, so a failure
+// carries the river lines that explain it.
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) {
+	w.t.Logf("river: %s", p)
+	return len(p), nil
+}
+
+// countJobs returns how many river_job rows exist for a kind, in any state.
+//
+// Counting the table rather than subscribing to completion events on purpose:
+// what this test asserts is that the job was CREATED.  Whether it then ran is
+// a different question, and a job that fails still leaves the row that proves
+// the enqueuer worked.
+func countJobs(t *testing.T, ctx context.Context, pool *pgxpool.Pool, kind string) int {
+	t.Helper()
+
+	var n int
+	err := pool.QueryRow(ctx, `SELECT count(*) FROM river_job WHERE kind = $1`, kind).Scan(&n)
+	require.NoError(t, err, "count river_job for kind %q", kind)
+	return n
+}
+
+// waitForJob polls until a row of the given kind exists, or the timeout
+// elapses.  Returns whether it appeared.
+func waitForJob(t *testing.T, ctx context.Context, pool *pgxpool.Pool, kind string, timeout time.Duration) bool {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if countJobs(t, ctx, pool, kind) > 0 {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+	return countJobs(t, ctx, pool, kind) > 0
+}
+
+// waitForAllJobs polls until every kind has a row, and returns the kinds that
+// never appeared.  One shared deadline, so N broken kinds cost one timeout.
+func waitForAllJobs(t *testing.T, ctx context.Context, pool *pgxpool.Pool, kinds []string, timeout time.Duration) []string {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		var missing []string
+		for _, kind := range kinds {
+			if countJobs(t, ctx, pool, kind) == 0 {
+				missing = append(missing, kind)
+			}
+		}
+		if len(missing) == 0 || time.Now().After(deadline) {
+			return missing
+		}
+		select {
+		case <-ctx.Done():
+			return missing
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// startClient boots and starts a client, registering a bounded shutdown.
+func startClient(t *testing.T, ctx context.Context, pool *pgxpool.Pool, cfg queue.Config) *river.Client[pgx.Tx] {
+	t.Helper()
+
+	c, err := queue.Boot(pool, cfg)
+	require.NoError(t, err, "queue.Boot must accept the configuration")
+	require.NoError(t, c.Start(ctx), "client.Start")
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = c.Stop(stopCtx)
+	})
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// The production configuration boots
+// ---------------------------------------------------------------------------
+
+// TestQueueRegistry_ProductionConfigStartsAndEnqueues is the end-to-end
+// reproduction of the 2026-09-08 incident, run forwards.
+//
+// It boots river with the queue map and periodic schedule the server ships,
+// against a real Postgres, and asserts that every kind declared RunOnStart
+// actually produces a river_job row.  On 2026-09-08 two of them did not, and
+// the only evidence was one ERROR line.
+//
+// The assertion is per-kind rather than "some rows exist" deliberately:
+// UniqueOpts.validate fails for ONE kind at a time, so an aggregate count
+// would have passed on the night of the incident.
+func TestQueueRegistry_ProductionConfigStartsAndEnqueues(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	pool := testutil.NewWebPool(t, ctx, pgURIGlobal)
+	testutil.TruncateAll(t, ctx, pool)
+
+	logger, errs := newCapturingLogger(t)
+	reg := queue.Default()
+
+	startClient(t, ctx, pool, queue.Config{
+		Workers:      inertWorkers(),
+		Queues:       reg.QueueConfigs(),
+		PeriodicJobs: reg.PeriodicJobs(),
+		Logger:       logger,
+	})
+
+	var runOnStart []string
+	for _, e := range reg.Entries() {
+		if e.Periodic != nil && e.Periodic.RunOnStart {
+			runOnStart = append(runOnStart, e.Kind())
+		}
+	}
+	require.NotEmpty(t, runOnStart, "the registry must declare boot-fired sweeps")
+
+	// One deadline for the whole set rather than one each: a broken kind must
+	// cost the suite a single timeout, not one per kind.
+	missing := waitForAllJobs(t, ctx, pool, runOnStart, registryWaitTimeout)
+	assert.Empty(t, missing,
+		"these kinds declare RunOnStart but river never created a job for them — "+
+			"this is the 2026-09-08 failure shape: the service starts, serves "+
+			"traffic, and silently stops enqueueing a sweep")
+
+	// The other half of the same guarantee, and the one that would catch a
+	// kind this test does not know to look for: river must have nothing to
+	// complain about.  The capturer is wired exactly as production wires it.
+	assert.Empty(t, errs.messages(),
+		"river logged an ERROR while starting the production configuration")
+}
+
+// ---------------------------------------------------------------------------
+// The incident, reproduced
+// ---------------------------------------------------------------------------
+
+// brokenUniqueArgs carries the UniqueOpts that took production down: the set
+// river's validate() requires, minus `running`.
+//
+// This is the mutation as a FIXTURE rather than as a manual edit somebody has
+// to remember to run. It cannot rot the way a hand-copied list of required
+// states can, because it asserts the CONSEQUENCE (no row, one ERROR) rather
+// than the rule.
+type brokenUniqueArgs struct{}
+
+func (brokenUniqueArgs) Kind() string { return "registry_test_broken_unique" }
+
+func (brokenUniqueArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue: queue.RatingsQueueName,
+		UniqueOpts: river.UniqueOpts{
+			ByArgs: true,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRetryable,
+				// rivertype.JobStateRunning — the removal that caused it.
+				rivertype.JobStateScheduled,
+			},
+		},
+	}
+}
+
+// healthyUniqueArgs is the same job with the state set put back, so the two
+// halves of this test differ in exactly one element.
+type healthyUniqueArgs struct{}
+
+func (healthyUniqueArgs) Kind() string { return "registry_test_healthy_unique" }
+
+func (healthyUniqueArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{
+		Queue: queue.RatingsQueueName,
+		UniqueOpts: river.UniqueOpts{
+			ByArgs: true,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRetryable,
+				rivertype.JobStateRunning,
+				rivertype.JobStateScheduled,
+			},
+		},
+	}
+}
+
+// TestQueueRegistry_MissingRunningStateStopsEnqueueingSilently is the
+// regression test for the incident itself.
+//
+// Two periodic jobs, identical but for one JobState. The healthy one produces
+// a river_job row. The broken one produces no row at all — and, before the
+// Sentry forwarding, no other signal either.
+//
+// Both halves matter. Without the healthy control the test would pass if the
+// harness simply never enqueued anything, which is the failure mode it is
+// meant to detect.
+func TestQueueRegistry_MissingRunningStateStopsEnqueueingSilently(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	pool := testutil.NewWebPool(t, ctx, pgURIGlobal)
+	testutil.TruncateAll(t, ctx, pool)
+
+	logger, errs := newCapturingLogger(t)
+
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &inert[brokenUniqueArgs]{})
+	river.AddWorker(workers, &inert[healthyUniqueArgs]{})
+
+	startClient(t, ctx, pool, queue.Config{
+		Workers: workers,
+		Queues: map[string]river.QueueConfig{
+			queue.RatingsQueueName: {MaxWorkers: 1},
+		},
+		PeriodicJobs: []*river.PeriodicJob{
+			river.NewPeriodicJob(
+				river.PeriodicInterval(time.Hour),
+				func() (river.JobArgs, *river.InsertOpts) { return brokenUniqueArgs{}, nil },
+				&river.PeriodicJobOpts{RunOnStart: true},
+			),
+			river.NewPeriodicJob(
+				river.PeriodicInterval(time.Hour),
+				func() (river.JobArgs, *river.InsertOpts) { return healthyUniqueArgs{}, nil },
+				&river.PeriodicJobOpts{RunOnStart: true},
+			),
+		},
+		Logger: logger,
+	})
+
+	// The control: a complete state set enqueues.
+	require.True(t, waitForJob(t, ctx, pool, healthyUniqueArgs{}.Kind(), registryWaitTimeout),
+		"the healthy control never enqueued — the harness itself is broken, and "+
+			"the negative assertion below would be meaningless")
+
+	// The incident: one missing state and the job simply does not exist.
+	assert.Zero(t, countJobs(t, ctx, pool, brokenUniqueArgs{}.Kind()),
+		"a UniqueOpts.ByState missing `running` must not enqueue — if this row "+
+			"exists, river relaxed its requirement and the incident's premise changed")
+
+	// And it is not silent any more.  This is the half that was missing on the
+	// night: river reported it, at ERROR, to a logger nothing was reading.
+	assert.Contains(t, errs.messages(),
+		"maintenance.PeriodicJobEnqueuer: Internal error generating periodic job",
+		"the failure must reach the Sentry forwarder; river reports it nowhere else")
+}
+
+// ---------------------------------------------------------------------------
+// The two other ways a kind can silently not run
+// ---------------------------------------------------------------------------
+
+// undeclaredQueueArgs routes to a queue no Config.Queues entry declares.
+type undeclaredQueueArgs struct{}
+
+func (undeclaredQueueArgs) Kind() string { return "registry_test_undeclared_queue" }
+func (undeclaredQueueArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{Queue: "registry_test_no_such_queue"}
+}
+
+// TestQueueRegistry_UndeclaredQueueNeverRuns records what river actually does
+// with a job routed to a queue that has no worker pool: the row is created and
+// then nothing ever fetches it.
+//
+// This is why Registry.validate rejects the configuration instead of leaving
+// it to river.  There is no error to observe here — not a log line, not a
+// failed insert — only a row that stays `available` forever.  It is the
+// quietest failure in this file, and the only defence against it is that the
+// registry refuses to be built that way.
+func TestQueueRegistry_UndeclaredQueueNeverRuns(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	pool := testutil.NewWebPool(t, ctx, pgURIGlobal)
+	testutil.TruncateAll(t, ctx, pool)
+
+	logger, errs := newCapturingLogger(t)
+
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &inert[undeclaredQueueArgs]{})
+
+	c := startClient(t, ctx, pool, queue.Config{
+		Workers: workers,
+		Queues:  map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 1}},
+		Logger:  logger,
+	})
+
+	_, err := c.Insert(ctx, undeclaredQueueArgs{}, nil)
+	require.NoError(t, err,
+		"river accepts the insert — the queue is not validated against Config.Queues")
+
+	require.True(t, waitForJob(t, ctx, pool, undeclaredQueueArgs{}.Kind(), registryWaitTimeout))
+
+	// Give any producer that might pick it up a fair chance to do so.
+	time.Sleep(2 * time.Second)
+
+	var state string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT state FROM river_job WHERE kind = $1`, undeclaredQueueArgs{}.Kind(),
+	).Scan(&state))
+	assert.Equal(t, "available", state,
+		"a job on an undeclared queue is never fetched; it sits available forever")
+	assert.Empty(t, errs.messages(),
+		"and river says nothing about it — which is exactly why the registry "+
+			"cross-checks queue names at construction instead")
+}
+
+// unregisteredArgs has no worker registered for its kind.
+type unregisteredArgs struct{}
+
+func (unregisteredArgs) Kind() string { return "registry_test_unregistered" }
+func (unregisteredArgs) InsertOpts() river.InsertOpts {
+	return river.InsertOpts{Queue: river.QueueDefault}
+}
+
+// TestQueueRegistry_UnregisteredKindIsRejectedAtInsert pins the one failure in
+// this family river catches loudly: a kind with no worker.
+//
+// Worth knowing which path this covers.  client.Insert validates against the
+// workers bundle and returns UnknownJobKindError.  The PERIODIC path does not
+// — insertParamsFromConfigArgsAndOptions never consults the bundle — so a
+// scheduled kind with no worker is inserted happily and only fails when a
+// producer tries to run it.  That is why worker coverage is asserted
+// separately against the production bundle rather than trusted to river.
+func TestQueueRegistry_UnregisteredKindIsRejectedAtInsert(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	pool := testutil.NewWebPool(t, ctx, pgURIGlobal)
+	testutil.TruncateAll(t, ctx, pool)
+
+	logger, _ := newCapturingLogger(t)
+
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &inert[queue.BangumiV1Args]{})
+
+	c := startClient(t, ctx, pool, queue.Config{
+		Workers: workers,
+		Queues:  map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 1}},
+		Logger:  logger,
+	})
+
+	_, err := c.Insert(ctx, unregisteredArgs{}, nil)
+	require.Error(t, err, "river must refuse a kind it has no worker for")
+
+	var unknown *river.UnknownJobKindError
+	require.ErrorAs(t, err, &unknown)
+	assert.Equal(t, unregisteredArgs{}.Kind(), unknown.Kind)
+	assert.Zero(t, countJobs(t, ctx, pool, unregisteredArgs{}.Kind()),
+		"a refused insert must leave no row")
+}
+
+// ---------------------------------------------------------------------------
+// The accepted tradeoff
+// ---------------------------------------------------------------------------
+
+// TestQueueRegistry_OrphanRunningRowSuppressesTheNextEnqueue pins the cost the
+// production state sets knowingly pay, because it is the cost somebody will
+// try to remove again.
+//
+// A deploy kills the process without changing a row that says `running`.
+// river reclaims it only through its rescuer, an hour later by default, and
+// for that hour the corpse is indistinguishable from a live pass — so the next
+// boot's RunOnStart insert suppresses itself against it.  Measured on prod
+// 2026-09-08: both ratings sweeps sat in `running` for 59 minutes producing
+// nothing, which is also exactly what a caught-up sweep looks like.
+//
+// Taking `running` out of the state set is the obvious fix and it is the
+// change that caused the outage — see
+// TestQueueRegistry_MissingRunningStateStopsEnqueueingSilently, which is the
+// other half of this pair. The two together say: this window is real, and this
+// is not how you close it. TODOS.md carries what would.
+func TestQueueRegistry_OrphanRunningRowSuppressesTheNextEnqueue(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	pool := testutil.NewWebPool(t, ctx, pgURIGlobal)
+	testutil.TruncateAll(t, ctx, pool)
+
+	logger, errs := newCapturingLogger(t)
+
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &inert[healthyUniqueArgs]{})
+
+	// Boot once so the row exists, then leave it stranded in `running` the way
+	// a killed process does.
+	c := startClient(t, ctx, pool, queue.Config{
+		Workers:      workers,
+		Queues:       map[string]river.QueueConfig{queue.RatingsQueueName: {MaxWorkers: 1}},
+		PeriodicJobs: []*river.PeriodicJob{healthyPeriodicJob()},
+		Logger:       logger,
+	})
+	require.True(t, waitForJob(t, ctx, pool, healthyUniqueArgs{}.Kind(), registryWaitTimeout))
+
+	stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	require.NoError(t, c.Stop(stopCtx))
+	stopCancel()
+
+	// The corpse: exactly what `docker kill` mid-pass leaves behind.  Clearing
+	// finalized_at as well as setting the state is not cosmetic -- river's
+	// `finalized_or_finalized_at_null` CHECK rejects a non-terminal row that
+	// still carries one, so a half-written corpse would fail here rather than
+	// reproduce anything.
+	_, err := pool.Exec(ctx,
+		`UPDATE river_job
+		    SET state = 'running', attempted_at = now(), finalized_at = NULL
+		  WHERE kind = $1`,
+		healthyUniqueArgs{}.Kind())
+	require.NoError(t, err)
+	require.Equal(t, 1, countJobs(t, ctx, pool, healthyUniqueArgs{}.Kind()))
+
+	// Second boot, as a deploy would.
+	logger2, errs2 := newCapturingLogger(t)
+	startClient(t, ctx, pool, queue.Config{
+		// The same bundle: river's producer only ever fetches `available`
+		// rows, so a registered worker cannot reach the corpse.  An empty
+		// bundle is not an option -- river refuses to Start without one.
+		Workers: workers,
+		Queues:  map[string]river.QueueConfig{queue.RatingsQueueName: {MaxWorkers: 1}},
+		PeriodicJobs: []*river.PeriodicJob{
+			river.NewPeriodicJob(
+				river.PeriodicInterval(time.Hour),
+				func() (river.JobArgs, *river.InsertOpts) { return healthyUniqueArgs{}, nil },
+				&river.PeriodicJobOpts{RunOnStart: true},
+			),
+		},
+		Logger: logger2,
+	})
+
+	time.Sleep(4 * time.Second)
+
+	assert.Equal(t, 1, countJobs(t, ctx, pool, healthyUniqueArgs{}.Kind()),
+		"the orphaned `running` row suppresses the boot enqueue — this is the "+
+			"accepted one-hour window, not a bug to fix by dropping `running`")
+
+	// And critically: this suppression is NOT reported. That is what made the
+	// window invisible on prod, and it is why the fix belongs elsewhere.
+	assert.Empty(t, errs.messages())
+	assert.Empty(t, errs2.messages(),
+		"a suppressed enqueue is silent by design in river; nothing here can "+
+			"tell it apart from a caught-up sweep")
+}
+
+// healthyPeriodicJob is the schedule used by both halves of the orphan test.
+func healthyPeriodicJob() *river.PeriodicJob {
+	return river.NewPeriodicJob(
+		river.PeriodicInterval(time.Hour),
+		func() (river.JobArgs, *river.InsertOpts) { return healthyUniqueArgs{}, nil },
+		&river.PeriodicJobOpts{RunOnStart: true},
+	)
+}

--- a/go-api/test/integration/queue_smoke_test.go
+++ b/go-api/test/integration/queue_smoke_test.go
@@ -77,9 +77,11 @@ func (noHitBangumi) Characters(_ context.Context, _ int) ([]bangumi.Character, e
 // Episodes joined BangumiV2Client via BangumiEpisodesFetcher after this stub
 // was written, and the stub was never updated -- which stopped the whole
 // `integration` package from compiling.  Nothing noticed because these tests
-// are behind a build tag and no CI job passes `-tags=integration`, so the
-// suite has been silently dead rather than failing.  Same no-hit shape as its
-// three siblings above.
+// are behind a build tag that, at the time, no CI job passed.
+//
+// That is no longer true: unit-tests.yml runs `go vet -tags=integration ./...`
+// and then the tagged suite itself, so this file compiles and runs on every
+// PR.  Same no-hit shape as its three siblings above.
 func (noHitBangumi) Episodes(_ context.Context, _ int) (*bangumi.EpisodesResponse, error) {
 	return nil, bangumi.ErrNotFound
 }
@@ -196,8 +198,8 @@ func (noRowV12DB) GetTitleChineseByAnilistIDs(_ context.Context, _ []int32) ([]d
 
 // The four below joined V12DB after this stub was written and were never
 // added, which is what stopped the `integration` package compiling.  See the
-// note on noHitBangumi.Episodes: the package is behind a build tag that no CI
-// job passes, so the suite went quiet rather than red.
+// note on noHitBangumi.Episodes: the build tag went ungated for two months, so
+// the suite went quiet rather than red.  unit-tests.yml gates it now.
 //
 // ListUnenrichedAnilistIDs satisfies queue.OrphanReader.  An empty slice ends
 // the orphan scan's paging loop on its first iteration, so the worker reaches


### PR DESCRIPTION
Implements the five tasks from the 2026-09-08 `/plan-eng-review` of go-api's background-job configuration. Baseline `62e1258`.

## Why

The starting point was not "this code is repetitive" — it was an outage with no symptoms.

On 2026-09-08 a change removed `rivertype.JobStateRunning` from one of four byte-identical `*UniqueStates` slices. The motive was sound: a deploy kills the process and leaves a job row saying `running` forever, and river's `UniqueOpts` treats that corpse as "already in flight", so the next boot's enqueue suppresses itself against it until the rescuer reclaims it an hour later.

But `UniqueOpts.validate` **requires** that state. Without it `PeriodicJobEnqueuer` fails for the whole kind, and reports it like this and nowhere else:

```
ERROR maintenance.PeriodicJobEnqueuer: Internal error generating periodic job
error: "UniqueOpts.ByState must contain all required states, missing: running"
```

The service started, served traffic, and stopped enqueueing that sweep. A one-hour self-healing suppression became a permanent one.

Three things should have caught it. The constraint was written in the same file, and quoted in that commit's own message. The test asserted the set had **four elements** — and the broken set also had four, because it kept the optional `retryable` and dropped the required `running`; counting is not the property, membership is. And the mutation check did a text substitution on a state sequence that appears identically in an earlier block, so it never touched the file it meant to.

## What this changes

**`internal/obs` — slog ERROR → Sentry.** Ordered first because the incident was not "no validation", it was "validation failed and nobody knew". `SentryErrorHandler` wraps any slog handler: stdout stays byte-identical, ERROR and above additionally reach Sentry. That covers every river background failure at once — the enqueuer swallows insert conflicts, transaction errors and constructor errors the same way, and none are reachable by a static gate.

The hub is resolved per record (preferring `GetHubFromContext`, so an error logged inside an HTTP handler keeps the middleware's request tags). `Enabled()` defers entirely to the wrapped handler — widening it here would put a class of line in Sentry and nowhere else, uncorrelatable against the container log. Forwarding is capped at 20/minute, and the first event after suppression carries the count it stood in for: a rate limiter that turns a storm into silence would reproduce this same incident one level up.

**`internal/queue` — the registry.** Queue names lived in `control.go`, worker counts in a 90-line map literal in `main.go`, schedules in ten `Periodic<Name>Job` constructors differing only in an interval and a bool. Adding a sweep meant touching all three and nothing noticed when you touched two.

`registry.go` + `registry_default.go` own all of it and validate at construction: a kind on an undeclared queue, a declared queue nothing rides, a duplicate kind, a worker count of zero or one with no recorded reason, a non-positive interval, and a kind whose declared queue disagrees with its own `InsertOpts()`.

That last one is the boundary. The registry **reads** `InsertOpts()` and checks it; it never becomes the source of routing. river calls `InsertOpts()` on the Args type, and one of those calls happens inside `bgm_bind_idmap.go`'s bind-and-enqueue transaction — turning a static method into a map lookup would put a panic surface on that path for nothing.

Worker counts are a type, not an int. Four are `1` because a second worker breaks something (a shared upstream token bucket extra workers only queue on; a check-then-update race a single slot makes unreachable); one is `4` because DeepSeek round-trips genuinely parallelise. `FixedConcurrency` vs `TunableConcurrency` carries that difference and each requires prose; `WithConcurrency` refuses a Fixed queue and quotes the reason back.

**`internal/admin` — pause generalised.** Eight queues were each given their own worker pool precisely so they could be stopped independently, and exactly one had a way to do it. `PauseQueue` / `ResumeQueue` / `QueuePaused` / `StatusAll` take a name validated against the registry; `PauseV3` and friends become thin aliases so existing callers are untouched.

The constraint `control.go` has carried since the surface was V3-only still holds — only its implementation moved. The whitelist is the registry minus `river.QueueDefault`, which is the queue that constraint was really about: `default` is not one workload but four (V1, V2, warm_season, orphan_scan), so pausing it freezes the enrichment a page load is waiting on. river's `"*"` falls to the same check. A refused name is a **400**, not a 500 — the operator asked for something that does not exist, which is a different thing from river failing.

Two fixes alongside. `PauseHeal`/`ResumeHeal` returned `200 {"paused":true}` with a nil `QueueCtrl`, having paused nothing; the comment called it "Express's in-memory bool flip semantics", which was true and beside the point — in Express the flag **was** the mechanism. Here it is river's, so an operator pressing the three-in-the-morning lever got a confident success and a queue that kept running. Now 503. And `Status` only ever reported `v3Paused`, so seven queues could be stopped but not seen; `GET /api/admin/queues` reports them all.

## Why the gate is an integration test, not a startup check

The obvious guard is a boot-time assertion that every `UniqueOpts.ByState` holds the four required states. It is wrong twice, and both were verified against river v0.37.1's source:

- It would **misfire**. `DescriptionBackfillArgs` and `DescriptionLlmBackfillArgs` use `UniqueOpts{ByArgs: true}` with a nil `ByState` on purpose, and `validate()` returns early on nil (`insert_opts.go:271`). A hand-written gate would reject two kinds river is perfectly happy with.
- It would **rot into the failure it prevents**. Those four states are river's private `requiredV3states` (`insert_opts.go:244`); `rivertype` exports nothing equal to it. A hand-copied list reports green while river reports an error the moment river adds a fifth — the same shape as this incident, now with a reassuring test on top.

So `test/integration/queue_registry_test.go` boots the shipped configuration against a real Postgres and asserts the rows land, running river's own `validate()`. Per-kind, not in aggregate: `UniqueOpts` fails for one kind at a time, so a total count would have passed on the night.

It also pins the three other ways a kind can quietly not run, each verified against a live database rather than assumed:

| Failure | What river actually does |
|---|---|
| `ByState` missing `running` | No row, one ERROR. Mutation is a **fixture** with a healthy control differing by one element, so it cannot rot the way a copied constant can. |
| Undeclared queue | Insert succeeds, row sits `available` forever, river says **nothing**. The quietest failure here — the only defence is that the registry refuses to be built that way. |
| Unregistered kind | Refused at `Insert` with `UnknownJobKindError` — but only on that path. The periodic path never consults the workers bundle. |

And it pins the cost the production state sets knowingly pay: an orphaned `running` row left by a killed process suppresses the next boot's enqueue for the hour the rescuer takes. Paired with the test above, the two say: this window is real, and removing `running` is not how to close it.

## Verification

- `go build`, `go vet`, `go vet -tags=integration`, the unit suite and the tagged integration suite are green.
- **The acceptance criterion**: reverting `62e1258` (dropping `running` from `ratingsUniqueStates`) turns the integration suite red, naming both `anilist_ratings` and `bangumi_ratings`, and the incident's exact ERROR line is captured by the Sentry forwarder.
- **42 mutations, 42 red suites.** Six initially survived and were fixes to the *tests*, not evidence the code was right: a sibling-isolation test whose parent slice had no spare capacity, so a shared backing array could never alias; a lazy-value test covering one of two resolution loops; a mutation that did not disable uniqueness at all because `ByState` alone still keys it; and one that failed to compile rather than failing a test (removing the forwarder orphaned its import), redone as a compiling regression.

## Coverage

`internal/obs` 93.5% · `internal/queue` registry+control **100% per-function** · `internal/admin` 87.5%. `cmd/server` stays low in aggregate because `main()` is one large uncovered function; the four extracted pieces are 100%.

A coverage pass found the gap that mattered most, and it was the on-theme one: everything was tested except whether `main()` actually **applies** the configuration. Most of `main()` fails loudly when wrong — a bad DSN exits, an unmounted route 404s, a missing handler is a compile error. Two spots do not, and both reproduce this incident's shape: drop the Sentry forwarder and stdout looks identical while Sentry goes deaf; drop `Queues` or `PeriodicJobs` and `queue.Boot` falls back to `{default: 1}`, so eight queues get no producer and no sweep is ever scheduled. Both are now extracted and tested, the logger through the real handler chain rather than by type assertion — a handler inserted between the two would satisfy a type check while swallowing the record.

## Test plan

- [ ] CI green (`unit-tests.yml` runs `go vet -tags=integration ./...` then the tagged suite)
- [ ] After deploy, `curl /version.json` to confirm which commit is live
- [ ] Confirm river logs no ERROR on boot; every hourly sweep should land a `river_job` row within a minute of start
- [ ] `GET /api/admin/queues` returns eight queues with their pause flags
- [ ] `POST /api/admin/queues/ratings/pause` pauses only that queue; `POST /api/admin/queues/default/pause` returns 400
- [ ] Deliberately trigger one ERROR and confirm it reaches Sentry (the DSN and init were already in place; only the forwarding is new)

## Not in scope

- Removing the one-hour orphan window. Needs dropping `UniqueOpts` for `MaxWorkers: 1` plus the read stamp — recorded in TODOS.md, and the test above pins the current cost so it cannot be "fixed" by dropping `running` again.
- The `anime_cache.bgm_id` unique index. This branch's cross-model review argued `bgm_bind`'s `MaxWorkers: 1` states a correctness invariant that out-of-process CLI writers break — true, and half right. The sharper version was already in TODOS.md: the invariant is not one `--apply` flag from being false, it has been false 541 times, some of them legitimately (Bangumi sometimes covers with one subject what AniList splits into two seasons). The reason string is corrected to claim only what the slot buys; the migration is blocked on adjudicating those rows, not on writing it.
- Mounting-level tests for the three new admin routes. Handler behaviour is covered; an unmounted route is a loud 404 on first use, not a silent failure.
