### PR TITLE
fix(http): give each API client its own transport instead of the global one

### DIFF
--- a/go-api/internal/anilist/client.go
+++ b/go-api/internal/anilist/client.go
@@ -40,6 +40,8 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 )
 
 // ---------------------------------------------------------------------------
@@ -264,7 +266,7 @@ func WithSleep(f func(context.Context, time.Duration) error) Option {
 func NewClient(opts ...Option) *Client {
 	c := &Client{
 		endpoint:        DefaultEndpoint,
-		http:            &http.Client{Timeout: httpTimeout},
+		http:            &http.Client{Timeout: httpTimeout, Transport: httpx.NewTransport()},
 		limiter:         rate.NewLimiter(rate.Every(minInterval), 1),
 		sleep:           defaultSleep,
 		breakerCooldown: breakerCooldown,

--- a/go-api/internal/anilist/transport_test.go
+++ b/go-api/internal/anilist/transport_test.go
@@ -1,0 +1,39 @@
+package anilist
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientDoesNotShareTheDefaultTransport pins that NewClient() gives its
+// client a private connection pool.
+//
+// This asserts a structural fact rather than a behaviour, which is unusual
+// and deliberate.  The behaviour it protects is a race: any httptest server
+// in this process, on Close(), calls CloseIdleConnections on
+// http.DefaultTransport (net/http/httptest/server.go), so a client sharing it
+// can have a pooled connection closed out from under an in-flight request by
+// an unrelated parallel test.  It surfaces as:
+//
+//	net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
+//
+// The window — connection checked out of the pool, request not yet finished —
+// is narrow enough that ~200 local attempts failed to reproduce it, so there
+// is no honest behavioural test to write.  What can be pinned is the property
+// that makes the race impossible, and reverting the fix turns this red.
+func TestClientDoesNotShareTheDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	c := NewClient()
+
+	transport := c.http.Transport
+	require.NotNil(t, transport,
+		"a nil Transport means net/http falls back to the shared "+
+			"http.DefaultTransport, which is the thing this guards against")
+	assert.NotSame(t, http.DefaultTransport, transport,
+		"this client shares the process-wide connection pool, so any httptest "+
+			"server's Close() can kill its in-flight requests")
+}

--- a/go-api/internal/bangumi/client.go
+++ b/go-api/internal/bangumi/client.go
@@ -45,6 +45,8 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 )
 
 // ---------------------------------------------------------------------------
@@ -152,7 +154,7 @@ func NewClient(opts ...Option) *Client {
 	c := &Client{
 		endpoint: DefaultEndpoint,
 		ua:       DefaultUA,
-		http:     &http.Client{Timeout: httpTimeout},
+		http:     &http.Client{Timeout: httpTimeout, Transport: httpx.NewTransport()},
 		limiter:  rate.NewLimiter(rate.Every(minInterval), 1),
 	}
 	for _, opt := range opts {

--- a/go-api/internal/bangumi/transport_test.go
+++ b/go-api/internal/bangumi/transport_test.go
@@ -1,0 +1,39 @@
+package bangumi
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientDoesNotShareTheDefaultTransport pins that NewClient() gives its
+// client a private connection pool.
+//
+// This asserts a structural fact rather than a behaviour, which is unusual
+// and deliberate.  The behaviour it protects is a race: any httptest server
+// in this process, on Close(), calls CloseIdleConnections on
+// http.DefaultTransport (net/http/httptest/server.go), so a client sharing it
+// can have a pooled connection closed out from under an in-flight request by
+// an unrelated parallel test.  It surfaces as:
+//
+//	net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
+//
+// The window — connection checked out of the pool, request not yet finished —
+// is narrow enough that ~200 local attempts failed to reproduce it, so there
+// is no honest behavioural test to write.  What can be pinned is the property
+// that makes the race impossible, and reverting the fix turns this red.
+func TestClientDoesNotShareTheDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	c := NewClient()
+
+	transport := c.http.Transport
+	require.NotNil(t, transport,
+		"a nil Transport means net/http falls back to the shared "+
+			"http.DefaultTransport, which is the thing this guards against")
+	assert.NotSame(t, http.DefaultTransport, transport,
+		"this client shares the process-wide connection pool, so any httptest "+
+			"server's Close() can kill its in-flight requests")
+}

--- a/go-api/internal/dandanplay/client.go
+++ b/go-api/internal/dandanplay/client.go
@@ -54,6 +54,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/lawrenceli0228/animego/go-api/internal/cache"
+	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 )
 
 // Defaults — exposed as package vars so tests can swap them.
@@ -148,7 +149,7 @@ func WithCredentials(appID, appSecret string) Option {
 func NewClient(opts ...Option) (*Client, error) {
 	c := &Client{
 		endpoint: DefaultEndpoint,
-		http:     &http.Client{Timeout: httpTimeout},
+		http:     &http.Client{Timeout: httpTimeout, Transport: httpx.NewTransport()},
 		limiter:  rate.NewLimiter(rate.Every(minInterval), 1),
 	}
 	for _, opt := range opts {

--- a/go-api/internal/dandanplay/transport_test.go
+++ b/go-api/internal/dandanplay/transport_test.go
@@ -1,0 +1,40 @@
+package dandanplay
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientDoesNotShareTheDefaultTransport pins that NewClient() gives its
+// client a private connection pool.
+//
+// This asserts a structural fact rather than a behaviour, which is unusual
+// and deliberate.  The behaviour it protects is a race: any httptest server
+// in this process, on Close(), calls CloseIdleConnections on
+// http.DefaultTransport (net/http/httptest/server.go), so a client sharing it
+// can have a pooled connection closed out from under an in-flight request by
+// an unrelated parallel test.  It surfaces as:
+//
+//	net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
+//
+// The window — connection checked out of the pool, request not yet finished —
+// is narrow enough that ~200 local attempts failed to reproduce it, so there
+// is no honest behavioural test to write.  What can be pinned is the property
+// that makes the race impossible, and reverting the fix turns this red.
+func TestClientDoesNotShareTheDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewClient()
+	require.NoError(t, err)
+
+	transport := c.http.Transport
+	require.NotNil(t, transport,
+		"a nil Transport means net/http falls back to the shared "+
+			"http.DefaultTransport, which is the thing this guards against")
+	assert.NotSame(t, http.DefaultTransport, transport,
+		"this client shares the process-wide connection pool, so any httptest "+
+			"server's Close() can kill its in-flight requests")
+}

--- a/go-api/internal/deepseek/client.go
+++ b/go-api/internal/deepseek/client.go
@@ -27,6 +27,8 @@ import (
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 )
 
 // DefaultEndpoint is the production chat-completions URL.  Override with
@@ -209,7 +211,7 @@ func NewClient(apiKey string, opts ...Option) *Client {
 		endpoint: DefaultEndpoint,
 		model:    DefaultModel,
 		apiKey:   apiKey,
-		httpc:    &http.Client{Timeout: httpTimeout},
+		httpc:    &http.Client{Timeout: httpTimeout, Transport: httpx.NewTransport()},
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/go-api/internal/deepseek/transport_test.go
+++ b/go-api/internal/deepseek/transport_test.go
@@ -1,0 +1,39 @@
+package deepseek
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientDoesNotShareTheDefaultTransport pins that NewClient gives its
+// client a private connection pool.
+//
+// This asserts a structural fact rather than a behaviour, which is unusual
+// and deliberate.  The behaviour it protects is a race: any httptest server
+// in this process, on Close(), calls CloseIdleConnections on
+// http.DefaultTransport (net/http/httptest/server.go), so a client sharing it
+// can have a pooled connection closed out from under an in-flight request by
+// an unrelated parallel test.  It surfaces as:
+//
+//	net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
+//
+// The window — connection checked out of the pool, request not yet finished —
+// is narrow enough that ~200 local attempts failed to reproduce it, so there
+// is no honest behavioural test to write.  What can be pinned is the property
+// that makes the race impossible, and reverting the fix turns this red.
+func TestClientDoesNotShareTheDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	c := NewClient("test-key")
+
+	transport := c.httpc.Transport
+	require.NotNil(t, transport,
+		"a nil Transport means net/http falls back to the shared "+
+			"http.DefaultTransport, which is the thing this guards against")
+	assert.NotSame(t, http.DefaultTransport, transport,
+		"this client shares the process-wide connection pool, so any httptest "+
+			"server's Close() can kill its in-flight requests")
+}

--- a/go-api/internal/httpx/transport.go
+++ b/go-api/internal/httpx/transport.go
@@ -1,0 +1,55 @@
+// transport.go — outbound HTTP plumbing.
+//
+// The rest of this package shapes RESPONSES we send.  This file is the one
+// piece of client-side plumbing here, and it exists because the alternative
+// was the same subtle three lines, with the same paragraph of explanation,
+// copied into five packages.
+package httpx
+
+import "net/http"
+
+// NewTransport returns a private *http.Transport carrying the standard
+// library's defaults.
+//
+// # WHY THIS IS NOT JUST http.DefaultTransport
+//
+// An *http.Client with a nil Transport uses http.DefaultTransport, which is
+// one object — and one connection pool — shared by the whole process.  That
+// is usually harmless in production and actively hostile under test, because
+// the standard library reaches into it from a place nobody expects
+// (net/http/httptest/server.go, in Server.Close):
+//
+//	// Not part of httptest.Server's correctness, but assume most
+//	// users of httptest.Server will be using the standard
+//	// transport, so help them out and close any idle connections for them.
+//	if t, ok := http.DefaultTransport.(closeIdleTransport); ok {
+//		t.CloseIdleConnections()
+//	}
+//
+// So ANY httptest server shutting down closes idle connections belonging to
+// every client in the process.  In a package whose tests run t.Parallel()
+// against their own httptest servers, one test's deferred srv.Close() can
+// kill a sibling's in-flight request the moment it reuses a pooled
+// connection, and the request fails with:
+//
+//	net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
+//
+// Observed in CI on 2026-09-08 in internal/bangumi.  It is rare because the
+// window is narrow — a connection has to be checked out of the pool and not
+// yet finished — which also makes it very hard to reproduce on demand and
+// very easy to dismiss as noise when it blocks a merge.
+//
+// Cloning gives each client its own pool, so the shared value nobody in this
+// codebase asked for stops being a channel between unrelated tests.  In
+// production it costs nothing and buys per-upstream pool isolation.
+func NewTransport() *http.Transport {
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		return t.Clone()
+	}
+	// Unreachable with the standard library: http.DefaultTransport has been
+	// an *http.Transport in every Go release.  If something replaced it,
+	// keep the isolation this function exists for rather than handing back
+	// the shared value, and keep proxy support — the one default that
+	// matters outside a datacentre.
+	return &http.Transport{Proxy: http.ProxyFromEnvironment}
+}

--- a/go-api/internal/httpx/transport_test.go
+++ b/go-api/internal/httpx/transport_test.go
@@ -1,0 +1,54 @@
+package httpx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewTransport_IsNotTheSharedDefault is the property every caller depends
+// on: a pool of its own.
+//
+// Sharing http.DefaultTransport makes an unrelated package's httptest server
+// able to close this client's idle connections, because Server.Close() calls
+// CloseIdleConnections on the default transport process-wide
+// (net/http/httptest/server.go).
+func TestNewTransport_IsNotTheSharedDefault(t *testing.T) {
+	t.Parallel()
+
+	tr := NewTransport()
+	require.NotNil(t, tr)
+	assert.NotSame(t, http.DefaultTransport, tr,
+		"a client using the shared default can have its connections closed by "+
+			"any httptest server in the process")
+}
+
+// TestNewTransport_IsFreshEveryCall pins that two clients do not end up
+// sharing one pool with each other either.
+func TestNewTransport_IsFreshEveryCall(t *testing.T) {
+	t.Parallel()
+
+	assert.NotSame(t, NewTransport(), NewTransport())
+}
+
+// TestNewTransport_KeepsStandardDefaults pins that isolation did not cost the
+// settings the default transport carries.  Proxy is the one that matters
+// outside a datacentre; the timeouts are what stop a wedged upstream holding
+// a connection open indefinitely.
+func TestNewTransport_KeepsStandardDefaults(t *testing.T) {
+	t.Parallel()
+
+	std, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok, "http.DefaultTransport is no longer an *http.Transport — "+
+		"re-verify NewTransport's fallback branch")
+
+	tr := NewTransport()
+	assert.NotNil(t, tr.Proxy, "proxy support must survive the clone")
+	assert.Equal(t, std.TLSHandshakeTimeout, tr.TLSHandshakeTimeout)
+	assert.Equal(t, std.IdleConnTimeout, tr.IdleConnTimeout)
+	assert.Equal(t, std.ExpectContinueTimeout, tr.ExpectContinueTimeout)
+	assert.Equal(t, std.MaxIdleConns, tr.MaxIdleConns)
+	assert.Equal(t, std.ForceAttemptHTTP2, tr.ForceAttemptHTTP2)
+}

--- a/go-api/internal/torrents/aggregator.go
+++ b/go-api/internal/torrents/aggregator.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/lawrenceli0228/animego/go-api/internal/cache"
+	"github.com/lawrenceli0228/animego/go-api/internal/httpx"
 )
 
 // torrentCacheTTL is the per-query result TTL for a NON-EMPTY result.
