### PR TITLE
fix(nginx): drop cross-origin isolation site-wide; the per-route exemption never applied to in-app navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## [未发布]
 
+### 预告片还是放不了：按路由去掉 COOP/COEP 在 SPA 里根本不成立，两个头整站删掉
+
+#174 让 nginx 在 `/anime/` 路由上不发 `Cross-Origin-Opener-Policy` / `Cross-Origin-Embedder-Policy`，验收时直接打开详情页是能播的。合并四天后用户报「还是不行」，截图里 DevTools 的 Issues 面板写着 *Specify a Cross-Origin Embedder Policy to stop this frame from being blocked*——那份文档**带着** COEP。
+
+★★ **COOP/COEP 是文档级属性，只在整页加载那一刻由响应头决定。** Next App Router 的站内跳转不发新文档请求：从首页点进 `/anime/185874`，URL 变了，文档还是首页那份，`crossOriginIsolated` 照样是 `true`，iframe 照样 `ERR_BLOCKED_BY_RESPONSE`。真 Chrome 两条路径各走一遍：硬刷新详情页 → `crossOriginIsolated=false`、能播；首页点进去 → **0 次文档请求**、`crossOriginIsolated=true`、被拦。#174 只救了搜索引擎落地和硬刷新，**上一次的验收恰好只验了这一种进入方式**。
+
+★★ **保留这两个头的理由也是假的。** `jassubOverlay.ts` 里那段「jassub 的 pthread worker 没有 SharedArrayBuffer 会静默挂死」是 4 月写播放器时的假设，从没测过。把线上那份 `public/jassub/` 的 wasm + worker.bundle.js 单独起个页面，带头/不带头各跑一次：`ready` 分别 233ms / **147ms**，ASS 都正常画出。jassub 2.5 的 emscripten loader 在非隔离页面把 pthread 池设成 0 走单线程，README 也明说会自动降级。**我们自己的闸门在 jassub 有机会降级之前就先退回 VTT 了**——所以 e2e 沙箱（`next dev`，从来没发过这两个头）里 ASS 字幕其实一直走的是 VTT 兜底，只是没人看。
+
+改法：三份 nginx 配置删掉 `map $uri` 和两条 `add_header`；`jassubOverlay.ts` 删掉 `crossOriginIsolated` 闸门。代价是 libass 在非隔离下单线程渲染，重特效 ASS 的 CPU 开销**没量**。
+
+守卫是一个 bun 测试，读 `nginx/*.conf` 断言没有 COOP/COEP 的 `add_header`，读 `jassubOverlay.ts` 断言没有 `crossOriginIsolated` 分支。放在 next-app 里而不是 e2e，因为头是 nginx 发的、`next.config.ts` 一个头都不设——对着 Next 应用本身写的任何测试在两种状态下都会绿。变异验证：把 COEP 那行加回 `default.conf`，1 fail。候选配置用线上 nginx 容器同一组挂载在 compose 网络上 `nginx -t` 过（线上那份作对照同样通过）。
+
+★ 部署注意：线上 `nginx/default.conf` 是 `default.p9.conf` 的拷贝（`diff` 逐字节相同），所以合并后要 `cp nginx/default.p9.conf nginx/default.conf && docker compose restart nginx`——restart 不是 reload，bind mount 换了 inode。
+
+
 ### 一个 httptest 服务器关闭，会掐断另一个测试正在飞的请求
 
 CI 在 #177 上挂了，挂在 #177 根本没碰的包里：`internal/bangumi` 报 `net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called`。