@@ -268,7 +269,7 @@ func WithToshoFn(f fetchFn) Option {
 // here, but the error is surfaced for completeness).
 func New(opts ...Option) (*Aggregator, error) {
 	a := &Aggregator{
-		httpClient:    &http.Client{},
+		httpClient:    &http.Client{Transport: httpx.NewTransport()},
 		ownsCache:     true,
 		emptyCacheTTL: torrentEmptyCacheTTL,
 	}

--- a/go-api/internal/torrents/transport_test.go
+++ b/go-api/internal/torrents/transport_test.go
@@ -1,0 +1,40 @@
+package torrents
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientDoesNotShareTheDefaultTransport pins that New() gives its
+// client a private connection pool.
+//
+// This asserts a structural fact rather than a behaviour, which is unusual
+// and deliberate.  The behaviour it protects is a race: any httptest server
+// in this process, on Close(), calls CloseIdleConnections on
+// http.DefaultTransport (net/http/httptest/server.go), so a client sharing it
+// can have a pooled connection closed out from under an in-flight request by
+// an unrelated parallel test.  It surfaces as:
+//
+//	net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
+//
+// The window — connection checked out of the pool, request not yet finished —
+// is narrow enough that ~200 local attempts failed to reproduce it, so there
+// is no honest behavioural test to write.  What can be pinned is the property
+// that makes the race impossible, and reverting the fix turns this red.
+func TestClientDoesNotShareTheDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	a, err := New()
+	require.NoError(t, err)
+
+	transport := a.httpClient.Transport
+	require.NotNil(t, transport,
+		"a nil Transport means net/http falls back to the shared "+
+			"http.DefaultTransport, which is the thing this guards against")
+	assert.NotSame(t, http.DefaultTransport, transport,
+		"this client shares the process-wide connection pool, so any httptest "+
+			"server's Close() can kill its in-flight requests")
+}


### PR DESCRIPTION
Fixes the flake that failed CI on #177 in a package #177 does not touch.

## The failure

```
--- FAIL: TestClient_Subject_500_ErrUpstream
    expected *ErrUpstream, got *fmt.wrapError: bangumi: http do:
    Get "http://127.0.0.1:43273/v0/subjects/326":
    net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
```

Nothing in this repo calls `CloseIdleConnections`. The standard library does, from a place that is easy to miss — `net/http/httptest/server.go`, inside `Server.Close()`:

```go
// Not part of httptest.Server's correctness, but assume most
// users of httptest.Server will be using the standard
// transport, so help them out and close any idle connections for them.
if t, ok := http.DefaultTransport.(closeIdleTransport); ok {
    t.CloseIdleConnections()
}
```

All five API clients built `&http.Client{...}` with no `Transport`, and a nil `Transport` means `http.DefaultTransport` — **one object, one connection pool, shared by the whole process**. So any httptest server shutting down closes idle connections belonging to every client in the process. In a package whose tests run `t.Parallel()` against their own servers, one test's deferred `srv.Close()` can kill a sibling's request the moment it reuses a pooled connection.

## Scope: all five, not just bangumi

| package | httptest files | `t.Parallel()` calls | exposed |
|---|---|---|---|
| torrents | 7 | 128 | yes — the most |
| bangumi | 2 | 44 | yes — drew the short straw first |
| anilist | 3 | 30 | yes |
| deepseek | 2 | 11 | yes |
| dandanplay | 3 | 0 | not today |

`dandanplay` is safe only because its tests happen not to be parallel — luck rather than design, and one future line away from ending. All five get `httpx.NewTransport()`, because leaving one exception is harder to remember than treating them alike.

Production has no call site passing `WithHTTPClient`, so every one of these was on the shared transport at runtime too. There it costs nothing and buys per-upstream pool isolation.

`torrents` keeps its deliberately absent client `Timeout` — `aggregator.go:159` records that the per-source `ctx.WithTimeout` is the authoritative deadline, so that absence is a decision, not an oversight.

## Why the tests assert a structure rather than a behaviour

Unusual, and deliberate.

The behaviour these protect is a race whose window is narrow: a connection has to be checked out of the pool with its request not yet finished. I could not reproduce it — 60 full-package runs at `-parallel=16`, plus a targeted reproduction using slow handlers alongside a sibling churning `httptest.Server.Close()`, roughly 200 attempts, zero failures. That also explains why it is rare in CI and easy to dismiss as noise when it blocks a merge.

So there is no honest behavioural test to write, and "it stopped failing" would not be evidence either, since not failing is the normal outcome. What can be pinned is the property that makes the race impossible: the client does not share the global pool.

**Six mutations, six red suites:**

- reverting each of the five clients to a nil `Transport` turns that package red;
- making `httpx.NewTransport` return the shared value instead of a clone turns **both** its own tests and the client tests red — which is what proves the client tests depend on the helper actually cloning, rather than merely on `Transport` being non-nil.

## Test plan

- [ ] CI green
- [ ] No production behaviour change to verify by hand: the clone carries `http.DefaultTransport`'s settings, and `TestNewTransport_KeepsStandardDefaults` pins proxy support plus the four timeouts and the HTTP/2 flag against the live default

## Relationship to #177

Independent — zero file overlap (#177 is `internal/{obs,queue,admin}` + `cmd/server`). Either can merge first. #177's CI is green after a re-run; this is what makes that re-run unnecessary next time.