--- a/next-app/src/app/[lang]/player/_components/crossOriginIsolation.test.ts
+++ b/next-app/src/app/[lang]/player/_components/crossOriginIsolation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// The gate that keeps cross-origin isolation from coming back.
+//
+// It was here twice. nginx sent Cross-Origin-Opener-Policy + Cross-Origin-
+// Embedder-Policy site-wide so /player could use SharedArrayBuffer, and
+// jassubOverlay.ts refused to mount unless `crossOriginIsolated` was true.
+// Both rested on a claim that was never measured: that jassub's pthread
+// workers hang without SAB. They do not — the emscripten loader sizes the
+// pthread pool to zero when the page is not isolated and renders
+// single-threaded (measured 2026-09-12: `ready` in 147ms, ASS painted).
+//
+// What the headers did do was block the YouTube trailer iframe on the detail
+// page. A per-route exemption (#174) could not fix that: COOP/COEP are
+// document-level, and Next's client-side navigation never fetches a new
+// document, so a visitor clicking from the home page into /anime/<id> kept
+// the home page's isolation. Only a hard load ever saw the exemption.
+//
+// Two assertions, one per place the isolation used to live. The header check
+// reads the nginx configs the compose file mounts, because that is where the
+// policy is actually emitted — next.config.ts sets no headers at all, so a
+// test against the Next app alone would pass in either state.
+
+const REPO_ROOT = join(import.meta.dir, "../../../../../..");
+const NGINX_CONFS = ["default.conf", "default.legacy.conf", "default.p9.conf"];
+
+const ISOLATION_HEADER =
+  /^\s*add_header\s+Cross-Origin-(?:Opener|Embedder)-Policy\b/m;
+
+describe("cross-origin isolation stays off", () => {
+  for (const conf of NGINX_CONFS) {
+    test(`nginx/${conf} emits neither COOP nor COEP`, () => {
+      const text = readFileSync(join(REPO_ROOT, "nginx", conf), "utf8");
+      expect(text).not.toMatch(ISOLATION_HEADER);
+    });
+  }
+
+  test("jassubOverlay does not bail out on crossOriginIsolated", () => {
+    const src = readFileSync(join(import.meta.dir, "jassubOverlay.ts"), "utf8");
+    // The old gate was `if (... !crossOriginIsolated) { ...; return null; }`.
+    // Match the condition, not the comment that now explains its absence.
+    expect(src).not.toMatch(/if\s*\([^)]*crossOriginIsolated/);
+  });
+});

--- a/next-app/src/app/[lang]/player/_components/jassubOverlay.ts
+++ b/next-app/src/app/[lang]/player/_components/jassubOverlay.ts
@@ -163,15 +163,13 @@ export async function mountJassub({ video, subContent, fonts }) {
   }
   if (!JASSUB || !video || !subContent) return null;
 
-  // jassub spawns emscripten pthread workers that need SharedArrayBuffer.
-  // SAB is only exposed when the page is cross-origin isolated (COOP +
-  // COEP set by the server). Without it the worker init hangs silently,
-  // so we'd rather fall back to VTT than freeze and confuse the user.
-  if (typeof crossOriginIsolated !== 'undefined' && !crossOriginIsolated) {
-    // eslint-disable-next-line no-console
-    console.warn('[jassub] page is not cross-origin isolated (no SharedArrayBuffer access). Falling back to VTT plaintext. Server must send Cross-Origin-Opener-Policy: same-origin + Cross-Origin-Embedder-Policy: credentialless (or require-corp).');
-    return null;
-  }
+  // No crossOriginIsolated gate here. There used to be one, on the theory
+  // that jassub's pthread workers hang without SharedArrayBuffer. They do
+  // not: the emscripten loader sizes the pthread pool to zero when the page
+  // is not isolated and renders single-threaded (measured: `ready` in 147ms,
+  // ASS painted). The gate was returning null before jassub ever got the
+  // chance to degrade, and the COOP/COEP headers it demanded were what
+  // blocked the YouTube trailer iframe on the detail page.
 
   // Wait for video metadata before reading videoWidth. If we hand jassub a
   // video with width=0, its _getElementBoundingBox returns NaN dimensions

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,40 +1,3 @@
-# Cross-origin isolation is a per-route decision, not a site-wide one.
-#
-# COOP + COEP make a document cross-origin isolated, which is what exposes
-# SharedArrayBuffer.  jassub needs it on /player and /library to render ASS
-# subtitles -- without it jassubOverlay.ts warns and falls back to plain VTT.
-#
-# The same two headers block every cross-origin IFRAME whose own document does
-# not ENFORCE COEP.  `credentialless` relaxes that for subresources.  It does
-# not relax it for frames.  YouTube's embed sends
-# `Cross-Origin-Resource-Policy: cross-origin` but only
-# `Cross-Origin-Embedder-Policy-Report-Only`, and report-only does not count.
-#
-# Measured against production 2026-09-08 with a real browser: the detail page
-# reported crossOriginIsolated === true and the youtube-nocookie request failed
-# with net::ERR_BLOCKED_BY_RESPONSE.  Note the iframe's `onload` fired anyway --
-# on the error page -- so onload is not the signal here; the failed request is.
-#
-# The detail page is the only route that frames a trailer and the only one that
-# never wanted SharedArrayBuffer, so it is the route that opts out.  Everything
-# else keeps the isolation, including /player and /library which depend on it.
-#
-# nginx omits an add_header whose value is empty.  Even if that ever changed,
-# an empty COOP/COEP value is not a valid policy and browsers fall back to
-# unsafe-none -- the same outcome -- so this cannot fail closed.
-#
-# The prefix group is the locale segment: LANGS is ["zh", "en", "zh-Hant"] and
-# zh is served bare, so /anime/, /en/anime/ and /zh-Hant/anime/ are one route.
-map $uri $coop_policy {
-    default                          "same-origin";
-    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
-}
-
-map $uri $coep_policy {
-    default                          "credentialless";
-    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
-}
-
 upstream app {
     server app:5001;
 }
@@ -415,8 +378,8 @@ server {
     }
 
     # /jassub/* is the WASM asset path under next-app/public/jassub/.
-    # Routed through Next so its standard cache headers + COOP/COEP
-    # apply. nginx-level caching could be tightened post-deploy.
+    # Routed through Next so its standard cache headers apply.
+    # nginx-level caching could be tightened post-deploy.
     location ^~ /jassub/ {
         proxy_pass http://next_app;
         proxy_intercept_errors on;
@@ -465,13 +428,18 @@ server {
     add_header X-Frame-Options DENY always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-    # Player /library route uses jassub (libass-wasm) for ASS subtitles.
-    # jassub spawns emscripten pthread workers that need SharedArrayBuffer,
-    # which is only exposed in a cross-origin isolated context.
-    # credentialless (not require-corp) so AniList/Bangumi cover CDNs
-    # (which don't send CORP) still load as no-cors no-credentials.
-    add_header Cross-Origin-Opener-Policy $coop_policy always;
-    add_header Cross-Origin-Embedder-Policy $coep_policy always;
+    # No Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy, on purpose.
+    #
+    # They were here so /player and /library got SharedArrayBuffer for jassub.
+    # Two things turned out to be false.  jassub 2.5 does not need SAB: its
+    # emscripten loader sizes the pthread pool to zero when the page is not
+    # cross-origin isolated and renders single-threaded (measured 2026-09-12:
+    # `ready` in 147ms without the headers, ASS painted).  And a per-route map
+    # cannot scope them: COOP/COEP are document-level, and Next's client-side
+    # navigation never fetches a new document, so a visitor who clicks from
+    # the home page into /anime/<id> carries the home page's isolation with
+    # them and the YouTube trailer iframe is blocked (ERR_BLOCKED_BY_RESPONSE).
+    # Only a hard load of the detail route ever saw the per-route exemption.
     add_header Cross-Origin-Resource-Policy "same-origin" always;
     # script-src directives explained:
     #   'wasm-unsafe-eval' — jassub WebAssembly.compile / .instantiate (player)

--- a/nginx/default.legacy.conf
+++ b/nginx/default.legacy.conf
@@ -57,43 +57,6 @@
 # the P6.9 / P7 / P9 commits and rebuild the legacy `app` image. That is
 # outside this conf's responsibility.
 
-# Cross-origin isolation is a per-route decision, not a site-wide one.
-#
-# COOP + COEP make a document cross-origin isolated, which is what exposes
-# SharedArrayBuffer.  jassub needs it on /player and /library to render ASS
-# subtitles -- without it jassubOverlay.ts warns and falls back to plain VTT.
-#
-# The same two headers block every cross-origin IFRAME whose own document does
-# not ENFORCE COEP.  `credentialless` relaxes that for subresources.  It does
-# not relax it for frames.  YouTube's embed sends
-# `Cross-Origin-Resource-Policy: cross-origin` but only
-# `Cross-Origin-Embedder-Policy-Report-Only`, and report-only does not count.
-#
-# Measured against production 2026-09-08 with a real browser: the detail page
-# reported crossOriginIsolated === true and the youtube-nocookie request failed
-# with net::ERR_BLOCKED_BY_RESPONSE.  Note the iframe's `onload` fired anyway --
-# on the error page -- so onload is not the signal here; the failed request is.
-#
-# The detail page is the only route that frames a trailer and the only one that
-# never wanted SharedArrayBuffer, so it is the route that opts out.  Everything
-# else keeps the isolation, including /player and /library which depend on it.
-#
-# nginx omits an add_header whose value is empty.  Even if that ever changed,
-# an empty COOP/COEP value is not a valid policy and browsers fall back to
-# unsafe-none -- the same outcome -- so this cannot fail closed.
-#
-# The prefix group is the locale segment: LANGS is ["zh", "en", "zh-Hant"] and
-# zh is served bare, so /anime/, /en/anime/ and /zh-Hant/anime/ are one route.
-map $uri $coop_policy {
-    default                          "same-origin";
-    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
-}
-
-map $uri $coep_policy {
-    default                          "credentialless";
-    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
-}
-
 upstream app {
     server app:5001;
 }
@@ -254,8 +217,18 @@ server {
     add_header X-Frame-Options DENY always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-    add_header Cross-Origin-Opener-Policy $coop_policy always;
-    add_header Cross-Origin-Embedder-Policy $coep_policy always;
+    # No Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy, on purpose.
+    #
+    # They were here so /player and /library got SharedArrayBuffer for jassub.
+    # Two things turned out to be false.  jassub 2.5 does not need SAB: its
+    # emscripten loader sizes the pthread pool to zero when the page is not
+    # cross-origin isolated and renders single-threaded (measured 2026-09-12:
+    # `ready` in 147ms without the headers, ASS painted).  And a per-route map
+    # cannot scope them: COOP/COEP are document-level, and Next's client-side
+    # navigation never fetches a new document, so a visitor who clicks from
+    # the home page into /anime/<id> carries the home page's isolation with
+    # them and the YouTube trailer iframe is blocked (ERR_BLOCKED_BY_RESPONSE).
+    # Only a hard load of the detail route ever saw the per-route exemption.
     add_header Cross-Origin-Resource-Policy "same-origin" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://static.cloudflareinsights.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; media-src 'self' blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' blob: wss://$host https://cloudflareinsights.com https://*.ingest.us.sentry.io; frame-src https://www.youtube-nocookie.com; object-src 'none'; base-uri 'self';" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), local-fonts=(self)" always;

--- a/nginx/default.p9.conf
+++ b/nginx/default.p9.conf
@@ -21,43 +21,6 @@
 # next-app upstream. After the P11 cutover + legacy retirement, EVERY
 # user-facing route is served by next-app (see the location blocks below).
 # The old Express `app` upstream is gone.
-# Cross-origin isolation is a per-route decision, not a site-wide one.
-#
-# COOP + COEP make a document cross-origin isolated, which is what exposes
-# SharedArrayBuffer.  jassub needs it on /player and /library to render ASS
-# subtitles -- without it jassubOverlay.ts warns and falls back to plain VTT.
-#
-# The same two headers block every cross-origin IFRAME whose own document does
-# not ENFORCE COEP.  `credentialless` relaxes that for subresources.  It does
-# not relax it for frames.  YouTube's embed sends
-# `Cross-Origin-Resource-Policy: cross-origin` but only
-# `Cross-Origin-Embedder-Policy-Report-Only`, and report-only does not count.
-#
-# Measured against production 2026-09-08 with a real browser: the detail page
-# reported crossOriginIsolated === true and the youtube-nocookie request failed
-# with net::ERR_BLOCKED_BY_RESPONSE.  Note the iframe's `onload` fired anyway --
-# on the error page -- so onload is not the signal here; the failed request is.
-#
-# The detail page is the only route that frames a trailer and the only one that
-# never wanted SharedArrayBuffer, so it is the route that opts out.  Everything
-# else keeps the isolation, including /player and /library which depend on it.
-#
-# nginx omits an add_header whose value is empty.  Even if that ever changed,
-# an empty COOP/COEP value is not a valid policy and browsers fall back to
-# unsafe-none -- the same outcome -- so this cannot fail closed.
-#
-# The prefix group is the locale segment: LANGS is ["zh", "en", "zh-Hant"] and
-# zh is served bare, so /anime/, /en/anime/ and /zh-Hant/anime/ are one route.
-map $uri $coop_policy {
-    default                          "same-origin";
-    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
-}
-
-map $uri $coep_policy {
-    default                          "credentialless";
-    "~^/(?:(?:en|zh-Hant)/)?anime/"  "";
-}
-
 upstream next_app {
     server next-app:3000;
 }
@@ -431,8 +394,8 @@ server {
     }
 
     # /jassub/* is the WASM asset path under next-app/public/jassub/.
-    # Routed through Next so its standard cache headers + COOP/COEP
-    # apply. nginx-level caching could be tightened post-deploy.
+    # Routed through Next so its standard cache headers apply.
+    # nginx-level caching could be tightened post-deploy.
     location ^~ /jassub/ {
         proxy_pass http://next_app;
         proxy_intercept_errors on;
@@ -537,13 +500,18 @@ server {
     add_header X-Frame-Options DENY always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-    # Player /library route uses jassub (libass-wasm) for ASS subtitles.
-    # jassub spawns emscripten pthread workers that need SharedArrayBuffer,
-    # which is only exposed in a cross-origin isolated context.
-    # credentialless (not require-corp) so AniList/Bangumi cover CDNs
-    # (which don't send CORP) still load as no-cors no-credentials.
-    add_header Cross-Origin-Opener-Policy $coop_policy always;
-    add_header Cross-Origin-Embedder-Policy $coep_policy always;
+    # No Cross-Origin-Opener-Policy / Cross-Origin-Embedder-Policy, on purpose.
+    #
+    # They were here so /player and /library got SharedArrayBuffer for jassub.
+    # Two things turned out to be false.  jassub 2.5 does not need SAB: its
+    # emscripten loader sizes the pthread pool to zero when the page is not
+    # cross-origin isolated and renders single-threaded (measured 2026-09-12:
+    # `ready` in 147ms without the headers, ASS painted).  And a per-route map
+    # cannot scope them: COOP/COEP are document-level, and Next's client-side
+    # navigation never fetches a new document, so a visitor who clicks from
+    # the home page into /anime/<id> carries the home page's isolation with
+    # them and the YouTube trailer iframe is blocked (ERR_BLOCKED_BY_RESPONSE).
+    # Only a hard load of the detail route ever saw the per-route exemption.
     add_header Cross-Origin-Resource-Policy "same-origin" always;
     # script-src directives explained:
     #   'wasm-unsafe-eval' — jassub WebAssembly.compile / .instantiate (player)


### PR DESCRIPTION
## 问题

#174 之后用户报预告片「还是不行」。截图里 DevTools Issues 面板:*Specify a Cross-Origin Embedder Policy to stop this frame from being blocked* —— 那份文档带着 COEP。

## 根因

COOP/COEP 是**文档级**属性,只在整页加载那一刻由响应头决定。Next App Router 站内跳转不发新文档请求,所以从首页点进 `/anime/185874`,文档还是首页那份,`crossOriginIsolated=true`,iframe `ERR_BLOCKED_BY_RESPONSE`。真 Chrome 实测:

| 进入方式 | 文档请求 | `crossOriginIsolated` | 预告 |
|---|---|---|---|
| 硬刷新 `/anime/185874` | 1 | false | ✅ 播放 |
| 首页 → 点进详情 | **0** | **true** | ❌ 被拦 |

#174 的 `map $uri` 只救了 SEO 落地和硬刷新;上次验收恰好只验了这一种。

## 保留两个头的理由也是假的

`jassubOverlay.ts` 里「jassub 没有 SharedArrayBuffer 会静默挂死」从没测过。拿线上 `public/jassub/` 的 wasm + worker.bundle.js 单独起页:

| | `crossOriginIsolated` | `ready` | ASS 渲染 |
|---|---|---|---|
| 带 COOP+COEP | true | 233ms | ✅ |
| 不带 | false | **147ms** | ✅ |

jassub 2.5 的 loader 非隔离时把 pthread 池设成 0 走单线程(README 明说自动降级)。我们的闸门在它降级之前就先退回 VTT 了——顺带说明 e2e 沙箱里 ASS 一直走的是 VTT 兜底。

## 改动

- 三份 nginx 配置:删 `map $uri $coop_policy/$coep_policy` 和两条 `add_header`
- `jassubOverlay.ts`:删 `crossOriginIsolated` 闸门
- 新增 `crossOriginIsolation.test.ts`:读 `nginx/*.conf` 断言无 COOP/COEP `add_header`,读 `jassubOverlay.ts` 断言无 `crossOriginIsolated` 分支。放 next-app 而非 e2e:头是 nginx 发的,对 Next 应用本身写的测试两种状态都绿
- CHANGELOG

代价:libass 单线程渲染,重特效 ASS 的 CPU 开销未量。

## 验证

- `bun test`:1928 pass / 0 fail
- 变异:把 COEP 那行加回 `default.conf` → 1 fail
- 候选 `default.p9.conf` 在 VPS 上用线上 nginx 容器同一组挂载、compose 网络 `nginx -t` 通过(线上那份作对照同样通过)

## 部署

线上 `nginx/default.conf` 是 `default.p9.conf` 的逐字节拷贝,合并后:
```
cp nginx/default.p9.conf nginx/default.conf && docker compose restart nginx
```
restart 不是 reload(bind mount 换 inode)。部署后我会用真 Chrome 跑「首页 → 点进详情 → 点预告」这条路径验收。